### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 라이 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/error/DataInconsistencyException.java
+++ b/src/main/java/roomescape/error/DataInconsistencyException.java
@@ -1,0 +1,9 @@
+package roomescape.error;
+
+import org.springframework.http.HttpStatus;
+
+public class DataInconsistencyException extends BusinessException {
+    public DataInconsistencyException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/roomescape/error/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/error/GlobalExceptionHandler.java
@@ -44,6 +44,13 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
     }
 
+    @ExceptionHandler(DataInconsistencyException.class)
+    public ResponseEntity<ErrorResponse> handlerDataInconsistency(DataInconsistencyException e) {
+        log.error("Data inconsistency exception: {}", e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnhandled(Exception e) {
         log.error("Unhandled exception", e);

--- a/src/main/java/roomescape/reservation/controller/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/controller/dto/ReservationResponse.java
@@ -1,13 +1,15 @@
 package roomescape.reservation.controller.dto;
 
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.Status;
 import roomescape.theme.controller.dto.ThemeResponse;
 
 public record ReservationResponse(
         Long id,
         String name,
         ReservationTimeResponse time,
-        ThemeResponse theme
+        ThemeResponse theme,
+        Status status
 ) {
 
     public static ReservationResponse from(Reservation reservation) {
@@ -15,7 +17,8 @@ public record ReservationResponse(
                 reservation.getId(),
                 reservation.getName(),
                 ReservationTimeResponse.from(reservation.getTime()),
-                ThemeResponse.from(reservation.getTheme())
+                ThemeResponse.from(reservation.getTheme()),
+                reservation.getStatus()
         );
     }
 }

--- a/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
@@ -66,12 +66,12 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public Optional<Reservation> findByIdForUpdate(Long id) {
-        List<Reservation> results = jdbcTemplate.query(
-                BASE_SELECT + "WHERE r.id = ? FOR UPDATE",
-                new ReservationRowMapper(),
+        jdbcTemplate.query(
+                "SELECT id FROM reservation WHERE id = ? FOR UPDATE",
+                (rs, rowNum) -> rs.getLong("id"),
                 id
         );
-        return results.stream().findFirst();
+        return findById(id);
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
@@ -65,6 +65,16 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public Optional<Reservation> findByIdForUpdate(Long id) {
+        List<Reservation> results = jdbcTemplate.query(
+                BASE_SELECT + "WHERE r.id = ? FOR UPDATE",
+                new ReservationRowMapper(),
+                id
+        );
+        return results.stream().findFirst();
+    }
+
+    @Override
     public boolean update(Long id, Long timeId, LocalDateTime now, Status status) {
         int affected = jdbcTemplate.update(
                 "UPDATE reservation SET time_id = ?, created_at = ?, status = ? WHERE id = ?",

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -14,6 +14,8 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long id);
 
+    Optional<Reservation> findByIdForUpdate(Long id);
+
     Reservation save(Reservation reservation);
 
     boolean update(Long id, Long timeId, LocalDateTime now, Status status);

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -124,6 +124,9 @@ public class ReservationServiceImpl implements ReservationService {
         promoteNextWaiting(reservation);
         ReservationTime newTime = findTime(timeId);
         newTime.validateReservableSchedule();
+        if (reservationRepository.isDuplicatedWithName(reservation.getName(), timeId, newTime)) {
+            throw new DuplicateReservationException();
+        }
         Status status = Status.from(
                 reservationRepository.hasConfirmedReservation(reservation.getTheme().getId(), newTime));
         boolean updated = reservationRepository.update(id, timeId, LocalDateTime.now(), status);

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -105,8 +105,7 @@ public class ReservationServiceImpl implements ReservationService {
     public void cancel(Long id) {
         Reservation reservation = reservationRepository.findByIdForUpdate(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
-        promoteNextWaiting(reservation);
-        reservationRepository.deleteById(id);
+        cancelWithPromotion(reservation);
     }
 
     @Override
@@ -116,8 +115,12 @@ public class ReservationServiceImpl implements ReservationService {
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         reservation.validateOwnedBy(name);
         reservation.getTime().validateNotPastForCancel();
+        cancelWithPromotion(reservation);
+    }
+
+    private void cancelWithPromotion(Reservation reservation) {
         promoteNextWaiting(reservation);
-        reservationRepository.deleteById(id);
+        reservationRepository.deleteById(reservation.getId());
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -61,9 +61,7 @@ public class ReservationServiceImpl implements ReservationService {
         validateThemeId(themeId);
         validateNotHoliday(time);
         Theme theme = themeRepository.findById(themeId);
-        if (reservationRepository.isDuplicatedWithName(request.name(), themeId, time)) {
-            throw new DuplicateReservationException();
-        }
+        validateNotDuplicated(request.name(), themeId, time);
         Status status = Status.from(reservationRepository.hasConfirmedReservation(themeId, time));
         Reservation newReservation = new Reservation(request.name(),
                 time,
@@ -71,6 +69,13 @@ public class ReservationServiceImpl implements ReservationService {
                 status,
                 LocalDateTime.now());
         return reservationRepository.save(newReservation);
+    }
+
+    private ReservationTime findTime(Long timeId) {
+        if (timeId == null) {
+            throw new IllegalArgumentException("예약 시간은 필수입니다.");
+        }
+        return timeService.findById(timeId);
     }
 
     private void validateThemeId(Long themeId) {
@@ -88,11 +93,10 @@ public class ReservationServiceImpl implements ReservationService {
         }
     }
 
-    private ReservationTime findTime(Long timeId) {
-        if (timeId == null) {
-            throw new IllegalArgumentException("예약 시간은 필수입니다.");
+    private void validateNotDuplicated(String name, Long themeId, ReservationTime time) {
+        if (reservationRepository.isDuplicatedWithName(name, themeId, time)) {
+            throw new DuplicateReservationException();
         }
-        return timeService.findById(timeId);
     }
 
     @Override
@@ -121,18 +125,16 @@ public class ReservationServiceImpl implements ReservationService {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         reservation.getTime().validateUpdatableReservation();
-        promoteNextWaiting(reservation);
+        Long themeId = reservation.getTheme().getId();
         ReservationTime newTime = findTime(timeId);
         newTime.validateReservableSchedule();
-        if (reservationRepository.isDuplicatedWithName(reservation.getName(), timeId, newTime)) {
-            throw new DuplicateReservationException();
-        }
+        validateNotDuplicated(reservation.getName(), themeId, newTime);
+        promoteNextWaiting(reservation);
         Status status = Status.from(
-                reservationRepository.hasConfirmedReservation(reservation.getTheme().getId(), newTime));
+                reservationRepository.hasConfirmedReservation(themeId, newTime));
         boolean updated = reservationRepository.update(id, timeId, LocalDateTime.now(), status);
         if (!updated) {
             throw new IllegalStateException("예약 수정에 실패했습니다. id: " + id);
-
         }
         return reservation.withTimeAndStatus(newTime, status);
     }

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -1,5 +1,6 @@
 package roomescape.reservation.service;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.holiday.service.HolidayService;
@@ -63,12 +64,12 @@ public class ReservationServiceImpl implements ReservationService {
         Theme theme = themeRepository.findById(themeId);
         validateNotDuplicated(request.name(), themeId, time);
         Status status = Status.from(reservationRepository.hasConfirmedReservation(themeId, time));
-        Reservation newReservation = new Reservation(request.name(),
-                time,
-                theme,
-                status,
-                LocalDateTime.now());
-        return reservationRepository.save(newReservation);
+        Reservation newReservation = new Reservation(request.name(), time, theme, status, LocalDateTime.now());
+        try {
+            return reservationRepository.save(newReservation);
+        } catch (DuplicateKeyException e) {
+            throw new DuplicateReservationException();
+        }
     }
 
     private ReservationTime findTime(Long timeId) {
@@ -102,7 +103,7 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancel(Long id) {
-        Reservation reservation = reservationRepository.findById(id)
+        Reservation reservation = reservationRepository.findByIdForUpdate(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         promoteNextWaiting(reservation);
         reservationRepository.deleteById(id);
@@ -111,7 +112,7 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancelForUser(Long id, String name) {
-        Reservation reservation = reservationRepository.findById(id)
+        Reservation reservation = reservationRepository.findByIdForUpdate(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         reservation.validateOwnedBy(name);
         reservation.getTime().validateNotPastForCancel();
@@ -122,7 +123,7 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public Reservation update(Long id, Long timeId) {
-        Reservation reservation = reservationRepository.findById(id)
+        Reservation reservation = reservationRepository.findByIdForUpdate(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         reservation.getTime().validateUpdatableReservation();
         Long themeId = reservation.getTheme().getId();

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -6,6 +6,7 @@ import roomescape.holiday.service.HolidayService;
 import roomescape.reservation.controller.dto.ReservationWithWaitingOrderResponse;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Status;
+import roomescape.error.DataInconsistencyException;
 import roomescape.reservation.exception.DuplicateReservationException;
 import roomescape.reservation.exception.ReservationNotFoundException;
 import roomescape.reservation.repository.ReservationRepository;
@@ -138,7 +139,7 @@ public class ReservationServiceImpl implements ReservationService {
             reservationRepository.findEarliestWaiting(reservation.getTime().getId(), reservation.getTheme().getId())
                     .ifPresent(waitingId -> {
                         if (!reservationRepository.promoteToReserved(waitingId)) {
-                            throw new IllegalStateException("대기 예약 승격에 실패했습니다. id: " + waitingId);
+                            throw new DataInconsistencyException("대기 예약 승격에 실패했습니다. id: " + waitingId);
                         }
                     });
         }

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -46,6 +46,13 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     @Override
+    public List<ReservationWithWaitingOrderResponse> getAllByName(String name) {
+        return reservationRepository.findAllByName(name).stream()
+                .map(ReservationWithWaitingOrderResponse::from)
+                .toList();
+    }
+
+    @Override
     @Transactional
     public Reservation create(ReservationSaveServiceRequest request) {
         ReservationTime time = findTime(request.timeId());
@@ -91,17 +98,10 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancel(Long id) {
-        boolean deleted = reservationRepository.deleteById(id);
-        if (!deleted) {
-            throw new ReservationNotFoundException(id);
-        }
-    }
-
-    @Override
-    public List<ReservationWithWaitingOrderResponse> getAllByName(String name) {
-        return reservationRepository.findAllByName(name).stream()
-                .map(ReservationWithWaitingOrderResponse::from)
-                .toList();
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id));
+        promoteNextWaiting(reservation);
+        reservationRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/resources/templates/dashboard/reservations.html
+++ b/src/main/resources/templates/dashboard/reservations.html
@@ -23,6 +23,9 @@
         .inline-form { display: inline-block; }
         .links a { margin-right: 12px; color: #4f46e5; text-decoration: none; }
         .empty { color: #667085; font-style: italic; }
+        .badge { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 0.8em; font-weight: 700; }
+        .badge.reserved { background: #ecfdf3; color: #027a48; }
+        .badge.waiting  { background: #fef9ec; color: #b45309; }
     </style>
 </head>
 <body>
@@ -61,6 +64,8 @@
                     <div class="head">
                         <div>
                             <strong th:text="${reservation.name()}"></strong>
+                            <span th:class="${reservation.status().name() == 'RESERVED'} ? 'badge reserved' : 'badge waiting'"
+                                  th:text="${reservation.status().name() == 'RESERVED'} ? '예약' : '대기'"></span>
                             <p th:text="|${reservation.time().startAt()} ~ ${reservation.time().endAt()} · ${reservation.theme().name()}|"></p>
                         </div>
                         <form class="inline-form" method="post" th:action="@{|/page/dashboard/reservations/${reservation.id()}/cancel|}">

--- a/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
@@ -23,6 +23,7 @@ import roomescape.reservation.controller.dto.ReservationTimeResponse;
 import roomescape.reservation.controller.dto.ReservationWithWaitingOrderResponse;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Status;
+import roomescape.reservation.exception.DuplicateReservationException;
 import roomescape.reservation.exception.ForbiddenRequestException;
 import roomescape.reservation.exception.PastReservationException;
 import roomescape.reservation.exception.ReservationNotFoundException;
@@ -421,5 +422,25 @@ class ReservationServiceImplTest {
         // when & then
         assertThatThrownBy(() -> reservationService.update(existing.getId(), oldTime.getId()))
                 .isInstanceOf(PastReservationException.class);
+    }
+
+    @DisplayName("변경하려는 슬롯에 같은 이름의 예약/대기가 이미 있는 경우, DuplicateReservationException이 발생한다.")
+    @Test
+    void update_중복_슬롯으로_변경하면_예외() {
+        // given
+        ReservationTime oldTime = new ReservationTime(1L, FUTURE_START, FUTURE_END);
+        ReservationTime newTime = new ReservationTime(2L,
+                LocalDateTime.of(2030, 6, 1, 14, 0),
+                LocalDateTime.of(2030, 6, 1, 16, 0));
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
+        when(reservationRepository.findEarliestWaiting(any(), any())).thenReturn(Optional.empty());
+        when(timeService.findById(2L)).thenReturn(newTime);
+        when(reservationRepository.isDuplicatedWithName("라이", 2L, newTime)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.update(existing.getId(), newTime.getId()))
+                .isInstanceOf(DuplicateReservationException.class);
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
@@ -186,7 +186,7 @@ class ReservationServiceImplTest {
 
     @DisplayName("같은 슬롯/테마에 중복 예약을 시도하는 경우, 대기로 넘어가기 때문에 예외가 발생하지 않는다.")
     @Test
-    void create_중복_예약이면_예외() {
+    void create_중복_예약이면_대기로_저장() {
         // given
         ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
@@ -373,7 +373,7 @@ class ReservationServiceImplTest {
         Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
         when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
         when(timeService.findById(2L)).thenReturn(newTime);
-        when(reservationRepository.hasConfirmedReservation(existing.getId(), newTime)).thenReturn(false);
+        when(reservationRepository.hasConfirmedReservation(theme.getId(), newTime)).thenReturn(false);
         when(reservationRepository.update(any(), any(), any(), any())).thenReturn(true);
 
         // when
@@ -435,9 +435,8 @@ class ReservationServiceImplTest {
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
         when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
-        when(reservationRepository.findEarliestWaiting(any(), any())).thenReturn(Optional.empty());
         when(timeService.findById(2L)).thenReturn(newTime);
-        when(reservationRepository.isDuplicatedWithName("라이", 2L, newTime)).thenReturn(true);
+        when(reservationRepository.isDuplicatedWithName("라이", 1L, newTime)).thenReturn(true);
 
         // when & then
         assertThatThrownBy(() -> reservationService.update(existing.getId(), newTime.getId()))

--- a/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
@@ -272,7 +272,7 @@ class ReservationServiceImplTest {
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
         Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(reservation.getId())).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdForUpdate(reservation.getId())).thenReturn(Optional.of(reservation));
         when(reservationRepository.findEarliestWaiting(any(), any())).thenReturn(Optional.empty());
 
         // when
@@ -289,7 +289,7 @@ class ReservationServiceImplTest {
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
         Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(reservation.getId())).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdForUpdate(reservation.getId())).thenReturn(Optional.of(reservation));
         when(reservationRepository.findEarliestWaiting(any(), any())).thenReturn(Optional.empty());
 
         // when
@@ -307,7 +307,7 @@ class ReservationServiceImplTest {
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
         Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
 
         // when & then
         assertThatThrownBy(() -> reservationService.cancelForUser(reservation.getId(), "어셔"))
@@ -319,7 +319,7 @@ class ReservationServiceImplTest {
     @Test
     void cancelForUser_존재하지_않는_예약이면_예외() {
         // given
-        when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
+        when(reservationRepository.findByIdForUpdate(999L)).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> reservationService.cancelForUser(999L, "name"))
@@ -332,7 +332,7 @@ class ReservationServiceImplTest {
         // given
         ReservationTime time = new ReservationTime(1L, PAST_START, PAST_END);
         Reservation past = new Reservation("라이", time, null, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(past.getId())).thenReturn(Optional.of(past));
+        when(reservationRepository.findByIdForUpdate(past.getId())).thenReturn(Optional.of(past));
 
         // when & then
         assertThatThrownBy(() -> reservationService.cancelForUser(past.getId(), "라이"))
@@ -346,7 +346,7 @@ class ReservationServiceImplTest {
         ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(any())).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository.findEarliestWaiting(time.getId(), theme.getId())).thenReturn(Optional.of(2L));
         when(reservationRepository.promoteToReserved(2L)).thenReturn(true);
         when(reservationRepository.deleteById(reservation.getId())).thenReturn(true);
@@ -355,7 +355,7 @@ class ReservationServiceImplTest {
         reservationService.cancelForUser(reservation.getId(), "라이");
 
         // then
-        verify(reservationRepository).findById(any());
+        verify(reservationRepository).findByIdForUpdate(1L);
         verify(reservationRepository).findEarliestWaiting(time.getId(), theme.getId());
         verify(reservationRepository).promoteToReserved(2L);
         verify(reservationRepository).deleteById(reservation.getId());
@@ -371,7 +371,7 @@ class ReservationServiceImplTest {
                 LocalDateTime.of(2030, 6, 1, 16, 0));
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
+        when(reservationRepository.findByIdForUpdate(existing.getId())).thenReturn(Optional.of(existing));
         when(timeService.findById(2L)).thenReturn(newTime);
         when(reservationRepository.hasConfirmedReservation(theme.getId(), newTime)).thenReturn(false);
         when(reservationRepository.update(any(), any(), any(), any())).thenReturn(true);
@@ -388,7 +388,7 @@ class ReservationServiceImplTest {
     @Test
     void update_존재하지_않는_예약이면_예외() {
         // given
-        when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
+        when(reservationRepository.findByIdForUpdate(999L)).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> reservationService.update(999L, 1L))
@@ -403,7 +403,7 @@ class ReservationServiceImplTest {
         ReservationTime newTime = new ReservationTime(2L, PAST_START, PAST_END);
         Theme theme = new Theme("테마1", "설명", "https://img.test/a.png").withId(1L);
         Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
+        when(reservationRepository.findByIdForUpdate(existing.getId())).thenReturn(Optional.of(existing));
         when(timeService.findById(newTime.getId())).thenReturn(newTime);
 
         // when & then
@@ -417,7 +417,7 @@ class ReservationServiceImplTest {
         // given
         ReservationTime oldTime = new ReservationTime(1L, PAST_START, PAST_END);
         Reservation existing = new Reservation("라이", oldTime, null, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
+        when(reservationRepository.findByIdForUpdate(existing.getId())).thenReturn(Optional.of(existing));
 
         // when & then
         assertThatThrownBy(() -> reservationService.update(existing.getId(), oldTime.getId()))
@@ -434,7 +434,7 @@ class ReservationServiceImplTest {
                 LocalDateTime.of(2030, 6, 1, 16, 0));
         Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
         Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
-        when(reservationRepository.findById(existing.getId())).thenReturn(Optional.of(existing));
+        when(reservationRepository.findByIdForUpdate(existing.getId())).thenReturn(Optional.of(existing));
         when(timeService.findById(2L)).thenReturn(newTime);
         when(reservationRepository.isDuplicatedWithName("라이", 1L, newTime)).thenReturn(true);
 

--- a/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
@@ -239,19 +239,6 @@ class ReservationServiceImplTest {
         assertThat(result).isEqualTo(reservations);
     }
 
-    @DisplayName("예약을 취소하는 경우, repository의 deleteById가 호출된다.")
-    @Test
-    void cancel_정상_취소() {
-        // given
-        when(reservationRepository.deleteById(1L)).thenReturn(true);
-
-        // when
-        reservationService.cancel(1L);
-
-        // then
-        verify(reservationRepository).deleteById(1L);
-    }
-
     @DisplayName("대기 순번을 포함한 예약 전체 정보를 조회한다.")
     @Test
     void getAllByName_예약_전체_정보_조회_테스트() {
@@ -275,6 +262,23 @@ class ReservationServiceImplTest {
         assertThat(result.getFirst().waitingOrder()).isNull();
         assertThat(result.get(1).waitingOrder()).isEqualTo(3);
         verify(reservationRepository, times(1)).findAllByName("라이");
+    }
+
+    @DisplayName("예약을 취소하는 경우, repository의 deleteById가 호출된다.")
+    @Test
+    void cancel_정상_취소() {
+        // given
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
+        Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        when(reservationRepository.findById(reservation.getId())).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findEarliestWaiting(any(), any())).thenReturn(Optional.empty());
+
+        // when
+        reservationService.cancel(1L);
+
+        // then
+        verify(reservationRepository).deleteById(1L);
     }
 
     @DisplayName("예약 대기가 없는 경우, RESERVED인 예약이 정상 취소된다.")

--- a/src/test/java/roomescape/reservation/service/ReservationTransactionTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationTransactionTest.java
@@ -2,8 +2,8 @@ package roomescape.reservation.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -54,6 +54,8 @@ class ReservationTransactionTest {
         reservationService.cancelForUser(reserved.getId(), "라이");
 
         // then
+        verify(reservationRepository).promoteToReserved(waiting.getId());
+        verify(reservationRepository).deleteById(reserved.getId());
         assertThat(reservationRepository.findById(reserved.getId())).isEmpty();
         Reservation promoted = reservationRepository.findById(waiting.getId()).get();
         assertThat(promoted.getStatus()).isEqualTo(Status.RESERVED);
@@ -72,7 +74,7 @@ class ReservationTransactionTest {
                 new Reservation("어셔", time, theme, Status.WAITING, LocalDateTime.now()));
 
         doThrow(new RuntimeException("강제 실패"))
-                .when(reservationRepository).deleteById(anyLong());
+                .when(reservationRepository).deleteById(reserved.getId());
 
         // when
         // 예외 강제 발생
@@ -80,7 +82,9 @@ class ReservationTransactionTest {
                 .isInstanceOf(RuntimeException.class);
 
         // then
-        // promoteToReserved가 롤백되어 대기 상태 그대로
+        // 같은 트랜잭션의 promoteToReserved가 롤백되어 대기 상태 그대로
+        verify(reservationRepository).promoteToReserved(waiting.getId());
+        verify(reservationRepository).deleteById(reserved.getId());
         Reservation stillWaiting = reservationRepository.findById(waiting.getId()).get();
         assertThat(stillWaiting.getStatus()).isEqualTo(Status.WAITING);
         assertThat(stillWaiting.getId()).isEqualTo(waiting.getId());

--- a/src/test/java/roomescape/reservation/service/ReservationTransactionTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationTransactionTest.java
@@ -1,0 +1,88 @@
+package roomescape.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.Status;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.ReservationTime;
+import roomescape.time.repository.TimeRepository;
+
+@SpringBootTest
+@Sql("/truncate.sql")
+class ReservationTransactionTest {
+
+    private static final LocalDateTime START = LocalDateTime.of(2030, 6, 1, 10, 0);
+    private static final LocalDateTime END = LocalDateTime.of(2030, 6, 1, 12, 0);
+
+    @Autowired
+    ReservationService reservationService;
+
+    @Autowired
+    ThemeRepository themeRepository;
+
+    @Autowired
+    TimeRepository timeRepository;
+
+    @MockitoSpyBean
+    ReservationRepository reservationRepository;
+
+    @DisplayName("예약 취소 시, 대기가 있으면 대기가 RESERVED로 승격되고 예약은 삭제된다.")
+    @Test
+    void cancelForUser_정상_동작() {
+        // given
+        ReservationTime time = timeRepository.save(START, END);
+        Theme theme = themeRepository.save(new Theme("테마", "설명", "https://img.test/a.png"));
+        Reservation reserved = reservationRepository.save(
+                new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()));
+        Reservation waiting = reservationRepository.save(
+                new Reservation("어셔", time, theme, Status.WAITING, LocalDateTime.now()));
+
+        // when
+        reservationService.cancelForUser(reserved.getId(), "라이");
+
+        // then
+        assertThat(reservationRepository.findById(reserved.getId())).isEmpty();
+        Reservation promoted = reservationRepository.findById(waiting.getId()).get();
+        assertThat(promoted.getStatus()).isEqualTo(Status.RESERVED);
+        assertThat(promoted.getId()).isEqualTo(waiting.getId());
+    }
+
+    @DisplayName("deleteById가 실패하는 경우, promoteToReserved가 롤백되어 대기 상태가 유지된다.")
+    @Test
+    void cancelForUser_중간_실패_시_롤백() {
+        // given
+        ReservationTime time = timeRepository.save(START, END);
+        Theme theme = themeRepository.save(new Theme("테마", "설명", "https://img.test/a.png"));
+        Reservation reserved = reservationRepository.save(
+                new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()));
+        Reservation waiting = reservationRepository.save(
+                new Reservation("어셔", time, theme, Status.WAITING, LocalDateTime.now()));
+
+        doThrow(new RuntimeException("강제 실패"))
+                .when(reservationRepository).deleteById(anyLong());
+
+        // when
+        // 예외 강제 발생
+        assertThatThrownBy(() -> reservationService.cancelForUser(reserved.getId(), "라이"))
+                .isInstanceOf(RuntimeException.class);
+
+        // then
+        // promoteToReserved가 롤백되어 대기 상태 그대로
+        Reservation stillWaiting = reservationRepository.findById(waiting.getId()).get();
+        assertThat(stillWaiting.getStatus()).isEqualTo(Status.WAITING);
+        assertThat(stillWaiting.getId()).isEqualTo(waiting.getId());
+    }
+}


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?

초코칩 안녕하세요! 리뷰이 라이입니다.
사이클2에서는 테스트, 그리고 트랜잭션과 데이터 일관성을 깊게 학습해 보려 합니다.
이번 사이클에서도 깊이 고민해 볼 만한 질문과 피드백 부탁드립니다! 🙇

---

### 트랜잭션 테스트 방식

트랜잭션 경계를 묶었을 때, 중간에 실패하면 데이터 일관성이 유지되는지 확인하기 위해, `ReservationTransactionTest`에 `cancelForUser`의 정상 동작과 롤백 테스트를 작성했습니다. 
롤백 테스트는 `@MockitoSpyBean`으로 `deleteById`를 강제로 실패시킨 뒤, 승격 후보인 대기자의 상태가 여전히 `WAITING`인지를 확인하는 방식입니다. 이렇게 중간 단계를 강제로 실패시켜 롤백을 검증하는 방법이 트랜잭션 동작을 확인하는 적절한 방식인지, 혹은 더 나은 방법이 있을지 피드백 받고 싶습니다!

### 비관적 락

현재 `findByIdForUpdate`를 만들어 `create`, `cancel`, `cancelForUser`, `update`에서 비관적 락을 걸고 있습니다. 
충돌 빈도를 고려한다면, 낙관적 락으로도 충분할 수 있다고 생각합니다. 다만, 예약은 충돌이 드물게 일어나더라도 한 번 꼬이면 이중 예약 같은 결과가 그대로 남는 도메인이라, 충돌을 확실히 막는 쪽이 낫다고 판단했습니다. 이러한 기준이 이 도메인에 합리적인지, 아니면 낙관적 락 + 재시도가 더 어울리는 상황인지 초코칩의 의견이 궁금합니다! 또한, 실무에서는 이와 같이 락을 거는 상황이 빈번한 것인지도 여쭤보고 싶습니다.

### 잠그는 행의 범위

현재 취소 로직을 고려했을 때, 다음과 같은 상황이 생길 수 있을 것 같습니다.

한 슬롯에 예약 A와 대기 B가 있고, A 취소와 B 취소가 동시에 일어나는 상황에서,

- A 취소는 A 행만 잠그고, 승격 대상인 B는 잠그지 않은 채 읽어서 B를 승격하려 합니다.
- B는 잠겨있지 않으니, B 취소 트랜잭션이 그대로 접근해 B를 삭제할 수 있습니다.
- 두 트랜잭션의 순서가 보장되지 않아서, A가 B를 승격한 시점엔 B가 이미 삭제된 뒤일 수 있습니다.

이런 경우에도 동시성 제어가 필요한 것인지 궁금합니다!