### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 제이크(정재민) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -114,14 +114,16 @@ public class ReservationService {
                         canceledReservation.getTheme().getId()
                 )
                 .filter(Waiting::isPromotable)
-                .ifPresent(head -> {
-                    reservationRepository.save(Reservation.create(
-                            head.getName(),
-                            head.getDate(),
-                            head.getTime(),
-                            head.getTheme()
-                    ));
-                    waitingRepository.deleteById(head.getId());
-                });
+                .ifPresent(this::promoteWaiting);
+    }
+
+    private void promoteWaiting(Waiting waiting) {
+        reservationRepository.save(Reservation.create(
+                waiting.getName(),
+                waiting.getDate(),
+                waiting.getTime(),
+                waiting.getTheme()
+        ));
+        waitingRepository.deleteById(waiting.getId());
     }
 }

--- a/src/main/java/roomescape/reservation/application/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/ReservationService.java
@@ -92,9 +92,10 @@ public class ReservationService {
 
     @Transactional
     public void deleteReservation(Long id) {
-        reservationRepository.findById(id)
+        Reservation targetReservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ReservationErrorCode.RESERVATION_NOT_FOUND, id));
         reservationRepository.deleteById(id);
+        promoteFirstWaiting(targetReservation);
     }
 
     @Transactional
@@ -103,5 +104,24 @@ public class ReservationService {
                 .orElseThrow(() -> new EntityNotFoundException(ReservationErrorCode.RESERVATION_NOT_FOUND, id));
         targetReservation.cancel(name);
         reservationRepository.deleteByIdAndName(id, name);
+        promoteFirstWaiting(targetReservation);
+    }
+
+    private void promoteFirstWaiting(Reservation canceledReservation) {
+        waitingRepository.findFirstBySlot(
+                        canceledReservation.getDate(),
+                        canceledReservation.getTime().getId(),
+                        canceledReservation.getTheme().getId()
+                )
+                .filter(Waiting::isPromotable)
+                .ifPresent(head -> {
+                    reservationRepository.save(Reservation.create(
+                            head.getName(),
+                            head.getDate(),
+                            head.getTime(),
+                            head.getTheme()
+                    ));
+                    waitingRepository.deleteById(head.getId());
+                });
     }
 }

--- a/src/main/java/roomescape/reservation/application/WaitingAdapter.java
+++ b/src/main/java/roomescape/reservation/application/WaitingAdapter.java
@@ -3,6 +3,7 @@ package roomescape.reservation.application;
 import org.springframework.stereotype.Component;
 import roomescape.global.exception.WaitingErrorCode;
 import roomescape.global.exception.customException.BusinessException;
+import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.ReservationRepository;
 import roomescape.waiting.application.WaitingReference;
 import roomescape.waiting.application.dto.WaitingCreateCommand;
