### PR TITLE
[방탈출 예약 대기 3 ~ 4 단계] 새로이(강철원)  미션 제출합니다

### DIFF
--- a/src/main/java/roomescape/RoomescapeApplication.java
+++ b/src/main/java/roomescape/RoomescapeApplication.java
@@ -2,7 +2,9 @@ package roomescape;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class RoomescapeApplication {
 

--- a/src/main/java/roomescape/member/domain/Password.java
+++ b/src/main/java/roomescape/member/domain/Password.java
@@ -24,8 +24,4 @@ public class Password {
     public static Password createForMember(@NonNull final String password) {
         return new Password(password);
     }
-
-    public boolean matchesPassword(final String password) {
-        return value.equals(password);
-    }
 }

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -46,6 +46,6 @@ public class AdminReservationController {
 
     @DeleteMapping("/{id}")
     public void deleteWaitingReservation(@PathVariable @NotNull final Long id) {
-        reservationService.deleteReservation(id);
+        reservationService.deleteById(id);
     }
 }

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -8,6 +8,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,7 +43,12 @@ public class AdminReservationController {
     }
 
     @PatchMapping("/{id}")
-    public void approveReservation(@PathVariable @NotNull final Long id) {
-        reservationService.approveReservation(id);
+    public void approveWaitingReservation(@PathVariable @NotNull final Long id) {
+        reservationService.approveWaitingReservation(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteWaitingReservation(@PathVariable @NotNull final Long id) {
+        reservationService.deleteReservation(id);
     }
 }

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -1,8 +1,16 @@
 package roomescape.reservation.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,16 +20,29 @@ import roomescape.reservation.dto.AdminReservationRequest;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.service.ReservationService;
 
-@RequestMapping("/admin/reservations")
+
 @RestController
 @RequiredArgsConstructor
+@Validated
+@RequestMapping("/admin/reservations")
 public class AdminReservationController {
 
+    private static final Log log = LogFactory.getLog(AdminReservationController.class);
     private final ReservationService reservationService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ReservationResponse saveReservation(@Valid @RequestBody final AdminReservationRequest request) {
         return reservationService.saveAdminReservation(request);
+    }
+
+    @GetMapping("/waiting")
+    public List<ReservationResponse> getWaitingReservations() {
+        return reservationService.findAllWaitingReservation();
+    }
+
+    @PatchMapping("/{id}")
+    public void approveReservation(@PathVariable @NotNull final Long id) {
+        reservationService.approveReservation(id);
     }
 }

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -4,8 +4,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,7 +26,6 @@ import roomescape.reservation.service.ReservationService;
 @RequestMapping("/admin/reservations")
 public class AdminReservationController {
 
-    private static final Log log = LogFactory.getLog(AdminReservationController.class);
     private final ReservationService reservationService;
 
     @PostMapping

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import roomescape.reservation.dto.AdminReservationRequest;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.service.ReservationService;
+import roomescape.reservation.service.WaitingReservationService;
 
 
 @RestController
@@ -27,6 +28,7 @@ import roomescape.reservation.service.ReservationService;
 public class AdminReservationController {
 
     private final ReservationService reservationService;
+    private final WaitingReservationService waitingReservationService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,6 +49,6 @@ public class AdminReservationController {
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteWaitingReservation(@PathVariable @NotNull final Long id) {
-        reservationService.deleteById(id);
+        waitingReservationService.deleteById(id);
     }
 }

--- a/src/main/java/roomescape/reservation/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/AdminReservationController.java
@@ -45,6 +45,7 @@ public class AdminReservationController {
     }
 
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteWaitingReservation(@PathVariable @NotNull final Long id) {
         reservationService.deleteById(id);
     }

--- a/src/main/java/roomescape/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/ReservationController.java
@@ -59,7 +59,7 @@ public class ReservationController {
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteReservation(@PathVariable final Long id) {
-        reservationService.deleteReservation(id);
+        reservationService.deleteById(id);
     }
 
     @GetMapping("/mine")

--- a/src/main/java/roomescape/reservation/controller/WaitingReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/WaitingReservationController.java
@@ -1,0 +1,40 @@
+package roomescape.reservation.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.auth.dto.LoginMember;
+import roomescape.reservation.dto.WaitingReservationRequest;
+import roomescape.reservation.dto.WaitingReservationResponse;
+import roomescape.reservation.service.WaitingReservationService;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/waitingReservations")
+
+public class WaitingReservationController {
+
+    private final WaitingReservationService waitingReservationService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public WaitingReservationResponse save(@Valid @RequestBody final WaitingReservationRequest request,
+                                           final LoginMember member) {
+        return waitingReservationService.save(request, member);
+    }
+
+    @DeleteMapping("{id}")
+    public void delete(@NotNull @PathVariable final Long id) {
+        waitingReservationService.deleteById(id);
+    }
+}

--- a/src/main/java/roomescape/reservation/controller/WaitingReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/WaitingReservationController.java
@@ -34,6 +34,7 @@ public class WaitingReservationController {
     }
 
     @DeleteMapping("{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@NotNull @PathVariable final Long id) {
         waitingReservationService.deleteById(id);
     }

--- a/src/main/java/roomescape/reservation/domain/BaseTimeEntity.java
+++ b/src/main/java/roomescape/reservation/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package roomescape.reservation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -21,7 +21,7 @@ import roomescape.member.domain.Member;
 @Table(
         uniqueConstraints = @UniqueConstraint(
                 name = "unique_reservation_per_time",
-                columnNames = {"roomEscapeInformation_id"}
+                columnNames = {"room_escape_information_id"}
         )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -1,6 +1,5 @@
 package roomescape.reservation.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,27 +7,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import roomescape.exception.ReservationException;
 import roomescape.member.domain.Member;
-import roomescape.reservationtime.domain.ReservationTime;
-import roomescape.theme.domain.Theme;
 
 @Getter
 @Entity
 @Table(
         uniqueConstraints = @UniqueConstraint(
                 name = "unique_reservation_per_time",
-                columnNames = {"date", "time_id", "theme_id"}
+                columnNames = {"roomEscapeInformation_id"}
         )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,16 +31,9 @@ public class Reservation extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private LocalDate date;
-
     @JoinColumn(nullable = false)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    private ReservationTime time;
-
-    @JoinColumn(nullable = false)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    private Theme theme;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private RoomEscapeInformation roomEscapeInformation;
 
     @JoinColumn(nullable = false)
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
@@ -56,24 +42,11 @@ public class Reservation extends BaseTimeEntity {
     @Builder
     private Reservation(
             final Long id,
-            @NonNull final LocalDate date,
-            @NonNull final ReservationTime time,
-            @NonNull final Theme theme,
+            @NonNull final RoomEscapeInformation roomEscapeInformation,
             @NonNull final Member member
     ) {
         this.id = id;
-        this.date = date;
-        this.time = time;
-        this.theme = theme;
+        this.roomEscapeInformation = roomEscapeInformation;
         this.member = member;
-    }
-
-    @PrePersist
-    private void validateFutureOrPresent() {
-        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
-        final LocalDateTime currentDateTime = LocalDateTime.now();
-        if (reservationDateTime.isBefore(currentDateTime)) {
-            throw new ReservationException("예약은 현재 시간 이후로 가능합니다.");
-        }
     }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -26,7 +26,7 @@ import roomescape.theme.domain.Theme;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reservation {
+public class Reservation extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,7 +49,7 @@ public class Reservation {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private ReservationStatus status = ReservationStatus.BOOKED;
+    private ReservationStatus status;
 
     @Builder
     private Reservation(
@@ -81,6 +81,22 @@ public class Reservation {
                 .theme(theme)
                 .member(member)
                 .status(ReservationStatus.BOOKED)
+                .build();
+    }
+
+    public static Reservation waiting(
+            final LocalDate date,
+            final ReservationTime reservationTime,
+            final Theme theme,
+            final Member member
+    ) {
+        return builder()
+                .id(null)
+                .date(date)
+                .time(reservationTime)
+                .theme(theme)
+                .member(member)
+                .status(ReservationStatus.WAITING)
                 .build();
     }
 

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -108,4 +108,8 @@ public class Reservation extends BaseTimeEntity {
             throw new ReservationException("예약은 현재 시간 이후로 가능합니다.");
         }
     }
+
+    public void updateStatus(final ReservationStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -32,7 +32,7 @@ public class Reservation extends BaseTimeEntity {
     private Long id;
 
     @JoinColumn(nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private RoomEscapeInformation roomEscapeInformation;
 
     @JoinColumn(nullable = false)

--- a/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
+++ b/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -23,6 +25,12 @@ import roomescape.theme.domain.Theme;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "unique_room_escape_information_per_time",
+                columnNames = {"date", "time_id", "theme_id"}
+        )
+)
 public class RoomEscapeInformation {
 
     @Id

--- a/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
+++ b/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
@@ -1,0 +1,64 @@
+package roomescape.reservation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import roomescape.exception.ReservationException;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.theme.domain.Theme;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomEscapeInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private ReservationTime time;
+
+    @JoinColumn(nullable = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Theme theme;
+
+    @Builder
+    private RoomEscapeInformation(
+            final Long id,
+            @NonNull final LocalDate date,
+            @NonNull final ReservationTime time,
+            @NonNull final Theme theme
+    ) {
+        this.id = id;
+        this.date = date;
+        this.time = time;
+        this.theme = theme;
+    }
+
+    @PrePersist
+    private void validateFutureOrPresent() {
+        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
+        final LocalDateTime currentDateTime = LocalDateTime.now();
+        if (reservationDateTime.isBefore(currentDateTime)) {
+            throw new ReservationException("예약은 현재 시간 이후로 가능합니다.");
+        }
+    }
+}

--- a/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
+++ b/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
@@ -54,14 +54,14 @@ public class RoomEscapeInformation {
             @NonNull final ReservationTime time,
             @NonNull final Theme theme
     ) {
-        validateFutureOrPresent();
+        validateFutureOrPresent(date, time);
         this.id = id;
         this.date = date;
         this.time = time;
         this.theme = theme;
     }
 
-    private void validateFutureOrPresent() {
+    private void validateFutureOrPresent(final LocalDate date, final ReservationTime time) {
         final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
         final LocalDateTime currentDateTime = LocalDateTime.now();
         if (reservationDateTime.isBefore(currentDateTime)) {

--- a/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
+++ b/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
@@ -55,13 +54,13 @@ public class RoomEscapeInformation {
             @NonNull final ReservationTime time,
             @NonNull final Theme theme
     ) {
+        validateFutureOrPresent();
         this.id = id;
         this.date = date;
         this.time = time;
         this.theme = theme;
     }
 
-    @PrePersist
     private void validateFutureOrPresent() {
         final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
         final LocalDateTime currentDateTime = LocalDateTime.now();

--- a/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
+++ b/src/main/java/roomescape/reservation/domain/RoomEscapeInformation.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
@@ -54,14 +55,14 @@ public class RoomEscapeInformation {
             @NonNull final ReservationTime time,
             @NonNull final Theme theme
     ) {
-        validateFutureOrPresent(date, time);
         this.id = id;
         this.date = date;
         this.time = time;
         this.theme = theme;
     }
 
-    private void validateFutureOrPresent(final LocalDate date, final ReservationTime time) {
+    @PrePersist
+    private void validateFutureOrPresent() {
         final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
         final LocalDateTime currentDateTime = LocalDateTime.now();
         if (reservationDateTime.isBefore(currentDateTime)) {

--- a/src/main/java/roomescape/reservation/domain/WaitingReservation.java
+++ b/src/main/java/roomescape/reservation/domain/WaitingReservation.java
@@ -8,31 +8,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import roomescape.exception.ReservationException;
 import roomescape.member.domain.Member;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
 @Getter
 @Entity
-@Table(
-        uniqueConstraints = @UniqueConstraint(
-                name = "unique_reservation_per_time",
-                columnNames = {"date", "time_id", "theme_id"}
-        )
-)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reservation extends BaseTimeEntity {
+public class WaitingReservation extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,7 +43,7 @@ public class Reservation extends BaseTimeEntity {
     private Member member;
 
     @Builder
-    private Reservation(
+    private WaitingReservation(
             final Long id,
             @NonNull final LocalDate date,
             @NonNull final ReservationTime time,
@@ -66,14 +55,5 @@ public class Reservation extends BaseTimeEntity {
         this.time = time;
         this.theme = theme;
         this.member = member;
-    }
-
-    @PrePersist
-    private void validateFutureOrPresent() {
-        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
-        final LocalDateTime currentDateTime = LocalDateTime.now();
-        if (reservationDateTime.isBefore(currentDateTime)) {
-            throw new ReservationException("예약은 현재 시간 이후로 가능합니다.");
-        }
     }
 }

--- a/src/main/java/roomescape/reservation/domain/WaitingReservation.java
+++ b/src/main/java/roomescape/reservation/domain/WaitingReservation.java
@@ -1,6 +1,5 @@
 package roomescape.reservation.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,15 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import roomescape.member.domain.Member;
-import roomescape.reservationtime.domain.ReservationTime;
-import roomescape.theme.domain.Theme;
 
 @Getter
 @Entity
@@ -27,16 +23,9 @@ public class WaitingReservation extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private LocalDate date;
-
     @JoinColumn(nullable = false)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    private ReservationTime time;
-
-    @JoinColumn(nullable = false)
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    private Theme theme;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private RoomEscapeInformation roomEscapeInformation;
 
     @JoinColumn(nullable = false)
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
@@ -45,15 +34,11 @@ public class WaitingReservation extends BaseTimeEntity {
     @Builder
     private WaitingReservation(
             final Long id,
-            @NonNull final LocalDate date,
-            @NonNull final ReservationTime time,
-            @NonNull final Theme theme,
+            @NonNull final RoomEscapeInformation roomEscapeInformation,
             @NonNull final Member member
     ) {
         this.id = id;
-        this.date = date;
-        this.time = time;
-        this.theme = theme;
+        this.roomEscapeInformation = roomEscapeInformation;
         this.member = member;
     }
 }

--- a/src/main/java/roomescape/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/MyReservationResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.ReservationStatus;
 
 public record MyReservationResponse(
         Long reservationId,
@@ -14,25 +15,34 @@ public record MyReservationResponse(
         Long rank
 ) {
 
-    public MyReservationResponse(final Reservation reservation) {
+    public MyReservationResponse(final Reservation reservation, final ReservationStatus status) {
         this(
                 reservation.getId(),
                 reservation.getTheme().getName(),
                 reservation.getDate(),
                 reservation.getTime().getStartAt(),
-                reservation.getStatus().getOutput(),
+                status.getOutput(),
                 null
         );
     }
 
-    public MyReservationResponse(final WaitingReservationWithRank reservation) {
+    public MyReservationResponse(final WaitingReservationWithRank waitingReservationWithRank,
+                                 ReservationStatus status) {
         this(
-                reservation.reservationId(),
-                reservation.theme(),
-                reservation.date(),
-                reservation.time(),
-                reservation.status(),
-                reservation.rank()
+                waitingReservationWithRank.reservationId(),
+                waitingReservationWithRank.theme(),
+                waitingReservationWithRank.date(),
+                waitingReservationWithRank.time(),
+                status.getOutput(),
+                waitingReservationWithRank.rank()
         );
+    }
+
+    public static MyReservationResponse from(Reservation reservation) {
+        return new MyReservationResponse(reservation, ReservationStatus.BOOKED);
+    }
+
+    public static MyReservationResponse from(WaitingReservationWithRank waiting) {
+        return new MyReservationResponse(waiting, ReservationStatus.WAITING);
     }
 }

--- a/src/main/java/roomescape/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/MyReservationResponse.java
@@ -18,9 +18,9 @@ public record MyReservationResponse(
     public MyReservationResponse(final Reservation reservation, final ReservationStatus status) {
         this(
                 reservation.getId(),
-                reservation.getTheme().getName(),
-                reservation.getDate(),
-                reservation.getTime().getStartAt(),
+                reservation.getRoomEscapeInformation().getTheme().getName(),
+                reservation.getRoomEscapeInformation().getDate(),
+                reservation.getRoomEscapeInformation().getTime().getStartAt(),
                 status.getOutput(),
                 null
         );

--- a/src/main/java/roomescape/reservation/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/ReservationResponse.java
@@ -19,9 +19,9 @@ public record ReservationResponse(
     public ReservationResponse(final Reservation reservation) {
         this(
                 reservation.getId(),
-                reservation.getDate(),
-                new ReservationTimeResponse(reservation.getTime()),
-                new ThemeResponse(reservation.getTheme()),
+                reservation.getRoomEscapeInformation().getDate(),
+                new ReservationTimeResponse(reservation.getRoomEscapeInformation().getTime()),
+                new ThemeResponse(reservation.getRoomEscapeInformation().getTheme()),
                 new MemberResponse(reservation.getMember())
         );
     }
@@ -29,9 +29,9 @@ public record ReservationResponse(
     public ReservationResponse(final WaitingReservation waitingReservation) {
         this(
                 waitingReservation.getId(),
-                waitingReservation.getDate(),
-                new ReservationTimeResponse(waitingReservation.getTime()),
-                new ThemeResponse(waitingReservation.getTheme()),
+                waitingReservation.getRoomEscapeInformation().getDate(),
+                new ReservationTimeResponse(waitingReservation.getRoomEscapeInformation().getTime()),
+                new ThemeResponse(waitingReservation.getRoomEscapeInformation().getTheme()),
                 new MemberResponse(waitingReservation.getMember())
         );
     }

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationRequest.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationRequest.java
@@ -1,0 +1,12 @@
+package roomescape.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record WaitingReservationRequest(
+        @NotNull @JsonFormat(pattern = "yyyy-MM-dd") LocalDate date,
+        @NotNull Long timeId,
+        @NotNull Long themeId
+) {
+}

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationResponse.java
@@ -17,9 +17,9 @@ public record WaitingReservationResponse(
     public WaitingReservationResponse(final WaitingReservation waitingReservation) {
         this(
                 waitingReservation.getId(),
-                waitingReservation.getDate(),
-                new ReservationTimeResponse(waitingReservation.getTime()),
-                new ThemeResponse(waitingReservation.getTheme()),
+                waitingReservation.getRoomEscapeInformation().getDate(),
+                new ReservationTimeResponse(waitingReservation.getRoomEscapeInformation().getTime()),
+                new ThemeResponse(waitingReservation.getRoomEscapeInformation().getTheme()),
                 new MemberResponse(waitingReservation.getMember())
         );
     }

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationResponse.java
@@ -3,30 +3,18 @@ package roomescape.reservation.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import roomescape.member.dto.MemberResponse;
-import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.WaitingReservation;
 import roomescape.reservationtime.dto.ReservationTimeResponse;
 import roomescape.theme.dto.ThemeResponse;
 
-public record ReservationResponse(
+public record WaitingReservationResponse(
         Long id,
         @JsonFormat(pattern = "yyyy-MM-dd") LocalDate date,
         ReservationTimeResponse time,
         ThemeResponse theme,
         MemberResponse member
 ) {
-
-    public ReservationResponse(final Reservation reservation) {
-        this(
-                reservation.getId(),
-                reservation.getDate(),
-                new ReservationTimeResponse(reservation.getTime()),
-                new ThemeResponse(reservation.getTheme()),
-                new MemberResponse(reservation.getMember())
-        );
-    }
-
-    public ReservationResponse(final WaitingReservation waitingReservation) {
+    public WaitingReservationResponse(final WaitingReservation waitingReservation) {
         this(
                 waitingReservation.getId(),
                 waitingReservation.getDate(),

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import roomescape.reservation.domain.Reservation;
 
-public record MyReservationResponse(
+public record WaitingReservationWithRank(
         Long reservationId,
         String theme,
         @JsonFormat(pattern = "yyyy-MM-dd") LocalDate date,
@@ -13,26 +13,14 @@ public record MyReservationResponse(
         String status,
         Long rank
 ) {
-
-    public MyReservationResponse(final Reservation reservation) {
+    public WaitingReservationWithRank(final Reservation reservation, final Long rank) {
         this(
                 reservation.getId(),
                 reservation.getTheme().getName(),
                 reservation.getDate(),
                 reservation.getTime().getStartAt(),
                 reservation.getStatus().getOutput(),
-                null
-        );
-    }
-
-    public MyReservationResponse(final WaitingReservationWithRank reservation) {
-        this(
-                reservation.reservationId(),
-                reservation.theme(),
-                reservation.date(),
-                reservation.time(),
-                reservation.status(),
-                reservation.rank()
+                rank
         );
     }
 }

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
@@ -3,24 +3,12 @@ package roomescape.reservation.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import roomescape.reservation.domain.Reservation;
 
 public record WaitingReservationWithRank(
         Long reservationId,
         String theme,
         @JsonFormat(pattern = "yyyy-MM-dd") LocalDate date,
         @JsonFormat(pattern = "HH:mm") LocalTime time,
-        String status,
         Long rank
 ) {
-    public WaitingReservationWithRank(final Reservation reservation, final Long rank) {
-        this(
-                reservation.getId(),
-                reservation.getTheme().getName(),
-                reservation.getDate(),
-                reservation.getTime().getStartAt(),
-                reservation.getStatus().getOutput(),
-                rank
-        );
-    }
 }

--- a/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
+++ b/src/main/java/roomescape/reservation/dto/WaitingReservationWithRank.java
@@ -3,6 +3,7 @@ package roomescape.reservation.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import roomescape.reservation.domain.WaitingReservation;
 
 public record WaitingReservationWithRank(
         Long reservationId,
@@ -11,4 +12,13 @@ public record WaitingReservationWithRank(
         @JsonFormat(pattern = "HH:mm") LocalTime time,
         Long rank
 ) {
+    public static WaitingReservationWithRank of(final WaitingReservation waitingReservation, final Long rank) {
+        return new WaitingReservationWithRank(
+                waitingReservation.getId(),
+                waitingReservation.getRoomEscapeInformation().getTheme().getName(),
+                waitingReservation.getRoomEscapeInformation().getDate(),
+                waitingReservation.getRoomEscapeInformation().getTime().getStartAt(),
+                rank
+        );
+    }
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -7,17 +7,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import roomescape.member.domain.Member;
 import roomescape.reservation.domain.Reservation;
-import roomescape.reservationtime.domain.ReservationTime;
-import roomescape.theme.domain.Theme;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     @Query("""
-            SELECT r FROM Reservation r
-            WHERE (:themeId IS NULL OR r.theme.id = :themeId)
-              AND (:memberId IS NULL OR r.member.id = :memberId)
-              AND (:localDateFrom IS NULL OR r.date >= :localDateFrom)
-              AND (:localDateTo IS NULL OR r.date <= :localDateTo)
+            select r from Reservation r
+            join RoomEscapeInformation re
+            on r.roomEscapeInformation.id = re.id
+            where (:themeId is null or re.theme.id = :themeId)
+              and (:memberId is null or r.member.id = :memberId)
+              and (:localDateFrom is null or re.date >= :localDateFrom)
+              and (:localDateTo is null or re.date <= :localDateTo)
             """)
     List<Reservation> findByCriteria(
             @Param("themeId") Long themeId,
@@ -25,12 +25,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("localDateFrom") LocalDate localDateFrom,
             @Param("localDateTo") LocalDate localDateTo
     );
-
-    boolean existsByDateAndTimeAndTheme(final LocalDate date, final ReservationTime time, final Theme theme);
-
-    boolean existsByThemeId(final Long themeId);
-
-    boolean existsByTimeId(final Long timeId);
 
     List<Reservation> findByMember(final Member member);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import roomescape.member.domain.Member;
 import roomescape.reservation.domain.Reservation;
-import roomescape.reservation.domain.ReservationStatus;
-import roomescape.reservation.dto.WaitingReservationWithRank;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
@@ -34,19 +32,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     boolean existsByTimeId(final Long timeId);
 
-    List<Reservation> findByMemberAndStatus(final Member member, ReservationStatus status);
-
-    @Query("""
-                select new roomescape.reservation.dto.WaitingReservationWithRank(r, 
-                  (select COUNT(rw)
-                   from Reservation rw
-                   where rw.theme = r.theme AND rw.date = r.date AND rw.time = r.time AND rw.createdAt <= r.createdAt AND rw.status = 'WAITING')
-                )
-                FROM Reservation r
-                WHERE r.member = :member
-                  AND r.status = 'WAITING'
-            """)
-    List<WaitingReservationWithRank> findWaitingReservationByMemberWithRank(@Param("member") Member member);
-
-    List<Reservation> findAllByStatus(ReservationStatus status);
+    List<Reservation> findByMember(final Member member);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import roomescape.member.domain.Member;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.ReservationStatus;
+import roomescape.reservation.dto.WaitingReservationWithRank;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
@@ -32,5 +34,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     boolean existsByTimeId(final Long timeId);
 
-    List<Reservation> findAllByMember(final Member member);
+    List<Reservation> findByMemberAndStatus(final Member member, ReservationStatus status);
+
+    @Query("""
+                select new roomescape.reservation.dto.WaitingReservationWithRank(r, 
+                  (select COUNT(rw)
+                   from Reservation rw
+                   where rw.theme = r.theme AND rw.date = r.date AND rw.time = r.time AND rw.createdAt <= r.createdAt AND rw.status = 'WAITING')
+                )
+                FROM Reservation r
+                WHERE r.member = :member
+                  AND r.status = 'WAITING'
+            """)
+    List<WaitingReservationWithRank> findWaitingReservationByMemberWithRank(@Param("member") Member member);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -27,4 +27,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     );
 
     List<Reservation> findByMember(final Member member);
+
+    boolean existsByRoomEscapeInformationId(Long roomEscapeInformationId);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -47,4 +47,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                   AND r.status = 'WAITING'
             """)
     List<WaitingReservationWithRank> findWaitingReservationByMemberWithRank(@Param("member") Member member);
+
+    List<Reservation> findAllByStatus(ReservationStatus status);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -12,8 +12,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("""
             select r from Reservation r
-            join RoomEscapeInformation re
-            on r.roomEscapeInformation.id = re.id
+            join fetch r.roomEscapeInformation re
             where (:themeId is null or re.theme.id = :themeId)
               and (:memberId is null or r.member.id = :memberId)
               and (:localDateFrom is null or re.date >= :localDateFrom)

--- a/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
@@ -15,8 +15,5 @@ public interface RoomEscapeInformationRepository extends JpaRepository<RoomEscap
 
     boolean existsByTimeId(final Long timeId);
 
-    Optional<RoomEscapeInformation> findByDateAndTimeAndTheme(final LocalDate date, final ReservationTime time,
-                                                              final Theme theme);
-
     Optional<RoomEscapeInformation> findByDateAndTimeIdAndThemeId(LocalDate date, Long timeId, Long themeId);
 }

--- a/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
@@ -1,0 +1,16 @@
+package roomescape.reservation.repository;
+
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import roomescape.reservation.domain.RoomEscapeInformation;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.theme.domain.Theme;
+
+public interface RoomEscapeInformationRepository extends JpaRepository<RoomEscapeInformation, Long> {
+
+    boolean existsByDateAndTimeAndTheme(final LocalDate date, final ReservationTime time, final Theme theme);
+
+    boolean existsByThemeId(final Long themeId);
+
+    boolean existsByTimeId(final Long timeId);
+}

--- a/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/RoomEscapeInformationRepository.java
@@ -1,6 +1,7 @@
 package roomescape.reservation.repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservationtime.domain.ReservationTime;
@@ -13,4 +14,9 @@ public interface RoomEscapeInformationRepository extends JpaRepository<RoomEscap
     boolean existsByThemeId(final Long themeId);
 
     boolean existsByTimeId(final Long timeId);
+
+    Optional<RoomEscapeInformation> findByDateAndTimeAndTheme(final LocalDate date, final ReservationTime time,
+                                                              final Theme theme);
+
+    Optional<RoomEscapeInformation> findByDateAndTimeIdAndThemeId(LocalDate date, Long timeId, Long themeId);
 }

--- a/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
@@ -1,0 +1,30 @@
+package roomescape.reservation.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import roomescape.member.domain.Member;
+import roomescape.reservation.domain.WaitingReservation;
+import roomescape.reservation.dto.WaitingReservationWithRank;
+
+public interface WaitingReservationRepository extends JpaRepository<WaitingReservation, Long> {
+
+    @Query("""
+            select new roomescape.reservation.dto.WaitingReservationWithRank(
+                w.id,
+                w.theme.name,
+                w.date,
+                w.time.startAt,
+                (select COUNT(wr)*1L from WaitingReservation wr
+                    where wr.theme = w.theme
+                      and wr.date = w.date
+                      and wr.time = w.time
+                      and wr.createdAt <= w.createdAt
+                )
+            )
+            from WaitingReservation w
+            where w.member = :member
+            """)
+    List<WaitingReservationWithRank> findWaitingReservationByMember(@Param("member") Member member);
+}

--- a/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
@@ -27,4 +27,6 @@ public interface WaitingReservationRepository extends JpaRepository<WaitingReser
             where w.member = :member
             """)
     List<WaitingReservationWithRank> findWaitingReservationByMember(@Param("member") Member member);
+
+    boolean existsByRoomEscapeInformationId(Long roomEscapeInformationId);
 }

--- a/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
@@ -13,13 +13,13 @@ public interface WaitingReservationRepository extends JpaRepository<WaitingReser
     @Query("""
             select new roomescape.reservation.dto.WaitingReservationWithRank(
                 w.id,
-                w.theme.name,
-                w.date,
-                w.time.startAt,
+                w.roomEscapeInformation.theme.name,
+                w.roomEscapeInformation.date,
+                w.roomEscapeInformation.time.startAt,
                 (select COUNT(wr)*1L from WaitingReservation wr
-                    where wr.theme = w.theme
-                      and wr.date = w.date
-                      and wr.time = w.time
+                    where wr.roomEscapeInformation.theme = w.roomEscapeInformation.theme
+                      and wr.roomEscapeInformation.date = w.roomEscapeInformation.date
+                      and wr.roomEscapeInformation.time = w.roomEscapeInformation.time
                       and wr.createdAt <= w.createdAt
                 )
             )

--- a/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/WaitingReservationRepository.java
@@ -1,10 +1,13 @@
 package roomescape.reservation.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import roomescape.member.domain.Member;
+import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservation.domain.WaitingReservation;
 import roomescape.reservation.dto.WaitingReservationWithRank;
 
@@ -27,6 +30,18 @@ public interface WaitingReservationRepository extends JpaRepository<WaitingReser
             where w.member = :member
             """)
     List<WaitingReservationWithRank> findWaitingReservationByMember(@Param("member") Member member);
+
+    @EntityGraph(attributePaths = {
+            "roomEscapeInformation",
+            "roomEscapeInformation.theme",
+            "roomEscapeInformation.time"
+    })
+    List<WaitingReservation> findByMember(Member member);
+
+    long countByRoomEscapeInformationAndCreatedAtLessThanEqual(
+            RoomEscapeInformation roomEscapeInfo,
+            LocalDateTime createdAt
+    );
 
     boolean existsByRoomEscapeInformationId(Long roomEscapeInformationId);
 }

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -90,8 +90,21 @@ public class ReservationService {
         }
     }
 
-    public void deleteReservation(final Long id) {
+    @Transactional
+    public void deleteById(final Long id) {
+        final Reservation reservation = reservationRepository.findById(id)
+                .orElse(null);
+        if (reservation == null) {
+            return;
+        }
+        final Long infoId = reservation.getRoomEscapeInformation().getId();
         reservationRepository.deleteById(id);
+
+        boolean hasBooked = reservationRepository.existsByRoomEscapeInformationId(infoId);
+        boolean hasWaiting = waitingReservationRepository.existsByRoomEscapeInformationId(infoId);
+        if (!hasBooked && !hasWaiting) {
+            roomEscapeInformationRepository.deleteById(infoId);
+        }
     }
 
     public List<MyReservationResponse> findMyReservations(final LoginMember loginMember) {

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -74,7 +74,7 @@ public class ReservationService {
             final LocalDate date,
             final ReservationTime reservationTime,
             final Theme theme,
-            Member member
+            final Member member
     ) {
         if (hasReservation(date, reservationTime, theme)) {
             throw new ReservationException("이미 해당 날짜에 예약이 존재합니다.");

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -81,11 +81,6 @@ public class ReservationService {
         reservationRepository.deleteById(id);
     }
 
-    private Member findMemberById(final Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 멤버입니다."));
-    }
-
     public List<MyReservationResponse> findMyReservations(final LoginMember loginMember) {
         final Member member = findMemberById(loginMember.id());
         final List<MyReservationResponse> bookedReservations = reservationRepository.findByMemberAndStatus(member,
@@ -100,6 +95,24 @@ public class ReservationService {
                 .toList();
     }
 
+    public List<ReservationResponse> findAllWaitingReservation() {
+        final List<Reservation> waitingReservations = reservationRepository.findAllByStatus(ReservationStatus.WAITING);
+        return waitingReservations.stream().map(ReservationResponse::new).toList();
+    }
+
+    public void approveReservation(final Long id) {
+        final Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("예약이 존재하지 않습니다."));
+
+        reservation.updateStatus(ReservationStatus.BOOKED);
+
+        reservationRepository.save(reservation);
+    }
+
+    private Member findMemberById(final Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 멤버입니다."));
+    }
 
     private ReservationTime findReservationTimeById(final Long timeId) {
         return reservationTimeRepository.findById(timeId).orElseThrow(() -> new NotFoundException("존재하지 않는 예약 시간입니다."));

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -75,9 +75,6 @@ public class ReservationService {
     }
 
     public void deleteReservation(final Long id) {
-        if (!reservationRepository.existsById(id)) {
-            throw new NotFoundException("존재하지 않는 예약입니다. id=" + id);
-        }
         reservationRepository.deleteById(id);
     }
 

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -100,7 +100,7 @@ public class ReservationService {
         return waitingReservations.stream().map(ReservationResponse::new).toList();
     }
 
-    public void approveReservation(final Long id) {
+    public void approveWaitingReservation(final Long id) {
         final Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("예약이 존재하지 않습니다."));
 

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -129,12 +129,20 @@ public class ReservationService {
     public void approveWaitingReservation(final Long id) {
         final WaitingReservation waitingReservation = waitingReservationRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("예약 대기가 존재하지 않습니다."));
+
         waitingReservationRepository.deleteById(waitingReservation.getId());
 
         final Reservation reservation = Reservation.builder()
                 .roomEscapeInformation(waitingReservation.getRoomEscapeInformation())
                 .member(waitingReservation.getMember())
                 .build();
+        if (hasReservation(
+                reservation.getRoomEscapeInformation().getDate(),
+                reservation.getRoomEscapeInformation().getTime(),
+                reservation.getRoomEscapeInformation().getTheme())
+        ) {
+            throw new ReservationException("이미 해당 날짜에 예약이 존재합니다.");
+        }
         reservationRepository.save(reservation);
     }
 

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -1,6 +1,7 @@
 package roomescape.reservation.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -80,6 +81,7 @@ public class ReservationService {
             throw new ReservationException("이미 해당 날짜에 예약이 존재합니다.");
         }
         try {
+            validateFutureOrPresent(date, reservationTime);
             final RoomEscapeInformation roomEscapeInformation = roomEscapeInformationRepository.save(
                     RoomEscapeInformation.builder().date(date).time(reservationTime).theme(theme).build());
             final Reservation reservation = reservationRepository.save(
@@ -136,6 +138,7 @@ public class ReservationService {
                 .roomEscapeInformation(waitingReservation.getRoomEscapeInformation())
                 .member(waitingReservation.getMember())
                 .build();
+        // FIXME:: 위치 수정
         if (hasReservation(
                 reservation.getRoomEscapeInformation().getDate(),
                 reservation.getRoomEscapeInformation().getTime(),
@@ -161,5 +164,13 @@ public class ReservationService {
 
     private boolean hasReservation(final LocalDate date, final ReservationTime time, final Theme theme) {
         return roomEscapeInformationRepository.existsByDateAndTimeAndTheme(date, time, theme);
+    }
+
+    private void validateFutureOrPresent(final LocalDate date, final ReservationTime time) {
+        final LocalDateTime reservationDateTime = LocalDateTime.of(date, time.getStartAt());
+        final LocalDateTime currentDateTime = LocalDateTime.now();
+        if (reservationDateTime.isBefore(currentDateTime)) {
+            throw new ReservationException("예약은 현재 시간 이후로 가능합니다.");
+        }
     }
 }

--- a/src/main/java/roomescape/reservation/service/WaitingReservationService.java
+++ b/src/main/java/roomescape/reservation/service/WaitingReservationService.java
@@ -8,10 +8,12 @@ import roomescape.auth.dto.LoginMember;
 import roomescape.exception.NotFoundException;
 import roomescape.member.domain.Member;
 import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservation.domain.WaitingReservation;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.dto.WaitingReservationRequest;
 import roomescape.reservation.dto.WaitingReservationResponse;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservation.repository.WaitingReservationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
@@ -26,6 +28,8 @@ public class WaitingReservationService {
     private final MemberRepository memberRepository;
     private final ThemeRepository themeRepository;
     private final ReservationTimeRepository reservationTimeRepository;
+    private final RoomEscapeInformationRepository roomEscapeInformationRepository;
+
 
     @Transactional
     public WaitingReservationResponse save(final WaitingReservationRequest request, final LoginMember loginMember) {
@@ -35,10 +39,15 @@ public class WaitingReservationService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 예약 시간입니다."));
         final Member member = memberRepository.findById(loginMember.id())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 멤버입니다."));
-        final WaitingReservation waitingReservation = WaitingReservation.builder()
+        final RoomEscapeInformation roomEscapeInformation = RoomEscapeInformation.builder()
                 .date(request.date())
                 .theme(theme)
                 .time(reservationTime)
+                .build();
+        roomEscapeInformationRepository.save(roomEscapeInformation);
+
+        final WaitingReservation waitingReservation = WaitingReservation.builder()
+                .roomEscapeInformation(roomEscapeInformation)
                 .member(member)
                 .build();
         return new WaitingReservationResponse(waitingReservationRepository.save(waitingReservation));
@@ -47,6 +56,11 @@ public class WaitingReservationService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public ReservationResponse saveAsWaitingIfReserved(final WaitingReservation waitingReservation) {
         return new ReservationResponse(waitingReservationRepository.save(waitingReservation));
+    }
+
+    public WaitingReservation findWaitingReservationById(final Long id) {
+        return waitingReservationRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 예약 대기입니다."));
     }
 
     public void deleteById(final Long id) {

--- a/src/main/java/roomescape/reservation/service/WaitingReservationService.java
+++ b/src/main/java/roomescape/reservation/service/WaitingReservationService.java
@@ -1,0 +1,55 @@
+package roomescape.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.auth.dto.LoginMember;
+import roomescape.exception.NotFoundException;
+import roomescape.member.domain.Member;
+import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.WaitingReservation;
+import roomescape.reservation.dto.ReservationResponse;
+import roomescape.reservation.dto.WaitingReservationRequest;
+import roomescape.reservation.dto.WaitingReservationResponse;
+import roomescape.reservation.repository.WaitingReservationRepository;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.repository.ReservationTimeRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class WaitingReservationService {
+
+    private final WaitingReservationRepository waitingReservationRepository;
+    private final MemberRepository memberRepository;
+    private final ThemeRepository themeRepository;
+    private final ReservationTimeRepository reservationTimeRepository;
+
+    @Transactional
+    public WaitingReservationResponse save(final WaitingReservationRequest request, final LoginMember loginMember) {
+        final Theme theme = themeRepository.findById(request.themeId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 테마입니다."));
+        final ReservationTime reservationTime = reservationTimeRepository.findById(request.timeId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 예약 시간입니다."));
+        final Member member = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 멤버입니다."));
+        final WaitingReservation waitingReservation = WaitingReservation.builder()
+                .date(request.date())
+                .theme(theme)
+                .time(reservationTime)
+                .member(member)
+                .build();
+        return new WaitingReservationResponse(waitingReservationRepository.save(waitingReservation));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ReservationResponse saveAsWaitingIfReserved(final WaitingReservation waitingReservation) {
+        return new ReservationResponse(waitingReservationRepository.save(waitingReservation));
+    }
+
+    public void deleteById(final Long id) {
+        this.waitingReservationRepository.deleteById(id);
+    }
+}

--- a/src/main/java/roomescape/reservation/service/WaitingReservationService.java
+++ b/src/main/java/roomescape/reservation/service/WaitingReservationService.java
@@ -2,7 +2,6 @@ package roomescape.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.NotFoundException;
@@ -10,7 +9,6 @@ import roomescape.member.domain.Member;
 import roomescape.member.repository.MemberRepository;
 import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservation.domain.WaitingReservation;
-import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.dto.WaitingReservationRequest;
 import roomescape.reservation.dto.WaitingReservationResponse;
 import roomescape.reservation.repository.RoomEscapeInformationRepository;
@@ -51,16 +49,6 @@ public class WaitingReservationService {
                 .member(member)
                 .build();
         return new WaitingReservationResponse(waitingReservationRepository.save(waitingReservation));
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public ReservationResponse saveAsWaitingIfReserved(final WaitingReservation waitingReservation) {
-        return new ReservationResponse(waitingReservationRepository.save(waitingReservation));
-    }
-
-    public WaitingReservation findWaitingReservationById(final Long id) {
-        return waitingReservationRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 예약 대기입니다."));
     }
 
     public void deleteById(final Long id) {

--- a/src/main/java/roomescape/reservation/service/WaitingReservationService.java
+++ b/src/main/java/roomescape/reservation/service/WaitingReservationService.java
@@ -13,10 +13,6 @@ import roomescape.reservation.dto.WaitingReservationRequest;
 import roomescape.reservation.dto.WaitingReservationResponse;
 import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservation.repository.WaitingReservationRepository;
-import roomescape.reservationtime.domain.ReservationTime;
-import roomescape.reservationtime.repository.ReservationTimeRepository;
-import roomescape.theme.domain.Theme;
-import roomescape.theme.repository.ThemeRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -24,25 +20,15 @@ public class WaitingReservationService {
 
     private final WaitingReservationRepository waitingReservationRepository;
     private final MemberRepository memberRepository;
-    private final ThemeRepository themeRepository;
-    private final ReservationTimeRepository reservationTimeRepository;
     private final RoomEscapeInformationRepository roomEscapeInformationRepository;
-
-
+    
     @Transactional
     public WaitingReservationResponse save(final WaitingReservationRequest request, final LoginMember loginMember) {
-        final Theme theme = themeRepository.findById(request.themeId())
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 테마입니다."));
-        final ReservationTime reservationTime = reservationTimeRepository.findById(request.timeId())
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 예약 시간입니다."));
         final Member member = memberRepository.findById(loginMember.id())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 멤버입니다."));
-        final RoomEscapeInformation roomEscapeInformation = RoomEscapeInformation.builder()
-                .date(request.date())
-                .theme(theme)
-                .time(reservationTime)
-                .build();
-        roomEscapeInformationRepository.save(roomEscapeInformation);
+        final RoomEscapeInformation roomEscapeInformation = roomEscapeInformationRepository.findByDateAndTimeIdAndThemeId(
+                        request.date(), request.timeId(), request.themeId())
+                .orElseThrow(() -> new NotFoundException("방탈출 정보가 존재하지 않습니다."));
 
         final WaitingReservation waitingReservation = WaitingReservation.builder()
                 .roomEscapeInformation(roomEscapeInformation)

--- a/src/main/java/roomescape/reservationtime/repository/ReservationTimeRepository.java
+++ b/src/main/java/roomescape/reservationtime/repository/ReservationTimeRepository.java
@@ -17,9 +17,9 @@ public interface ReservationTimeRepository extends JpaRepository<ReservationTime
               )
             from ReservationTime rt
             left join Reservation r
-              on rt.id = r.time.id
-              and r.date = :date
-              and r.theme.id = :themeId
+              on rt.id = r.roomEscapeInformation.time.id
+              and r.roomEscapeInformation.date = :date
+              and r.roomEscapeInformation.theme.id = :themeId
             order by rt.startAt
             """)
     List<AvailableReservationTimeResponse> findAllAvailable(

--- a/src/main/java/roomescape/reservationtime/repository/ReservationTimeRepository.java
+++ b/src/main/java/roomescape/reservationtime/repository/ReservationTimeRepository.java
@@ -11,7 +11,7 @@ import roomescape.reservationtime.dto.AvailableReservationTimeResponse;
 public interface ReservationTimeRepository extends JpaRepository<ReservationTime, Long> {
 
     @Query("""
-            select
+            select distinct 
               new roomescape.reservationtime.dto.AvailableReservationTimeResponse(
                 rt.id, rt.startAt, (r.id is not null) as alreadyBooked
               )

--- a/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import roomescape.exception.ReservationException;
-import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.dto.ReservationTimeRequest;
 import roomescape.reservationtime.dto.ReservationTimeResponse;
@@ -15,7 +15,7 @@ import roomescape.reservationtime.repository.ReservationTimeRepository;
 public class ReservationTimeService {
 
     private final ReservationTimeRepository reservationTimeRepository;
-    private final ReservationRepository reservationRepository;
+    private final RoomEscapeInformationRepository roomEscapeInformationRepository;
 
     public ReservationTimeResponse saveTime(final ReservationTimeRequest request) {
         final ReservationTime reservationTime = reservationTimeRepository.save(ReservationTime.from(request.startAt()));
@@ -30,7 +30,7 @@ public class ReservationTimeService {
     }
 
     public void delete(final Long id) {
-        if (reservationRepository.existsByTimeId(id)) {
+        if (roomEscapeInformationRepository.existsByTimeId(id)) {
             throw new ReservationException("해당 시간으로 예약된 건이 존재합니다.");
         }
         reservationTimeRepository.deleteById(id);

--- a/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
@@ -3,6 +3,7 @@ package roomescape.reservationtime.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.exception.ReservationException;
 import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
@@ -29,6 +30,7 @@ public class ReservationTimeService {
                 .toList();
     }
 
+    @Transactional
     public void delete(final Long id) {
         if (roomEscapeInformationRepository.existsByTimeId(id)) {
             throw new ReservationException("해당 시간으로 예약된 건이 존재합니다.");

--- a/src/main/java/roomescape/theme/repository/ThemeRepository.java
+++ b/src/main/java/roomescape/theme/repository/ThemeRepository.java
@@ -11,8 +11,8 @@ public interface ThemeRepository extends JpaRepository<Theme, Long> {
 
     @Query("""
             SELECT t FROM Theme t
-            JOIN Reservation r ON r.theme.id = t.id
-            WHERE r.date BETWEEN :startDate AND :endDate
+            JOIN Reservation r ON r.roomEscapeInformation.theme.id = t.id
+            WHERE r.roomEscapeInformation.date BETWEEN :startDate AND :endDate
             GROUP BY t
             ORDER BY COUNT(r) DESC
             LIMIT 10

--- a/src/main/java/roomescape/theme/service/ThemeService.java
+++ b/src/main/java/roomescape/theme/service/ThemeService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.exception.ReservationException;
 import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.theme.domain.Theme;
@@ -40,6 +41,7 @@ public class ThemeService {
                 .toList();
     }
 
+    @Transactional
     public void delete(final Long id) {
         if (roomEscapeInformationRepository.existsByThemeId((id))) {
             throw new ReservationException("해당 테마로 예약된 건이 존재합니다.");

--- a/src/main/java/roomescape/theme/service/ThemeService.java
+++ b/src/main/java/roomescape/theme/service/ThemeService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import roomescape.exception.ReservationException;
-import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.dto.PopularThemeResponse;
 import roomescape.theme.dto.ThemeRequest;
@@ -17,7 +17,7 @@ import roomescape.theme.repository.ThemeRepository;
 public class ThemeService {
 
     private final ThemeRepository themeRepository;
-    private final ReservationRepository reservationRepository;
+    private final RoomEscapeInformationRepository roomEscapeInformationRepository;
 
     public ThemeResponse saveTheme(final ThemeRequest request) {
         final Theme theme = themeRepository.save(Theme.of(request.name(), request.description(), request.thumbnail()));
@@ -41,7 +41,7 @@ public class ThemeService {
     }
 
     public void delete(final Long id) {
-        if (reservationRepository.existsByThemeId((id))) {
+        if (roomEscapeInformationRepository.existsByThemeId((id))) {
             throw new ReservationException("해당 테마로 예약된 건이 존재합니다.");
         }
         themeRepository.deleteById(id);

--- a/src/main/java/roomescape/ui/ViewController.java
+++ b/src/main/java/roomescape/ui/ViewController.java
@@ -36,6 +36,11 @@ public class ViewController {
         return "reservation-mine";
     }
 
+    @GetMapping("/admin/waiting")
+    public String getWaitingReservationsPage() {
+        return "admin/waiting";
+    }
+
     @GetMapping("/")
     public String getHomePage() {
         return "index";

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,8 +13,14 @@ VALUES ('운영진', 'admin@naver.com', '1234', 'ADMIN');
 INSERT INTO member(name, email, password, role)
 VALUES ('홍길동', 'member@naver.com', '1234', 'MEMBER');
 
-INSERT INTO reservation(date, time_id, theme_id, member_id)
-VALUES ('2025-05-11', 1, 1, 1);
+INSERT INTO room_escape_information(date, time_id, theme_id)
+VALUES ('2025-05-11', 1, 1);
 
-INSERT INTO reservation(date, time_id, theme_id, member_id)
-VALUES ('2025-05-20', 1, 1, 1);
+INSERT INTO room_escape_information(date, time_id, theme_id)
+VALUES ('2099-05-11', 1, 1);
+
+INSERT INTO reservation(room_escape_information_id, member_id)
+VALUES (1, 1);
+
+INSERT INTO reservation(room_escape_information_id, member_id)
+VALUES (2, 1);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,8 +13,8 @@ VALUES ('운영진', 'admin@naver.com', '1234', 'ADMIN');
 INSERT INTO member(name, email, password, role)
 VALUES ('홍길동', 'member@naver.com', '1234', 'MEMBER');
 
-INSERT INTO reservation(date, time_id, theme_id, member_id, status)
-VALUES ('2025-05-11', 1, 1, 1, 'BOOKED');
+INSERT INTO reservation(date, time_id, theme_id, member_id)
+VALUES ('2025-05-11', 1, 1, 1);
 
-INSERT INTO reservation(date, time_id, theme_id, member_id, status)
-VALUES ('2025-05-20', 1, 1, 1, 'BOOKED');
+INSERT INTO reservation(date, time_id, theme_id, member_id)
+VALUES ('2025-05-20', 1, 1, 1);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -15,3 +15,6 @@ VALUES ('홍길동', 'member@naver.com', '1234', 'MEMBER');
 
 INSERT INTO reservation(date, time_id, theme_id, member_id, status)
 VALUES ('2025-05-11', 1, 1, 1, 'BOOKED');
+
+INSERT INTO reservation(date, time_id, theme_id, member_id, status)
+VALUES ('2025-05-20', 1, 1, 1, 'BOOKED');

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -49,7 +49,7 @@ function requestDeleteWaiting(id) {
     /*
     TODO: [3단계] 예약 대기 기능 - 예약 대기 취소 API 호출
      */
-    const endpoint = `/reservations/${id}`;
+    const endpoint = `/waitingReservations/${id}`;
     return fetch(endpoint, {
         method: 'DELETE'
     }).then(response => {

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -14,11 +14,13 @@ function render(data) {
 
     data.forEach(item => {
         const row = tableBody.insertRow();
-
         const theme = item.theme;
         const date = item.date;
         const time = item.time;
-        const status = item.status;
+        let status = item.status;
+        if (status === "예약 대기") {
+            status = `${item.rank}번째 ${item.status}`;
+        }
 
         row.insertCell(0).textContent = theme;
         row.insertCell(1).textContent = date;

--- a/src/main/resources/static/js/reservation-mine.js
+++ b/src/main/resources/static/js/reservation-mine.js
@@ -36,7 +36,7 @@ function render(data) {
             cancelButton.textContent = '취소';
             cancelButton.className = 'btn btn-danger';
             cancelButton.onclick = function () {
-                requestDeleteWaiting(item.id).then(() => window.location.reload());
+                requestDeleteWaiting(item.reservationId).then(() => window.location.reload());
             };
             cancelCell.appendChild(cancelButton);
         } else { // 예약 완료 상태일 때
@@ -49,7 +49,7 @@ function requestDeleteWaiting(id) {
     /*
     TODO: [3단계] 예약 대기 기능 - 예약 대기 취소 API 호출
      */
-    const endpoint = '';
+    const endpoint = `/reservations/${id}`;
     return fetch(endpoint, {
         method: 'DELETE'
     }).then(response => {

--- a/src/main/resources/static/js/reservation-with-member.js
+++ b/src/main/resources/static/js/reservation-with-member.js
@@ -233,6 +233,9 @@ function requestCreate(reservation) {
     return fetch('/admin/reservations', requestOptions)
         .then(response => {
             if (response.status === 201) return response.json();
+            if (response.status === 400) {
+                alert('이미 해당 날짜에 예약이 존재합니다.');
+            }
             throw new Error('Create failed');
         });
 }

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -194,7 +194,7 @@ function onWaitButtonClick() {
             timeId: selectedTimeId
         };
 
-        fetch('/reservations', {
+        fetch('/waitingReservations', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -30,6 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('reserve-button').addEventListener('click', onReservationButtonClick);
+    document.getElementById('wait-button').addEventListener('click', onWaitButtonClick);
+
 });
 
 function renderTheme(themes) {
@@ -50,9 +52,6 @@ function createSlot(type, text, id, booked) {
     div.setAttribute('data-' + type + '-id', id);
     if (type === 'time') {
         div.setAttribute('data-time-booked', booked);
-        if (booked) {
-            div.classList.add('disabled');
-        }
     }
     return div;
 }
@@ -126,18 +125,22 @@ function checkDateAndThemeAndTime() {
     const selectedThemeElement = document.querySelector('.theme-slot.active');
     const selectedTimeElement = document.querySelector('.time-slot.active');
     const reserveButton = document.getElementById("reserve-button");
+    const waitButton = document.getElementById("wait-button");
 
     if (selectedDate && selectedThemeElement && selectedTimeElement) {
         if (selectedTimeElement.getAttribute('data-time-booked') === 'true') {
             // 선택된 시간이 이미 예약된 경우
             reserveButton.classList.add("disabled");
+            waitButton.classList.remove("disabled"); // 예약 대기 버튼 활성화
         } else {
             // 선택된 시간이 예약 가능한 경우
             reserveButton.classList.remove("disabled");
+            waitButton.classList.add("disabled"); // 예약 대기 버튼 비활성화
         }
     } else {
         // 날짜, 테마, 시간 중 하나라도 선택되지 않은 경우
         reserveButton.classList.add("disabled");
+        waitButton.classList.add("disabled");
     }
 }
 
@@ -180,6 +183,45 @@ function onReservationButtonClick() {
             });
     } else {
         alert("Please select a date, theme, and time before making a reservation.");
+    }
+}
+
+function onWaitButtonClick() {
+    const selectedDate = document.getElementById("datepicker").value;
+    const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
+    const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
+
+    if (selectedDate && selectedThemeId && selectedTimeId) {
+        const reservationData = {
+            date: selectedDate,
+            themeId: selectedThemeId,
+            timeId: selectedTimeId
+        };
+
+        /*
+        TODO: [3단계] 예약 대기 생성 요청 API 호출
+         */
+        fetch('/reservations', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(reservationData)
+        })
+            .then(response => {
+                if (!response.ok) throw new Error('Reservation waiting failed');
+                return response.json();
+            })
+            .then(data => {
+                alert('Reservation waiting successful!');
+                window.location.href = "/";
+            })
+            .catch(error => {
+                alert("An error occurred while making the reservation waiting.");
+                console.error(error);
+            });
+    } else {
+        alert("Please select a date, theme, and time before making a reservation waiting.");
     }
 }
 

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -107,10 +107,6 @@ function renderAvailableTimes(times) {
         return;
     }
     times.forEach(time => {
-        /*
-        TODO: [3단계] 사용자 예약 - 예약 가능 시간 조회 API 호출 후 렌더링
-              response 명세에 맞춰 createSlot 함수 호출 시 값 설정
-        */
         const startAt = time.startAt;
         const timeId = time.id;
         const alreadyBooked = time.alreadyBooked;
@@ -198,9 +194,6 @@ function onWaitButtonClick() {
             timeId: selectedTimeId
         };
 
-        /*
-        TODO: [3단계] 예약 대기 생성 요청 API 호출
-         */
         fetch('/reservations', {
             method: 'POST',
             headers: {

--- a/src/main/resources/static/js/waiting.js
+++ b/src/main/resources/static/js/waiting.js
@@ -1,0 +1,89 @@
+document.addEventListener('DOMContentLoaded', () => {
+    /*
+    TODO: [4단계] 예약 대기 관리 기능
+          예약 대기 목록 조회 endpoint 설정
+     */
+    fetch('') // 내 예약 목록 조회 API 호출
+        .then(response => {
+            if (response.status === 200) return response.json();
+            throw new Error('Read failed');
+        })
+        .then(render)
+        .catch(error => console.error('Error fetching reservations:', error));
+});
+
+function render(data) {
+    const tableBody = document.getElementById('table-body');
+    tableBody.innerHTML = '';
+
+    data.forEach(item => {
+        const row = tableBody.insertRow();
+
+        /*
+        TODO: [4단계] 예약 대기 관리 기능
+              예약 대기 목록 조회 response 명세에 맞춰 값 설정
+         */
+        const id = '';
+        const name = '';
+        const theme = '';
+        const date = '';
+        const startAt = '';
+
+        row.insertCell(0).textContent = id;            // 예약 대기 id
+        row.insertCell(1).textContent = name;          // 예약자명
+        row.insertCell(2).textContent = theme;         // 테마명
+        row.insertCell(3).textContent = date;          // 예약 날짜
+        row.insertCell(4).textContent = startAt;       // 시작 시간
+
+        const actionCell = row.insertCell(row.cells.length);
+
+        /*
+        TODO: [4단계] 예약 대기 관리 기능
+              예약 대기 승인/거절 버튼이 필요한 경우 활성화하여 사용
+         */
+        // actionCell.appendChild(createActionButton('승인', 'btn-primary', approve));
+        // actionCell.appendChild(createActionButton('거절', 'btn-danger', deny));
+    });
+}
+
+function approve(event) {
+    const row = event.target.closest('tr');
+    const id = row.cells[0].textContent;
+
+    /*
+    TODO: [4단계] 예약 대기 목록 관리 기능
+          예약 대기 승인 API 호출
+     */
+    const endpoint = '' + id;
+    return fetch(endpoint, {
+        method: ''
+    }).then(response => {
+        if (response.status === 200) return;
+        throw new Error('Delete failed');
+    }).then(() => location.reload());
+}
+
+function deny(event) {
+    const row = event.target.closest('tr');
+    const id = row.cells[0].textContent;
+
+    /*
+    TODO: [4단계] 예약 대기 목록 관리 기능
+          예약 대기 거절 API 호출
+     */
+    const endpoint = '' + id;
+    return fetch(endpoint, {
+        method: ''
+    }).then(response => {
+        if (response.status === 200) return;
+        throw new Error('Delete failed');
+    }).then(() => location.reload());
+}
+
+function createActionButton(label, className, eventListener) {
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.classList.add('btn', className, 'mr-2');
+    button.addEventListener('click', eventListener);
+    return button;
+}

--- a/src/main/resources/static/js/waiting.js
+++ b/src/main/resources/static/js/waiting.js
@@ -67,9 +67,9 @@ function deny(event) {
     TODO: [4단계] 예약 대기 목록 관리 기능
           예약 대기 거절 API 호출
      */
-    const endpoint = '' + id;
+    const endpoint = `/admin/reservations/${id}`;
     return fetch(endpoint, {
-        method: ''
+        method: 'DELETE'
     }).then(response => {
         if (response.status === 200) return;
         throw new Error('Delete failed');

--- a/src/main/resources/static/js/waiting.js
+++ b/src/main/resources/static/js/waiting.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     TODO: [4단계] 예약 대기 관리 기능
           예약 대기 목록 조회 endpoint 설정
      */
-    fetch('') // 내 예약 목록 조회 API 호출
+    fetch('/admin/reservations/waiting') // 내 예약 목록 조회 API 호출
         .then(response => {
             if (response.status === 200) return response.json();
             throw new Error('Read failed');
@@ -23,11 +23,11 @@ function render(data) {
         TODO: [4단계] 예약 대기 관리 기능
               예약 대기 목록 조회 response 명세에 맞춰 값 설정
          */
-        const id = '';
-        const name = '';
-        const theme = '';
-        const date = '';
-        const startAt = '';
+        const id = item.id;
+        const name = item.member.name;
+        const theme = item.theme.name;
+        const date = item.date;
+        const startAt = item.time.startAt;
 
         row.insertCell(0).textContent = id;            // 예약 대기 id
         row.insertCell(1).textContent = name;          // 예약자명
@@ -37,12 +37,8 @@ function render(data) {
 
         const actionCell = row.insertCell(row.cells.length);
 
-        /*
-        TODO: [4단계] 예약 대기 관리 기능
-              예약 대기 승인/거절 버튼이 필요한 경우 활성화하여 사용
-         */
-        // actionCell.appendChild(createActionButton('승인', 'btn-primary', approve));
-        // actionCell.appendChild(createActionButton('거절', 'btn-danger', deny));
+        actionCell.appendChild(createActionButton('승인', 'btn-primary', approve));
+        actionCell.appendChild(createActionButton('거절', 'btn-danger', deny));
     });
 }
 
@@ -54,9 +50,9 @@ function approve(event) {
     TODO: [4단계] 예약 대기 목록 관리 기능
           예약 대기 승인 API 호출
      */
-    const endpoint = '' + id;
+    const endpoint = `/admin/reservations/${id}`;
     return fetch(endpoint, {
-        method: ''
+        method: 'PATCH'
     }).then(response => {
         if (response.status === 200) return;
         throw new Error('Delete failed');

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -31,6 +31,9 @@
                 <a class="nav-link" href="/admin/time">Time</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/admin/waiting">Waiting</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/login">Login</a>
             </li>
             <li class="nav-item dropdown">

--- a/src/main/resources/templates/admin/reservation-new.html
+++ b/src/main/resources/templates/admin/reservation-new.html
@@ -31,6 +31,9 @@
                 <a class="nav-link" href="/admin/time">Time</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/admin/waiting">Waiting</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/login">Login</a>
             </li>
             <li class="nav-item dropdown">

--- a/src/main/resources/templates/admin/theme.html
+++ b/src/main/resources/templates/admin/theme.html
@@ -31,6 +31,9 @@
                 <a class="nav-link" href="/admin/time">Time</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/admin/waiting">Waiting</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/login">Login</a>
             </li>
             <li class="nav-item dropdown">

--- a/src/main/resources/templates/admin/time.html
+++ b/src/main/resources/templates/admin/time.html
@@ -31,6 +31,9 @@
                 <a class="nav-link" href="/admin/time">Time</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/admin/waiting">Waiting</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/login">Login</a>
             </li>
             <li class="nav-item dropdown">

--- a/src/main/resources/templates/admin/waiting.html
+++ b/src/main/resources/templates/admin/waiting.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>방탈출 어드민</title>
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <a class="navbar-brand" href="/admin">
+        <img src="/image/admin-logo.png" alt="LOGO" style="height: 40px;">
+    </a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="/admin/reservation">Reservation</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/admin/theme">Theme</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/admin/time">Time</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/login">Login</a>
+            </li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+                   aria-haspopup="true" aria-expanded="false">
+                    <img class="profile-image" src="/image/default-profile.png" alt="Profile">
+                    <span id="profile-name">Profile</span> <!-- 프로필 이름을 넣을 span 추가 -->
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <a class="dropdown-item" href="/reservation-mine">My Reservation</a>
+                    <div class="dropdown-divider"></div>
+                    <a class="dropdown-item" href="#" id="logout-btn">Logout</a>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>
+
+<div class="content-container">
+    <h2 class="content-container-title">예약 대기 관리 페이지</h2>
+    <div class="table-container"/>
+    <table class="table">
+        <thead>
+        <tr>
+            <th scope="col">예약대기 번호</th>
+            <th scope="col">예약자</th>
+            <th scope="col">테마</th>
+            <th scope="col">날짜</th>
+            <th scope="col">시간</th>
+            <th scope="col"></th>
+        </tr>
+        </thead>
+        <tbody id="table-body">
+        </tbody>
+    </table>
+</div>
+
+<script src="/js/user-scripts.js"></script>
+<script src="/js/waiting.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/waiting.html
+++ b/src/main/resources/templates/admin/waiting.html
@@ -31,6 +31,9 @@
                 <a class="nav-link" href="/admin/time">Time</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/admin/waiting">Waiting</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/login">Login</a>
             </li>
             <li class="nav-item dropdown">

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -77,6 +77,7 @@
   <!-- Reservation Button -->
   <div class="button-group float-right">
     <button id="reserve-button" class="btn btn-primary mt-3 disabled">예약하기</button>
+    <button id="wait-button" class="btn btn-secondary mt-3 disabled">예약대기</button>
   </div>
 </div>
 </div>

--- a/src/test/java/roomescape/member/domain/MemberTest.java
+++ b/src/test/java/roomescape/member/domain/MemberTest.java
@@ -50,6 +50,7 @@ class MemberTest {
                 .build();
 
         SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(member.getPassword()).isEqualTo("secret");
             soft.assertThat(member.matchesPassword("secret")).isTrue();
             soft.assertThat(member.matchesPassword("wrong")).isFalse();
         });

--- a/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
@@ -180,7 +180,7 @@ class ReservationControllerTest {
                 .count();
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(booked).isEqualTo(3); // 기존 2건 + 예약 1건
+            softly.assertThat(booked).isEqualTo(3); // 기존 2건 + 예약 1건 = 3건
             softly.assertThat(waiting).isEqualTo(4); // 대기 4건
         });
     }

--- a/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
@@ -8,12 +8,20 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.jdbc.Sql;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.Password;
+import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.WaitingReservationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
 import roomescape.theme.domain.Theme;
@@ -26,8 +34,19 @@ class ReservationControllerTest {
 
     @Autowired
     ReservationTimeRepository timeRepository;
+
     @Autowired
     ThemeRepository themeRepository;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    WaitingReservationRepository waitingReservationRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
 
     @Test
     void 유저_예약_생성_조회_삭제() {
@@ -81,5 +100,88 @@ class ReservationControllerTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(0));
+    }
+
+    @Test
+    void 동시_요청으로_동일한_시간대에_예약을_추가한다() throws InterruptedException {
+
+        int threadCount = 5;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 반드시 DB에서 조회해서 사용!
+        final Member member = memberRepository.findByEmailAndPassword("admin@naver.com",
+                        Password.createForMember("1234"))
+                .orElseThrow();
+
+        ReservationTime time = timeRepository.save(ReservationTime.from(LocalTime.of(10, 0)));
+        Theme theme1 = themeRepository.save(Theme.of("name", "desc", "thumb"));
+        Theme theme2 = themeRepository.save(Theme.of("name2", "desc2", "thumb2"));
+        Theme theme3 = themeRepository.save(Theme.of("name3", "desc3", "thumb3"));
+
+        Map<String, String> params = new HashMap<>();
+        LocalDate localDate = LocalDate.of(2999, 1, 1);
+        params.put("date", localDate.toString());
+        params.put("timeId", time.getId().toString());
+        params.put("themeId", theme1.getId().toString());
+
+        reservationRepository.save(Reservation.builder()
+                .date(LocalDate.of(2999, 1, 1))
+                .time(time)
+                .theme(theme2)
+                .member(member)
+                .build()
+        );
+        reservationRepository.save(Reservation.builder()
+                .date(LocalDate.of(2999, 1, 1))
+                .time(time)
+                .theme(theme3)
+                .member(member)
+                .build()
+        );
+
+        Map<String, String> adminUser = Map.of("email", "admin@naver.com", "password", "1234");
+        String token = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(adminUser)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .cookie("token");
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("token", token)
+                            .body(params)
+                            .when()
+                            .post("/reservations");
+                } finally {
+                    latch.countDown(); // 반드시 finally에서!
+                }
+            }).start();
+        }
+
+        latch.await(); // 모든 Thread가 끝날 때까지 대기
+
+        // then
+        Thread.sleep(1000);
+
+        long booked = reservationRepository.findByMember(member)
+                .stream()
+                .filter(r -> r.getDate().equals(localDate))
+                .count();
+        long waiting = waitingReservationRepository.findWaitingReservationByMember(member)
+                .stream()
+                .filter(w -> w.date().equals(localDate))
+                .count();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(booked).isEqualTo(3); // 기존 2건 + 예약 1건
+            softly.assertThat(waiting).isEqualTo(4); // 대기 4건
+        });
     }
 }

--- a/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
@@ -108,7 +108,7 @@ class ReservationControllerTest {
 
 
     @Test
-    void 동시_요청으로_동일한_시간대에_예약을_추가한다() throws InterruptedException {
+    void 여러건의_동일_조건에_대한_동시_요청이_들어올_때_하나의_예약만_생성된다() throws InterruptedException {
         int threadCount = 5;
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -179,14 +179,13 @@ class ReservationControllerTest {
             }).start();
         }
 
-        latch.await(); // 모든 Thread가 끝날 때까지 대기
+        latch.await();
 
         // then
         Thread.sleep(1000);
 
         long booked = reservationRepository.findByMember(member)
-                .stream()
-                .count();
+                .size();
 
         assertThat(booked).isEqualTo(3); // 기존 2건 + 예약 1건 = 3건
     }

--- a/src/test/java/roomescape/reservation/domain/ReservationTest.java
+++ b/src/test/java/roomescape/reservation/domain/ReservationTest.java
@@ -28,10 +28,15 @@ class ReservationTest {
         LocalDate today = LocalDate.now();
         LocalTime later = LocalTime.now().plusMinutes(5);
         ReservationTime reservationTime = ReservationTime.from(later);
-        Reservation reservation = Reservation.builder()
+
+        RoomEscapeInformation info = RoomEscapeInformation.builder()
                 .date(today)
                 .time(reservationTime)
                 .theme(defaultTheme)
+                .build();
+
+        Reservation reservation = Reservation.builder()
+                .roomEscapeInformation(info)
                 .member(defaultMember)
                 .build();
 
@@ -56,41 +61,93 @@ class ReservationTest {
         // when
         // then
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThatThrownBy(() ->
-                            Reservation.builder()
-                                    .date(null)
-                                    .time(reservationTime)
-                                    .theme(theme)
-                                    .member(member)
-                                    .build())
-                    .isInstanceOf(NullPointerException.class);
+            softly.assertThatThrownBy(() -> {
+                RoomEscapeInformation info = RoomEscapeInformation.builder()
+                        .date(null)
+                        .time(reservationTime)
+                        .theme(theme)
+                        .build();
+                Reservation.builder()
+                        .roomEscapeInformation(info)
+                        .member(member)
+                        .build();
+            }).isInstanceOf(NullPointerException.class);
 
-            softly.assertThatThrownBy(() ->
-                            Reservation.builder()
-                                    .date(localDate)
-                                    .time(null)
-                                    .theme(theme)
-                                    .member(member)
-                                    .build())
-                    .isInstanceOf(NullPointerException.class);
+            softly.assertThatThrownBy(() -> {
+                RoomEscapeInformation info = RoomEscapeInformation.builder()
+                        .date(localDate)
+                        .time(null)
+                        .theme(theme)
+                        .build();
+                Reservation.builder()
+                        .roomEscapeInformation(info)
+                        .member(member)
+                        .build();
+            }).isInstanceOf(NullPointerException.class);
 
-            softly.assertThatThrownBy(() ->
-                            Reservation.builder()
-                                    .date(localDate)
-                                    .time(reservationTime)
-                                    .theme(null)
-                                    .member(member)
-                                    .build())
-                    .isInstanceOf(NullPointerException.class);
+            softly.assertThatThrownBy(() -> {
+                RoomEscapeInformation info = RoomEscapeInformation.builder()
+                        .date(localDate)
+                        .time(reservationTime)
+                        .theme(null)
+                        .build();
+                Reservation.builder()
+                        .roomEscapeInformation(info)
+                        .member(member)
+                        .build();
+            }).isInstanceOf(NullPointerException.class);
 
-            softly.assertThatThrownBy(() ->
-                            Reservation.builder()
-                                    .date(localDate)
-                                    .time(reservationTime)
-                                    .theme(theme)
-                                    .member(null)
-                                    .build())
-                    .isInstanceOf(NullPointerException.class);
+            softly.assertThatThrownBy(() -> {
+                RoomEscapeInformation info = RoomEscapeInformation.builder()
+                        .date(localDate)
+                        .time(reservationTime)
+                        .theme(theme)
+                        .build();
+                Reservation.builder()
+                        .roomEscapeInformation(info)
+                        .member(null)
+                        .build();
+            }).isInstanceOf(NullPointerException.class);
+
+            softly.assertThatThrownBy(() -> {
+                Reservation.builder()
+                        .roomEscapeInformation(null)
+                        .member(member)
+                        .build();
+            }).isInstanceOf(NullPointerException.class);
         });
+    }
+
+    @Test
+    void 예약_시간이_현재_이후면_객체가_정상_생성된다() {
+        // given
+        LocalDate localDate = LocalDate.now();
+        LocalTime oneMinuteLater = LocalTime.now().plusMinutes(1);
+        ReservationTime futureTime = ReservationTime.from(oneMinuteLater);
+        Theme theme = Theme.of("테마", "설명", "썸네일");
+        Member member = Member.builder()
+                .name("김철수")
+                .email("kim@example.com")
+                .password(Password.createForMember("pass123"))
+                .role(MemberRole.MEMBER)
+                .build();
+
+        RoomEscapeInformation info = RoomEscapeInformation.builder()
+                .date(localDate)
+                .time(futureTime)
+                .theme(theme)
+                .build();
+
+        // when
+        Reservation reservation = Reservation.builder()
+                .roomEscapeInformation(info)
+                .member(member)
+                .build();
+
+        // then
+        assertThat(reservation.getRoomEscapeInformation().getDate()).isEqualTo(localDate);
+        assertThat(reservation.getRoomEscapeInformation().getTime()).isEqualTo(futureTime);
+        assertThat(reservation.getRoomEscapeInformation().getTheme()).isEqualTo(theme);
+        assertThat(reservation.getMember()).isEqualTo(member);
     }
 }

--- a/src/test/java/roomescape/reservation/domain/ReservationTest.java
+++ b/src/test/java/roomescape/reservation/domain/ReservationTest.java
@@ -27,8 +27,13 @@ class ReservationTest {
         // given
         LocalDate today = LocalDate.now();
         LocalTime later = LocalTime.now().plusMinutes(5);
-        ReservationTime rt = ReservationTime.from(later);
-        Reservation reservation = Reservation.booked(today, rt, defaultTheme, defaultMember);
+        ReservationTime reservationTime = ReservationTime.from(later);
+        Reservation reservation = Reservation.builder()
+                .date(today)
+                .time(reservationTime)
+                .theme(defaultTheme)
+                .member(defaultMember)
+                .build();
 
         // when
         // then
@@ -51,22 +56,40 @@ class ReservationTest {
         // when
         // then
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThatThrownBy(
-                            () -> Reservation.booked(null, reservationTime, theme, member))
+            softly.assertThatThrownBy(() ->
+                            Reservation.builder()
+                                    .date(null)
+                                    .time(reservationTime)
+                                    .theme(theme)
+                                    .member(member)
+                                    .build())
                     .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(
-                            () -> Reservation.booked(localDate, null, theme, member))
+
+            softly.assertThatThrownBy(() ->
+                            Reservation.builder()
+                                    .date(localDate)
+                                    .time(null)
+                                    .theme(theme)
+                                    .member(member)
+                                    .build())
                     .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(
-                            () -> Reservation.booked(localDate, reservationTime, null, member))
+
+            softly.assertThatThrownBy(() ->
+                            Reservation.builder()
+                                    .date(localDate)
+                                    .time(reservationTime)
+                                    .theme(null)
+                                    .member(member)
+                                    .build())
                     .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(() -> Reservation.booked(null, reservationTime, theme, member))
-                    .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(() -> Reservation.booked(localDate, null, theme, member))
-                    .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(() -> Reservation.booked(localDate, reservationTime, null, member))
-                    .isInstanceOf(NullPointerException.class);
-            softly.assertThatThrownBy(() -> Reservation.booked(localDate, reservationTime, theme, null))
+
+            softly.assertThatThrownBy(() ->
+                            Reservation.builder()
+                                    .date(localDate)
+                                    .time(reservationTime)
+                                    .theme(theme)
+                                    .member(null)
+                                    .build())
                     .isInstanceOf(NullPointerException.class);
         });
     }

--- a/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
@@ -72,8 +72,19 @@ class JdbcReservationRepositoryTest {
         tm.persistAndFlush(member1);
         tm.persistAndFlush(member2);
 
-        Reservation reservation1 = Reservation.booked(date, time1, theme1, member1);
-        Reservation reservation2 = Reservation.booked(date, time2, theme2, member2);
+        Reservation reservation1 = Reservation.builder()
+                .date(date)
+                .time(time1)
+                .theme(theme1)
+                .member(member1)
+                .build();
+
+        Reservation reservation2 = Reservation.builder()
+                .date(date)
+                .time(time2)
+                .theme(theme2)
+                .member(member2)
+                .build();
         tm.persistAndFlush(reservation1);
         tm.persistAndFlush(reservation2);
 
@@ -97,9 +108,9 @@ class JdbcReservationRepositoryTest {
         LocalDate date2 = LocalDate.of(2999, 7, 2);
         LocalDate date3 = LocalDate.of(2999, 7, 3);
 
-        tm.persistAndFlush(Reservation.booked(date1, time1, theme1, member1));
-        tm.persistAndFlush(Reservation.booked(date2, time1, theme1, member1));
-        tm.persistAndFlush(Reservation.booked(date3, time1, theme1, member1));
+        tm.persistAndFlush(Reservation.builder().date(date1).time(time1).theme(theme1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().date(date2).time(time1).theme(theme1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().date(date3).time(time1).theme(theme1).member(member1).build());
 
         tm.clear();
 
@@ -130,11 +141,11 @@ class JdbcReservationRepositoryTest {
         tm.persistAndFlush(member1);
         tm.persistAndFlush(member2);
 
-        tm.persistAndFlush(Reservation.booked(date1, time1, theme1, member1));
-        tm.persistAndFlush(Reservation.booked(date2, time1, theme1, member1));
-        tm.persistAndFlush(Reservation.booked(date3, time1, theme1, member1));
-        tm.persistAndFlush(Reservation.booked(date4, time1, theme1, member2));
-        tm.persistAndFlush(Reservation.booked(date5, time1, theme1, member2));
+        tm.persistAndFlush(Reservation.builder().date(date5).time(time1).theme(theme1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().date(date4).time(time1).theme(theme1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().date(date3).time(time1).theme(theme1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().date(date2).time(time1).theme(theme1).member(member2).build());
+        tm.persistAndFlush(Reservation.builder().date(date1).time(time1).theme(theme1).member(member2).build());
 
         tm.clear();
 
@@ -161,7 +172,12 @@ class JdbcReservationRepositoryTest {
         tm.persistAndFlush(theme1);
         tm.persistAndFlush(member1);
         tm.persistAndFlush(futureTime);
-        final Reservation booked = Reservation.booked(today, futureTime, theme1, member1);
+        final Reservation booked = Reservation.builder()
+                .date(today)
+                .theme(theme1)
+                .member(member1)
+                .time(futureTime)
+                .build();
 
         tm.clear();
 
@@ -183,7 +199,12 @@ class JdbcReservationRepositoryTest {
         LocalDate today = LocalDate.now();
         LocalTime oneMinuteBefore = LocalTime.now().minusMinutes(1);
         ReservationTime pastTime = ReservationTime.from(oneMinuteBefore);
-        final Reservation booked = Reservation.booked(today, pastTime, defaultTheme, defaultMember);
+        final Reservation booked = Reservation.builder()
+                .date(today)
+                .time(pastTime)
+                .theme(defaultTheme)
+                .member(defaultMember)
+                .build();
         // when
 
         // then

--- a/src/test/java/roomescape/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/repository/ReservationRepositoryTest.java
@@ -2,7 +2,6 @@ package roomescape.reservation.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static roomescape.constant.TestData.RESERVATION_COUNT;
 
 import java.time.LocalDate;
@@ -15,17 +14,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.jdbc.Sql;
-import roomescape.exception.ReservationException;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.MemberRole;
 import roomescape.member.domain.Password;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
 @DataJpaTest
 @Sql("/data.sql")
-class JdbcReservationRepositoryTest {
+class ReservationRepositoryTest {
 
     @Autowired
     private TestEntityManager tm;
@@ -72,19 +71,31 @@ class JdbcReservationRepositoryTest {
         tm.persistAndFlush(member1);
         tm.persistAndFlush(member2);
 
-        Reservation reservation1 = Reservation.builder()
+        RoomEscapeInformation info1 = RoomEscapeInformation.builder()
                 .date(date)
                 .time(time1)
                 .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info2 = RoomEscapeInformation.builder()
+                .date(date)
+                .time(time2)
+                .theme(theme2)
+                .build();
+
+        tm.persistAndFlush(info1);
+        tm.persistAndFlush(info2);
+
+        Reservation reservation1 = Reservation.builder()
+                .roomEscapeInformation(info1)
                 .member(member1)
                 .build();
 
         Reservation reservation2 = Reservation.builder()
-                .date(date)
-                .time(time2)
-                .theme(theme2)
+                .roomEscapeInformation(info2)
                 .member(member2)
                 .build();
+
         tm.persistAndFlush(reservation1);
         tm.persistAndFlush(reservation2);
 
@@ -108,9 +119,31 @@ class JdbcReservationRepositoryTest {
         LocalDate date2 = LocalDate.of(2999, 7, 2);
         LocalDate date3 = LocalDate.of(2999, 7, 3);
 
-        tm.persistAndFlush(Reservation.builder().date(date1).time(time1).theme(theme1).member(member1).build());
-        tm.persistAndFlush(Reservation.builder().date(date2).time(time1).theme(theme1).member(member1).build());
-        tm.persistAndFlush(Reservation.builder().date(date3).time(time1).theme(theme1).member(member1).build());
+        RoomEscapeInformation info1 = RoomEscapeInformation.builder()
+                .date(date1)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info2 = RoomEscapeInformation.builder()
+                .date(date2)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info3 = RoomEscapeInformation.builder()
+                .date(date3)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        tm.persistAndFlush(info1);
+        tm.persistAndFlush(info2);
+        tm.persistAndFlush(info3);
+
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info1).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info2).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info3).member(member1).build());
 
         tm.clear();
 
@@ -120,8 +153,8 @@ class JdbcReservationRepositoryTest {
         // then
         SoftAssertions.assertSoftly(soft -> {
             assertThat(reservations).hasSize(2);
-            assertThat(reservations.get(0).getDate()).isEqualTo(date2);
-            assertThat(reservations.get(1).getDate()).isEqualTo(date3);
+            assertThat(reservations.get(0).getRoomEscapeInformation().getDate()).isEqualTo(date2);
+            assertThat(reservations.get(1).getRoomEscapeInformation().getDate()).isEqualTo(date3);
         });
     }
 
@@ -135,17 +168,51 @@ class JdbcReservationRepositoryTest {
         LocalDate date5 = LocalDate.of(2999, 7, 5);
 
         tm.persistAndFlush(time1);
-
-        tm.persistAndFlush(time1);
         tm.persistAndFlush(theme1);
         tm.persistAndFlush(member1);
         tm.persistAndFlush(member2);
 
-        tm.persistAndFlush(Reservation.builder().date(date5).time(time1).theme(theme1).member(member1).build());
-        tm.persistAndFlush(Reservation.builder().date(date4).time(time1).theme(theme1).member(member1).build());
-        tm.persistAndFlush(Reservation.builder().date(date3).time(time1).theme(theme1).member(member1).build());
-        tm.persistAndFlush(Reservation.builder().date(date2).time(time1).theme(theme1).member(member2).build());
-        tm.persistAndFlush(Reservation.builder().date(date1).time(time1).theme(theme1).member(member2).build());
+        RoomEscapeInformation info1 = RoomEscapeInformation.builder()
+                .date(date1)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info2 = RoomEscapeInformation.builder()
+                .date(date2)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info3 = RoomEscapeInformation.builder()
+                .date(date3)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info4 = RoomEscapeInformation.builder()
+                .date(date4)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        RoomEscapeInformation info5 = RoomEscapeInformation.builder()
+                .date(date5)
+                .time(time1)
+                .theme(theme1)
+                .build();
+
+        tm.persistAndFlush(info1);
+        tm.persistAndFlush(info2);
+        tm.persistAndFlush(info3);
+        tm.persistAndFlush(info4);
+        tm.persistAndFlush(info5);
+
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info5).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info4).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info3).member(member1).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info2).member(member2).build());
+        tm.persistAndFlush(Reservation.builder().roomEscapeInformation(info1).member(member2).build());
 
         tm.clear();
 
@@ -172,11 +239,18 @@ class JdbcReservationRepositoryTest {
         tm.persistAndFlush(theme1);
         tm.persistAndFlush(member1);
         tm.persistAndFlush(futureTime);
-        final Reservation booked = Reservation.builder()
+
+        RoomEscapeInformation info = RoomEscapeInformation.builder()
                 .date(today)
-                .theme(theme1)
-                .member(member1)
                 .time(futureTime)
+                .theme(theme1)
+                .build();
+
+        tm.persistAndFlush(info);
+
+        final Reservation booked = Reservation.builder()
+                .roomEscapeInformation(info)
+                .member(member1)
                 .build();
 
         tm.clear();
@@ -184,32 +258,5 @@ class JdbcReservationRepositoryTest {
         // when
         // then
         assertThatCode(() -> repository.save(booked)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void 예약_시간이_현재_이전이면_ReservationException이_발생한다() {
-        // given
-        Theme defaultTheme = Theme.of("테마", "설명", "썸네일");
-        Member defaultMember = Member.builder()
-                .name("김철수")
-                .email("member@naver.com")
-                .password(Password.createForMember("1234"))
-                .role(MemberRole.MEMBER)
-                .build();
-        LocalDate today = LocalDate.now();
-        LocalTime oneMinuteBefore = LocalTime.now().minusMinutes(1);
-        ReservationTime pastTime = ReservationTime.from(oneMinuteBefore);
-        final Reservation booked = Reservation.builder()
-                .date(today)
-                .time(pastTime)
-                .theme(defaultTheme)
-                .member(defaultMember)
-                .build();
-        // when
-
-        // then
-        assertThatThrownBy(() -> repository.save(booked))
-                .isInstanceOf(ReservationException.class)
-                .hasMessage("예약은 현재 시간 이후로 가능합니다.");
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -39,7 +39,7 @@ class ReservationServiceTest {
 
     @Autowired
     private ReservationRepository reservationRepository;
-    
+
     @Autowired
     private ReservationService service;
 
@@ -138,7 +138,7 @@ class ReservationServiceTest {
         tm.persistAndFlush(reservation);
 
         // when
-        service.deleteReservation(reservation.getId());
+        service.deleteById(reservation.getId());
 
         // then
         assertThat(reservationRepository.findByCriteria(null, null, null, null))

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -30,7 +30,7 @@ import roomescape.theme.domain.Theme;
 
 @DataJpaTest
 @Sql("/data.sql")
-@Import(ReservationService.class)
+@Import({ReservationService.class, WaitingReservationService.class})
 class ReservationServiceTest {
 
     @Autowired
@@ -38,7 +38,7 @@ class ReservationServiceTest {
 
     @Autowired
     private ReservationRepository reservationRepository;
-
+    
     @Autowired
     private ReservationService service;
 
@@ -63,7 +63,12 @@ class ReservationServiceTest {
                 .role(MemberRole.MEMBER)
                 .build();
 
-        reservation = Reservation.booked(LocalDate.of(2999, 5, 11), time, theme, member);
+        reservation = Reservation.builder()
+                .date(LocalDate.of(2999, 5, 11))
+                .time(time)
+                .theme(theme)
+                .member(member)
+                .build();
     }
 
     @Test
@@ -83,7 +88,7 @@ class ReservationServiceTest {
         tm.persistAndFlush(theme);
         tm.persistAndFlush(member);
         ReservationRequest request = new ReservationRequest(LocalDate.of(2000, 10, 8), time.getId(), theme.getId());
-        final LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(),
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(),
                 member.getRole());
         tm.clear();
 

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.auth.dto.LoginMember;
-import roomescape.exception.NotFoundException;
 import roomescape.exception.ReservationException;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.MemberRole;
@@ -75,24 +74,6 @@ class ReservationServiceTest {
 
         // then
         assertThat(responses).hasSize(RESERVATION_COUNT);
-    }
-
-    @Test
-    void 중복된_날짜와_시간이면_예외가_발생한다() {
-        // given: r1과 동일한 date/time 요청
-        tm.persistAndFlush(time);
-        tm.persistAndFlush(theme);
-        tm.persistAndFlush(member);
-        tm.persistAndFlush(reservation);
-        ReservationRequest dupReq = new ReservationRequest(reservation.getDate(), time.getId(), theme.getId());
-        final LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(),
-                member.getRole());
-        tm.clear();
-        // when
-        // then
-        assertThatThrownBy(() -> service.saveReservation(dupReq, loginMember))
-                .isInstanceOf(ReservationException.class)
-                .hasMessage("해당 시간은 이미 예약되어있습니다.");
     }
 
     @Test
@@ -155,14 +136,5 @@ class ReservationServiceTest {
                 .hasSize(RESERVATION_COUNT)
                 .extracting(Reservation::getId)
                 .doesNotContain(reservation.getId());
-    }
-
-    @Test
-    void 존재하지_않는_예약을_삭제하면_예외가_발생한다() {
-        // when
-        // then
-        assertThatThrownBy(() -> service.deleteReservation(999L))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 예약입니다. id=999");
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -21,6 +21,7 @@ import roomescape.member.domain.Member;
 import roomescape.member.domain.MemberRole;
 import roomescape.member.domain.Password;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservation.dto.ReservationRequest;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.dto.ReservationSearchRequest;
@@ -43,19 +44,15 @@ class ReservationServiceTest {
     private ReservationService service;
 
     private ReservationTime time;
-
     private Theme theme;
-
     private Member member;
-
+    private RoomEscapeInformation roomEscapeInformation;
     private Reservation reservation;
 
     @BeforeEach
     void setUp() {
         time = ReservationTime.from(LocalTime.of(14, 0));
-
         theme = Theme.of("테마1", "설명1", "썸네일1");
-
         member = Member.builder()
                 .name("김철수")
                 .email("member@example.com")
@@ -63,10 +60,14 @@ class ReservationServiceTest {
                 .role(MemberRole.MEMBER)
                 .build();
 
-        reservation = Reservation.builder()
+        roomEscapeInformation = RoomEscapeInformation.builder()
                 .date(LocalDate.of(2999, 5, 11))
                 .time(time)
                 .theme(theme)
+                .build();
+
+        reservation = Reservation.builder()
+                .roomEscapeInformation(roomEscapeInformation)
                 .member(member)
                 .build();
     }
@@ -78,7 +79,9 @@ class ReservationServiceTest {
                 new ReservationSearchRequest(null, null, null, null));
 
         // then
-        assertThat(responses).hasSize(RESERVATION_COUNT);
+        assertThat(responses).hasSize(RESERVATION_COUNT)
+                .extracting(ReservationResponse::id)
+                .doesNotContain(0L);
     }
 
     @Test
@@ -131,6 +134,7 @@ class ReservationServiceTest {
         tm.persistAndFlush(member);
         tm.persistAndFlush(time);
         tm.persistAndFlush(theme);
+        tm.persistAndFlush(roomEscapeInformation);
         tm.persistAndFlush(reservation);
 
         // when

--- a/src/test/java/roomescape/reservation/service/WaitingReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/WaitingReservationServiceTest.java
@@ -1,0 +1,171 @@
+package roomescape.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+import roomescape.auth.dto.LoginMember;
+import roomescape.exception.NotFoundException;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.MemberRole;
+import roomescape.member.domain.Password;
+import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.RoomEscapeInformation;
+import roomescape.reservation.domain.WaitingReservation;
+import roomescape.reservation.dto.WaitingReservationRequest;
+import roomescape.reservation.dto.WaitingReservationResponse;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
+import roomescape.reservation.repository.WaitingReservationRepository;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.repository.ReservationTimeRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+
+@DataJpaTest
+@Sql("/data.sql")
+class WaitingReservationServiceTest {
+
+    @Autowired
+    private WaitingReservationRepository waitingReservationRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RoomEscapeInformationRepository roomEscapeInformationRepository;
+
+    @Autowired
+    private ReservationTimeRepository reservationTimeRepository;
+
+    @Autowired
+    private ThemeRepository themeRepository;
+
+    private WaitingReservationService service;
+    private Member member;
+    private Theme theme;
+    private ReservationTime time;
+    private RoomEscapeInformation roomEscapeInformation;
+
+    @BeforeEach
+    void setUp() {
+        service = new WaitingReservationService(
+                reservationRepository,
+                waitingReservationRepository,
+                memberRepository,
+                roomEscapeInformationRepository
+        );
+
+        member = Member.builder()
+                .name("대기자")
+                .email("waiting@example.com")
+                .password(Password.createForMember("pass123"))
+                .role(MemberRole.MEMBER)
+                .build();
+        memberRepository.save(member);
+
+        theme = Theme.of("대기테마", "대기설명", "대기썸네일");
+        themeRepository.save(theme);
+
+        time = ReservationTime.from(LocalTime.of(15, 0));
+        reservationTimeRepository.save(time);
+
+        roomEscapeInformation = RoomEscapeInformation.builder()
+                .date(LocalDate.of(2999, 12, 31))
+                .time(time)
+                .theme(theme)
+                .build();
+        roomEscapeInformationRepository.save(roomEscapeInformation);
+    }
+
+    @Test
+    void 대기_예약이_정상적으로_저장된다() {
+        // given
+        WaitingReservationRequest request = new WaitingReservationRequest(
+                LocalDate.of(2999, 12, 31),
+                time.getId(),
+                theme.getId()
+        );
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(),
+                member.getRole());
+
+        // when
+        WaitingReservationResponse response = service.save(request, loginMember);
+
+        // then
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.id()).isNotNull();
+            soft.assertThat(response.date()).isEqualTo(request.date());
+            soft.assertThat(response.member().name()).isEqualTo(member.getName());
+            soft.assertThat(response.theme().name()).isEqualTo(theme.getName());
+        });
+    }
+
+    @Test
+    void 존재하지_않는_회원으로_대기_예약시_예외발생() {
+        // given
+        WaitingReservationRequest request = new WaitingReservationRequest(
+                LocalDate.of(2999, 12, 31),
+                time.getId(),
+                theme.getId()
+        );
+        LoginMember nonExistentMember = new LoginMember(9999L, "존재안함", "none@example.com", MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() -> service.save(request, nonExistentMember))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 멤버입니다.");
+    }
+
+    @Test
+    void 대기_예약_삭제시_연관된_방탈출_정보도_삭제된다() {
+        // given
+        WaitingReservation waitingReservation = WaitingReservation.builder()
+                .roomEscapeInformation(roomEscapeInformation)
+                .member(member)
+                .build();
+        waitingReservationRepository.save(waitingReservation);
+
+        // when
+        service.deleteById(waitingReservation.getId());
+
+        // then
+        assertThat(waitingReservationRepository.findById(waitingReservation.getId())).isEmpty();
+        assertThat(roomEscapeInformationRepository.findById(roomEscapeInformation.getId())).isEmpty();
+    }
+
+//    @Test
+//    void ID로_대기_예약을_찾을_수_있다() {
+//        // given
+//        WaitingReservation waitingReservation = WaitingReservation.builder()
+//                .roomEscapeInformation(roomEscapeInformation)
+//                .member(member)
+//                .build();
+//        WaitingReservation saved = waitingReservationRepository.save(waitingReservation);
+//
+//        // when
+//        WaitingReservation found = service.findWaitingReservationById(saved.getId());
+//
+//        // then
+//        assertThat(found).isNotNull();
+//        assertThat(found.getId()).isEqualTo(saved.getId());
+//    }
+//
+//    @Test
+//    void 존재하지_않는_대기_예약_ID로_조회시_예외발생() {
+//        // when & then
+//        assertThatThrownBy(() -> service.findWaitingReservationById(9999L))
+//                .isInstanceOf(NotFoundException.class)
+//                .hasMessage("존재하지 않는 대기 예약입니다.");
+//    }
+} 

--- a/src/test/java/roomescape/reservationtime/repository/ReservationTimeRepositoryTest.java
+++ b/src/test/java/roomescape/reservationtime/repository/ReservationTimeRepositoryTest.java
@@ -13,7 +13,7 @@ import roomescape.reservationtime.dto.AvailableReservationTimeResponse;
 
 @DataJpaTest
 @Sql("/data.sql")
-class JdbcReservationTimeRepositoryTest {
+class ReservationTimeRepositoryTest {
 
     @Autowired
     private ReservationTimeRepository repository;
@@ -28,8 +28,8 @@ class JdbcReservationTimeRepositoryTest {
         // then
         SoftAssertions.assertSoftly(soft -> {
                     soft.assertThat(allAvailable).hasSize(RESERVATION_TIME_COUNT);
-                    soft.assertThat(allAvailable.get(0).alreadyBooked()).isTrue();
-                    soft.assertThat(allAvailable.get(1).alreadyBooked()).isFalse();
+                    soft.assertThat(allAvailable).extracting(AvailableReservationTimeResponse::alreadyBooked)
+                            .containsExactly(true, false);
                 }
         );
     }

--- a/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
+++ b/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.exception.ReservationException;
-import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.dto.ReservationTimeResponse;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
@@ -26,7 +26,7 @@ class ReservationTimeServiceTest {
     private ReservationTimeRepository reservationTimeRepository;
 
     @Autowired
-    private ReservationRepository reservationRepository;
+    private RoomEscapeInformationRepository roomEscapeInformationRepository;
 
     private ReservationTimeService service;
 
@@ -35,7 +35,7 @@ class ReservationTimeServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new ReservationTimeService(reservationTimeRepository, reservationRepository);
+        service = new ReservationTimeService(reservationTimeRepository, roomEscapeInformationRepository);
         reservationTimeRepository.saveAll(List.of(
                 ReservationTime.from(time1),
                 ReservationTime.from(time2)

--- a/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
+++ b/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
@@ -4,19 +4,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static roomescape.constant.TestData.RESERVATION_TIME_COUNT;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.exception.ReservationException;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.MemberRole;
+import roomescape.member.domain.Password;
+import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.RoomEscapeInformation;
 import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.dto.ReservationTimeRequest;
 import roomescape.reservationtime.dto.ReservationTimeResponse;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
-
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
 
 @DataJpaTest
 @Sql("/data.sql")
@@ -28,57 +37,94 @@ class ReservationTimeServiceTest {
     @Autowired
     private RoomEscapeInformationRepository roomEscapeInformationRepository;
 
-    private ReservationTimeService service;
+    @Autowired
+    private ThemeRepository themeRepository;
 
-    private final LocalTime time1 = LocalTime.of(13, 0);
-    private final LocalTime time2 = LocalTime.of(14, 0);
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private ReservationTimeService service;
+    private Theme theme;
+    private Member member;
 
     @BeforeEach
     void setUp() {
         service = new ReservationTimeService(reservationTimeRepository, roomEscapeInformationRepository);
-        reservationTimeRepository.saveAll(List.of(
-                ReservationTime.from(time1),
-                ReservationTime.from(time2)
-        ));
+
+        theme = Theme.of("테마1", "설명1", "썸네일1");
+        themeRepository.save(theme);
+
+        member = Member.builder()
+                .name("사용자1")
+                .email("user1@example.com")
+                .password(Password.createForMember("pass123"))
+                .role(MemberRole.MEMBER)
+                .build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    void 예약_시간이_정상적으로_저장된다() {
+        // given
+        LocalTime newTime = LocalTime.of(16, 30);
+        ReservationTimeRequest request = new ReservationTimeRequest(newTime);
+
+        // when
+        ReservationTimeResponse response = service.saveTime(request);
+
+        // then
+        assertThat(response.id()).isNotNull();
+        assertThat(response.startAt()).isEqualTo(newTime);
     }
 
     @Test
     void 모든_예약_시간을_조회한다() {
+        // given
+        LocalTime time1 = LocalTime.of(10, 0);
+        LocalTime time2 = LocalTime.of(11, 30);
+        reservationTimeRepository.saveAll(List.of(
+                ReservationTime.from(time1),
+                ReservationTime.from(time2)
+        ));
+
         // when
-        List<ReservationTimeResponse> all = service.findAll();
+        List<ReservationTimeResponse> responses = service.findAll();
 
         // then
-        assertThat(all).hasSize(RESERVATION_TIME_COUNT + 2)
+        assertThat(responses).hasSize(RESERVATION_TIME_COUNT + 2)
                 .extracting(ReservationTimeResponse::startAt)
                 .contains(time1, time2);
     }
 
     @Test
-    void 예약_시간이_삭제된다() {
+    void 예약이_없는_시간은_삭제된다() {
         // given
-        List<ReservationTimeResponse> before = service.findAll();
-        final Long idToDelete = before.stream()
-                .filter(response -> response.startAt() == time1).findFirst().get().id();
+        ReservationTime time = ReservationTime.from(LocalTime.of(14, 30));
+        ReservationTime savedTime = reservationTimeRepository.save(time);
 
         // when
-        service.delete(idToDelete);
+        service.delete(savedTime.getId());
 
         // then
-        List<ReservationTimeResponse> after = service.findAll();
-        assertThat(after).hasSize(RESERVATION_TIME_COUNT + 1)
-                .extracting(ReservationTimeResponse::id)
-                .doesNotContain(idToDelete);
+        assertThat(reservationTimeRepository.findById(savedTime.getId())).isEmpty();
     }
 
-
     @Test
-    void 예약이_존재하는_시간을_삭제하지_못_한다() {
+    void 예약이_있는_시간은_삭제할_수_없다() {
         // given
-        // when
-        // then
-        assertThatThrownBy(() -> service.delete(1L))
+        ReservationTime time = ReservationTime.from(LocalTime.of(15, 0));
+        ReservationTime savedTime = reservationTimeRepository.save(time);
+
+        RoomEscapeInformation info = RoomEscapeInformation.builder()
+                .date(LocalDate.of(2999, 12, 31))
+                .time(savedTime)
+                .theme(theme)
+                .build();
+        roomEscapeInformationRepository.save(info);
+
+        // when & then
+        assertThatThrownBy(() -> service.delete(savedTime.getId()))
                 .isInstanceOf(ReservationException.class)
                 .hasMessage("해당 시간으로 예약된 건이 존재합니다.");
-
     }
 }

--- a/src/test/java/roomescape/theme/repository/ThemeRepositoryTest.java
+++ b/src/test/java/roomescape/theme/repository/ThemeRepositoryTest.java
@@ -13,7 +13,7 @@ import roomescape.theme.domain.Theme;
 
 @DataJpaTest
 @Sql("/data.sql")
-class JdbcThemeRepositoryTest {
+class ThemeRepositoryTest {
 
     @Autowired
     private ThemeRepository repository;

--- a/src/test/java/roomescape/theme/service/ThemeServiceTest.java
+++ b/src/test/java/roomescape/theme/service/ThemeServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.exception.ReservationException;
-import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.RoomEscapeInformationRepository;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.dto.ThemeRequest;
 import roomescape.theme.dto.ThemeResponse;
@@ -22,7 +22,7 @@ import roomescape.theme.repository.ThemeRepository;
 class ThemeServiceTest {
 
     @Autowired
-    private ReservationRepository reservationRepository;
+    private RoomEscapeInformationRepository roomEscapeInformationRepository;
 
     @Autowired
     private ThemeRepository themeRepository;
@@ -31,7 +31,7 @@ class ThemeServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new ThemeService(themeRepository, reservationRepository);
+        service = new ThemeService(themeRepository, roomEscapeInformationRepository);
     }
 
     @Test

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,6 +1,7 @@
 ALTER TABLE member ALTER COLUMN id RESTART WITH 1;
 ALTER TABLE reservation ALTER COLUMN id RESTART WITH 1;
 ALTER TABLE reservation_time ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE room_escape_information ALTER COLUMN id RESTART WITH 1;
 ALTER TABLE theme ALTER COLUMN id RESTART WITH 1;
 
 INSERT INTO reservation_time(start_at)
@@ -18,7 +19,14 @@ VALUES ('운영진', 'admin@naver.com', '1234', 'ADMIN');
 INSERT INTO member(name, email, password, role)
 VALUES ('홍길동', 'member@naver.com', '1234', 'MEMBER');
 
-INSERT INTO reservation(date, time_id, theme_id, member_id)
-VALUES ('2999-05-01', 1, 1, 1);
-INSERT INTO reservation(date, time_id, theme_id, member_id)
-VALUES ('2999-05-01', 2, 2, 2);
+INSERT INTO room_escape_information(date, time_id, theme_id)
+VALUES ('2999-05-01', 1, 1);
+
+INSERT INTO room_escape_information(date, time_id, theme_id)
+VALUES ('2999-05-05', 1, 2);
+
+INSERT INTO reservation(room_escape_information_id, member_id)
+VALUES (1, 1);
+
+INSERT INTO reservation(room_escape_information_id, member_id)
+VALUES (2, 1);

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -18,7 +18,7 @@ VALUES ('운영진', 'admin@naver.com', '1234', 'ADMIN');
 INSERT INTO member(name, email, password, role)
 VALUES ('홍길동', 'member@naver.com', '1234', 'MEMBER');
 
-INSERT INTO reservation(date, time_id, theme_id, member_id, status)
-VALUES ('2999-05-01', 1, 1, 1, 'BOOKED');
-INSERT INTO reservation(date, time_id, theme_id, member_id, status)
-VALUES ('2999-05-01', 2, 2, 2, 'BOOKED');
+INSERT INTO reservation(date, time_id, theme_id, member_id)
+VALUES ('2999-05-01', 1, 1, 1);
+INSERT INTO reservation(date, time_id, theme_id, member_id)
+VALUES ('2999-05-01', 2, 2, 2);


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?
- [x] [프롤로그](https://prolog.techcourse.co.kr)에 셀프 체크를 작성했나요?
  <!-- 작성한 셀프 체크의 링크를 남겨주세요. -->
  [프롤로그 링크](https://prolog.techcourse.co.kr/studylogs/4367)

## 객체지향 생활체조 요구사항을 얼마나 잘 충족했다고 생각하시나요?
### 1~5점 중에서 선택해주세요.

- [ ] 1 (전혀 충족하지 못함)
- [ ] 2
- [ ] 3 (보통)
- [x] 4
- [ ] 5 (완벽하게 충족)

### 선택한 점수의 이유를 적어주세요.
<!-- 이유 작성 -->

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->|


## 🤔 고민했던 부분

### 1. DB 설계를 어떻게 할까?

<img width="361" alt="image" src="https://github.com/user-attachments/assets/527ebf43-f38e-426e-b611-28fb008fd9ab" />

처음에는 reservation 테이블 하나에 status 컬럼만 두면 모든 게 해결될 거라고 생각했습니다. BOOKED(확정)과 WAITING(대기)라는 두 가지 상태만 구분하면 되니 ERD도 단순했고, 처음 코드를 작성하기에도 부담이 없었습니다. 
또한 필드도 완전히 동일했고 객체 또한 또렷하게 구분되는 행위가 존재하지 않았기 때문에 상태로만 구분하면 되겠다고 생각했습니다.  
만약 둘 중 하나의 필드가 다른 하나와 구분되는 무언가 있거나 특정 행위가 존재한다면 나누었겠지만 존재하지 않았습니다.  

하지만 개발을 이어 가면서 두 가지 질문이 생겼습니다. “대기열은 앞으로도 단순히 상태만 다른 예약으로 남을까?” 그리고 “여러 사용자가 동시에 같은 시간에 예약을 시도하면 안전하게 처리할 수 있을까?”였습니다. 이 질문에 답을 찾다 보니 예약과 대기를 처음부터 분리하는 것이 훨씬 나은 선택이라는 결론에 도달했습니다. 그 이유는 다음과 같습니다.

먼저 확장성 문제입니다. 지금은 대기열에 특별한 정보가 필요 없지만, 조금만 기능이 늘어나면 상황이 달라집니다. 예를 들어 알림 전송 기록, 일정시간 후 예약 대기 만료 시점 등과 같은 값이 생기면  단일 테이블에 이런 전용 컬럼을 계속 추가하면 BOOKED을 가지고 있는 행에는 쓸모없는 NULL 값이 쌓이고, 인덱스는 불필요하게 커져서 점점 느려진다고 생각했습니다. 반면 대기를 별도 테이블로 빼두면, 필요한 컬럼을 자유롭게 추가해도 예약 데이터에는 전혀 영향을 주지 않습니다. 도메인 코드도 “예약은 좌석을 확정하는 행위, 대기는 순번을 관리하는 행위”로 명확히 나뉘어 책임이 선명해져서 가독성과 확장성을 챙길 수 있게 됩니다.  

두 번째로 동시성 문제입니다. 방탈출 같은 서비스는 여러 사용자가 같은 시간대를 동시에 클릭할 수 있습니다. 테이블이 하나라면 (theme_id, date, time_id, status='BOOKED') 조합에 유니크 인덱스를 걸어 중복 예약을 막을 수 있습니다. 그런데 대기도 같은 테이블에 있으면, 대기를 저장할 때마저 유니크 제약에 걸려버려 대기열 자체를 만들 수 없습니다. 
h2,mysql은  status='BOOKED'만은 유니크로 만들 수 없습니다.  왜냐하면 조건부 인덱스를 지원하지 않기 때문입니다. (단, PostgreSQL은 지원)  

그렇다면 현재 미션 환경내에서 할 수 있는 것은 "락"입니다.  단일 테이블 구조에서 비관적 락을 쓰면 다른 사용자는 락이 풀릴 때까지 기다려야 합니다. 트래픽이 몰릴 때 응답 지연이 크게 늘어나는 단점이 존재합니다. 낙관적 락은 충돌 시 재시도해야 하는데, 충돌이 잦은 구간에서는 재시도 횟수가 폭발할 수 있습니다. 

그렇게 고민해서 결국 예약과 예약 대기를 분리하자고 마음먹었습니다.


<img width="945" alt="image" src="https://github.com/user-attachments/assets/37244d3b-f2ca-40cb-a5b0-dd37df865bd3" />


+) 현재 낙관적락으로 교체를 고려중에 있습니다.  
유니크로만 동시성을 잡기에는 한계가 존재합니다.  
현재 미션 수준에서는 잡을 수 있지만 조금 더 복잡한 요구사항이 추가된다면 유니크를 통해 더 이상 동시성을 잡을 수 없다고 생각합니다.


### 📌 코드리뷰 질문 그라운드룰 (지우지 마세요)
✅ 많은 사람과 공유하고 토론해보는 것이 더 좋은 질문에는, 리뷰어가 💬말풍선 이모지를 남겨 토론을 추천할 수 있어요.  
✅ 토론을 추천받은 질문은 `#be-7기-잡담-질답`슬랙채널이나 캠퍼스에서 자유롭게 토론을 이어가보세요!  
✅ 코드에 대한 맥락 없이 리뷰어의 주관적인 의견을 묻거나, 단순히 현업에서는 어떻게 하는지를 묻는 질문은 코드 리뷰 본문에는 어울리지 않아요.  
코드 리뷰는 변경된 코드의 목적, 의도, 품질을 중심으로 논의하는 자리예요.  
✅ 코드와 관련된 질문이 있다면 PR 본문에 적기보다는, 해당 코드를 선택해 코멘트를 남겨주세요.