@@ -18,11 +19,14 @@ public class WaitingAdapter implements WaitingReference {
 
     @Override
     public void validateExistReservation(WaitingCreateCommand waitingCreateCommand) {
-        if (reservationRepository.findByDateAndTimeIdAndThemeId(
-                waitingCreateCommand.date(),
-                waitingCreateCommand.timeId(),
-                waitingCreateCommand.themeId()).isEmpty()) {
-            throw new BusinessException(WaitingErrorCode.WAITING_NOT_EXIST_RESERVATION);
+        Reservation reservation = reservationRepository.findByDateAndTimeIdAndThemeId(
+                        waitingCreateCommand.date(),
+                        waitingCreateCommand.timeId(),
+                        waitingCreateCommand.themeId())
+                .orElseThrow(() -> new BusinessException(WaitingErrorCode.WAITING_NOT_EXIST_RESERVATION));
+
+        if (reservation.getName().equals(waitingCreateCommand.name())) {
+            throw new BusinessException(WaitingErrorCode.WAITING_ALREADY_EXISTS);
         }
     }
 }

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -54,6 +54,10 @@ public class Waiting {
         return new Waiting(id, name, date, time, theme, rank, createdAt);
     }
 
+    public boolean isPromotable() {
+        return !LocalDateTime.of(date, time.getStartAt()).isBefore(LocalDateTime.now());
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/waiting/domain/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/domain/WaitingRepository.java
@@ -8,6 +8,8 @@ public interface WaitingRepository {
     Waiting save(Waiting waiting);
     Optional<Waiting> findById(Long id);
     Optional<Waiting> findByNameAndDateAndTimeIdAndThemeId(String name, LocalDate date, Long timeId, Long themeId);
+    Optional<Waiting> findFirstBySlot(LocalDate date, Long timeId, Long themeId);
     void deleteByIdAndName(Long id, String name);
+    void deleteById(Long id);
     List<Waiting> findByName(String name);
 }

--- a/src/main/java/roomescape/waiting/infrastructure/WaitingJdbcTemplateRepository.java
+++ b/src/main/java/roomescape/waiting/infrastructure/WaitingJdbcTemplateRepository.java
@@ -89,7 +89,34 @@ public class WaitingJdbcTemplateRepository implements WaitingRepository {
           AND time_id = ?
           AND theme_id = ?
         """;
+    private static final String FIND_FIRST_BY_SLOT_QUERY = """
+        SELECT *
+        FROM (
+            SELECT w.id,
+                   w.name AS waiting_name,
+                   w.date,
+                   w.created_at,
+                   rt.id AS time_id,
+                   rt.start_at,
+                   t.id AS theme_id,
+                   t.name AS theme_name,
+                   t.description AS theme_description,
+                   t.thumbnail_url,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY w.date, w.time_id, w.theme_id
+                       ORDER BY w.created_at, w.id
+                   ) AS rank
+            FROM waiting w
+            JOIN reservation_time rt ON w.time_id = rt.id
+            JOIN theme t ON w.theme_id = t.id
+        ) ranked_waiting
+        WHERE date = ?
+          AND time_id = ?
+          AND theme_id = ?
+          AND rank = 1
+        """;
     private static final String DELETE_BY_ID_AND_NAME_QUERY = "DELETE FROM waiting WHERE id = ? AND name = ?";
+    private static final String DELETE_BY_ID_QUERY = "DELETE FROM waiting WHERE id = ?";
 
     private static final RowMapper<Waiting> ROW_MAPPER = (rs, rowNum) -> {
         ReservationTime time = ReservationTime.createRow(
@@ -166,11 +193,32 @@ public class WaitingJdbcTemplateRepository implements WaitingRepository {
     }
 
     @Override
+    public Optional<Waiting> findFirstBySlot(LocalDate date, Long timeId, Long themeId) {
+        List<Waiting> waiting = jdbcTemplate.query(
+                FIND_FIRST_BY_SLOT_QUERY,
+                ROW_MAPPER,
+                date,
+                timeId,
+                themeId
+        );
+        return waiting.stream()
+                .findFirst();
+    }
+
+    @Override
     public void deleteByIdAndName(Long id, String name) {
         jdbcTemplate.update(
                 DELETE_BY_ID_AND_NAME_QUERY,
                 id,
                 name
+        );
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jdbcTemplate.update(
+                DELETE_BY_ID_QUERY,
+                id
         );
     }
 

--- a/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/application/ReservationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -330,6 +331,73 @@ class ReservationServiceTest {
 
         // then
         assertThat(reservationRepository.findById(savedReservation.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("예약을 취소하면 같은 슬롯의 1순위 대기가 예약으로 승격된다")
+    void cancelReservation_promotes_first_waiting() {
+        // given
+        ReservationTime savedTime = reservationTimeRepository.save(ReservationTime.create(LocalTime.now().plusHours(1)));
+        Theme savedTheme = themeRepository.save(Theme.create("공포", "아니", "https://good.com/thumb-nail/1"));
+        LocalDate date = LocalDate.now().plusDays(1);
+        Reservation savedReservation = reservationRepository.save(Reservation.create("인직", date, savedTime, savedTheme));
+        waitingRepository.save(Waiting.create("브라운", date, savedTime, savedTheme));
+        waitingRepository.save(Waiting.create("리오", date, savedTime, savedTheme));
+
+        // when
+        reservationService.cancelReservation(savedReservation.getId(), "인직");
+
+        // then
+        assertThat(reservationRepository.findById(savedReservation.getId())).isEmpty();
+        List<Reservation> promoted = reservationRepository.findByName("브라운");
+        assertThat(promoted).hasSize(1);
+        assertThat(promoted.getFirst().getDate()).isEqualTo(date);
+        assertThat(promoted.getFirst().getTime().getId()).isEqualTo(savedTime.getId());
+        assertThat(promoted.getFirst().getTheme().getId()).isEqualTo(savedTheme.getId());
+        assertThat(waitingRepository.findByName("브라운")).isEmpty();
+        assertThat(waitingRepository.findByName("리오")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("관리자가 예약을 삭제하면 같은 슬롯의 1순위 대기가 예약으로 승격된다")
+    void deleteReservation_promotes_first_waiting() {
+        // given
+        ReservationTime savedTime = reservationTimeRepository.save(ReservationTime.create(LocalTime.now().plusHours(1)));
+        Theme savedTheme = themeRepository.save(Theme.create("공포", "아니", "https://good.com/thumb-nail/1"));
+        LocalDate date = LocalDate.now().plusDays(1);
+        Reservation savedReservation = reservationRepository.save(Reservation.create("인직", date, savedTime, savedTheme));
+        waitingRepository.save(Waiting.create("브라운", date, savedTime, savedTheme));
+
+        // when
+        reservationService.deleteReservation(savedReservation.getId());
+
+        // then
+        assertThat(reservationRepository.findById(savedReservation.getId())).isEmpty();
+        assertThat(reservationRepository.findByName("브라운")).hasSize(1);
+        assertThat(waitingRepository.findByName("브라운")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("관리자가 과거 예약을 삭제해도 과거 대기는 승격되지 않는다")
+    void deleteReservation_skips_past_waiting() {
+        // given
+        ReservationTime savedTime = reservationTimeRepository.save(ReservationTime.create(LocalTime.of(10, 0)));
+        Theme savedTheme = themeRepository.save(Theme.create("공포", "아니", "https://good.com/thumb-nail/1"));
+        LocalDate pastDate = LocalDate.now().minusDays(1);
+        Reservation pastReservation = reservationRepository.save(
+                Reservation.createRow(null, "인직", pastDate, savedTime, savedTheme, LocalDateTime.now().minusDays(2))
+        );
+        waitingRepository.save(
+                Waiting.createRow(null, "브라운", pastDate, savedTime, savedTheme, null, LocalDateTime.now().minusDays(2))
+        );
+
+        // when
+        reservationService.deleteReservation(pastReservation.getId());
+
+        // then
+        assertThat(reservationRepository.findById(pastReservation.getId())).isEmpty();
+        assertThat(reservationRepository.findByName("브라운")).isEmpty();
+        assertThat(waitingRepository.findByName("브라운")).hasSize(1);
     }
 
 }

--- a/src/test/java/roomescape/reservation/application/WaitingAdapterTest.java
+++ b/src/test/java/roomescape/reservation/application/WaitingAdapterTest.java
@@ -65,4 +65,25 @@ class WaitingAdapterTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("예약이 존재하지 않으면, 대기요청을 할 수 없습니다.");
     }
+
+    @Test
+    @DisplayName("본인이 예약한 슬롯에 대기를 신청하면 예외가 발생한다")
+    void 본인이_예약한_슬롯에_대기를_신청하면_예외가_발생한다() {
+        // given
+        LocalDate date = LocalDate.now().plusDays(1);
+        ReservationTime time = ReservationTime.createRow(1L, LocalTime.of(10, 0));
+        Theme theme = Theme.createRow(1L, "공포", "설명", "https://good.com");
+        reservationRepository.save(Reservation.create("브라운", date, time, theme));
+        WaitingCreateCommand command = new WaitingCreateCommand(
+                "브라운",
+                date,
+                time.getId(),
+                theme.getId()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> waitingAdapter.validateExistReservation(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미 예약된 시간입니다. 다른 시간을 선택해 주세요.");
+    }
 }

--- a/src/test/java/roomescape/waiting/domain/WaitingTest.java
+++ b/src/test/java/roomescape/waiting/domain/WaitingTest.java
@@ -68,4 +68,30 @@ class WaitingTest {
         assertThat(savedWaiting.getTheme()).isEqualTo(waiting.getTheme());
         assertThat(savedWaiting.getRank()).isEqualTo(waiting.getRank());
     }
+
+    @Test
+    @DisplayName("미래 일정의 예약 대기는 승격 가능하다")
+    void isPromotable_true_with_future_schedule() {
+        // given
+        ReservationTime time = ReservationTime.createRow(1L, LocalTime.of(10, 0));
+        Theme theme = Theme.createRow(1L, "공포", "무서운 테마", "https://good.com/thumb-nail/1");
+        Waiting waiting = Waiting.create("브라운", LocalDate.now().plusDays(1), time, theme);
+
+        // when & then
+        assertThat(waiting.isPromotable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("지난 일정의 예약 대기는 승격 불가하다")
+    void isPromotable_false_with_past_schedule() {
+        // given
+        ReservationTime time = ReservationTime.createRow(1L, LocalTime.of(10, 0));
+        Theme theme = Theme.createRow(1L, "공포", "무서운 테마", "https://good.com/thumb-nail/1");
+        Waiting pastWaiting = Waiting.createRow(
+                1L, "브라운", LocalDate.now().minusDays(1), time, theme, 1L, LocalDateTime.now().minusDays(2)
+        );
+
+        // when & then
+        assertThat(pastWaiting.isPromotable()).isFalse();
+    }
 }

--- a/src/test/java/roomescape/waiting/fake/FakeWaitingRepository.java
+++ b/src/test/java/roomescape/waiting/fake/FakeWaitingRepository.java
@@ -1,6 +1,7 @@
 package roomescape.waiting.fake;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,11 +56,25 @@ public class FakeWaitingRepository implements WaitingRepository {
     }
 
     @Override
+    public Optional<Waiting> findFirstBySlot(LocalDate date, Long timeId, Long themeId) {
+        return store.values().stream()
+                .filter(waiting -> waiting.getDate().equals(date))
+                .filter(waiting -> waiting.getTime().getId().equals(timeId))
+                .filter(waiting -> waiting.getTheme().getId().equals(themeId))
+                .min(Comparator.comparing(Waiting::getCreatedAt).thenComparing(Waiting::getId));
+    }
+
+    @Override
     public void deleteByIdAndName(Long id, String name) {
         store.values().removeIf(waiting ->
                 waiting.getId().equals(id)
                         && waiting.getName().equals(name)
         );
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
     }
 
     public boolean isEmpty() {

--- a/src/test/java/roomescape/waiting/infrastructure/WaitingJdbcTemplateRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/infrastructure/WaitingJdbcTemplateRepositoryTest.java
@@ -219,4 +219,48 @@ class WaitingJdbcTemplateRepositoryTest {
                 savedTheme.getId()
         )).isEmpty();
     }
+
+    @Test
+    @DisplayName("슬롯의 1순위(가장 먼저 신청한) 예약 대기를 조회한다")
+    void findFirstBySlot_success() {
+        // given
+        LocalDate date = LocalDate.now().plusDays(1);
+        Waiting first = waitingRepository.save(Waiting.create("리오", date, savedTime, savedTheme));
+        waitingRepository.save(Waiting.create("브라운", date, savedTime, savedTheme));
+
+        // when
+        Waiting head = waitingRepository.findFirstBySlot(date, savedTime.getId(), savedTheme.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(head.getId()).isEqualTo(first.getId());
+        assertThat(head.getName()).isEqualTo("리오");
+        assertThat(head.getRank()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("대기가 없는 슬롯의 1순위를 조회하면 빈 Optional을 반환한다")
+    void findFirstBySlot_returns_empty_when_no_waiting() {
+        // when & then
+        assertThat(waitingRepository.findFirstBySlot(
+                LocalDate.now().plusDays(1),
+                savedTime.getId(),
+                savedTheme.getId()
+        )).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ID로 예약 대기를 삭제한다")
+    void deleteById_success() {
+        // given
+        Waiting savedWaiting = waitingRepository.save(
+                Waiting.create("브라운", LocalDate.now().plusDays(1), savedTime, savedTheme)
+        );
+
+        // when
+        waitingRepository.deleteById(savedWaiting.getId());
+
+        // then
+        assertThat(waitingRepository.findById(savedWaiting.getId())).isEmpty();
+    }
 }


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [x] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?

`예약 삭제 → 1순위 대기 승격`을 **하나의 트랜잭션**으로 처리했습니다.

- **장점:** 취소와 승격이 원자적으로 처리돼 빈 슬롯에 새치기하는 경우가 없고, 승격 유실도 없습니다.
- **단점:** 취소와 승격 책임이 묶이고, 승격 실패 시 취소까지 롤백됩니다.


이벤트로 2개 트랜잭션 분리를 고려했을 때, 대기 승격이 실패했을때를 보장하기 위해서 아웃박스 패턴도 생각했었지만, 현재 규모에서는 과한 복잡도 때문에 단일 트랜잭션을 골랐습니다.

**질문**
1. 이 규모에서 단일 트랜잭션 선택이 적절할까요?
2. 실제 운영 규모라면 승격을 이벤트로 분리하고 아웃박스로 보장하는 게 합리적일까요? 어느 임계점부터 고려해볼만 할까요?