### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 어셔(박진우) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/global/config/JdbcConfig.java
+++ b/src/main/java/roomescape/global/config/JdbcConfig.java
@@ -1,0 +1,18 @@
+package roomescape.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class JdbcConfig {
+
+    @Bean
+    @Primary
+    public ReadOnlyAwareJdbcTemplate readOnlyAwareJdbcTemplate(DataSource dataSource) {
+        return new ReadOnlyAwareJdbcTemplate(dataSource);
+    }
+}

--- a/src/main/java/roomescape/global/config/ReadOnlyAwareJdbcTemplate.java
+++ b/src/main/java/roomescape/global/config/ReadOnlyAwareJdbcTemplate.java
@@ -1,0 +1,59 @@
+package roomescape.global.config;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.sql.DataSource;
+
+public class ReadOnlyAwareJdbcTemplate extends JdbcTemplate {
+
+    public ReadOnlyAwareJdbcTemplate(DataSource dataSource) {
+        super(dataSource);
+    }
+
+    private void rejectIfReadOnly() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            throw new ReadOnlyViolationException(
+                    "읽기 전용 트랜잭션에서는 쓰기 작업을 수행할 수 없습니다.");
+        }
+    }
+
+    @Override
+    public int update(PreparedStatementCreator psc, KeyHolder generatedKeyHolder) {
+        rejectIfReadOnly();
+        return super.update(psc, generatedKeyHolder);
+    }
+
+    @Override
+    public int update(String sql, Object... args) {
+        rejectIfReadOnly();
+        return super.update(sql, args);
+    }
+
+    @Override
+    public int update(String sql) {
+        rejectIfReadOnly();
+        return super.update(sql);
+    }
+
+    @Override
+    public int update(String sql, PreparedStatementSetter pss) {
+        rejectIfReadOnly();
+        return super.update(sql, pss);
+    }
+
+    @Override
+    public int update(PreparedStatementCreator psc) {
+        rejectIfReadOnly();
+        return super.update(psc);
+    }
+
+    @Override
+    public int update(String sql, Object[] args, int[] argTypes) {
+        rejectIfReadOnly();
+        return super.update(sql, args, argTypes);
+    }
+}

--- a/src/main/java/roomescape/global/config/ReadOnlyViolationException.java
+++ b/src/main/java/roomescape/global/config/ReadOnlyViolationException.java
@@ -1,0 +1,7 @@
+package roomescape.global.config;
+
+public class ReadOnlyViolationException extends UnsupportedOperationException {
+    public ReadOnlyViolationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/global/error/BusinessException.java
+++ b/src/main/java/roomescape/global/error/BusinessException.java
@@ -1,4 +1,4 @@
-package roomescape.error;
+package roomescape.global.error;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/roomescape/global/error/ErrorCode.java
+++ b/src/main/java/roomescape/global/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package roomescape.error;
+package roomescape.global.error;
 
 public enum ErrorCode {
     TIME_NOT_FOUND("예약 시간을 찾을 수 없습니다."),
@@ -13,9 +13,8 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다."),
     RESERVATION_FORBIDDEN_REQUEST("예약에 대한 접근 권한이 없습니다."),
     RESERVATION_EXPIRED("이미 시간이 지난 예약은 수정 및 삭제할 수 없습니다."),
+    CONCURRENT_REQUEST("동시 요청으로 인해 처리하지 못했습니다. 잠시 후 시도해 주세요.")
     ;
-
-
 
     private final String message;
 

--- a/src/main/java/roomescape/global/error/ErrorResponse.java
+++ b/src/main/java/roomescape/global/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package roomescape.error;
+package roomescape.global.error;
 
 public record ErrorResponse(ErrorCode code, String message) {
     public static ErrorResponse of(ErrorCode code) {

--- a/src/main/java/roomescape/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/global/error/GlobalExceptionHandler.java
@@ -1,7 +1,8 @@
-package roomescape.error;
+package roomescape.global.error;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import roomescape.global.config.ReadOnlyViolationException;
 
 @RestControllerAdvice(annotations = RestController.class)
 public class GlobalExceptionHandler {
@@ -42,6 +44,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid() {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+    }
+
+    @ExceptionHandler(ConcurrencyFailureException.class)
+    public ResponseEntity<ErrorResponse> handleConcurrencyFailure(ConcurrencyFailureException e) {
+        log.warn("동시 요청으로 인한 실패: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.of(ErrorCode.CONCURRENT_REQUEST));
+    }
+
+    @ExceptionHandler(ReadOnlyViolationException.class)
+    public ResponseEntity<ErrorResponse> handleReadOnlyViolation(ReadOnlyViolationException e) {
+        log.error("읽기 전용 트랜잭션에서 쓰기 시도: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/roomescape/holiday/exception/HolidayNotFoundException.java
+++ b/src/main/java/roomescape/holiday/exception/HolidayNotFoundException.java
@@ -2,8 +2,8 @@ package roomescape.holiday.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class HolidayNotFoundException extends BusinessException {
     public HolidayNotFoundException(Long id) {

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -36,6 +36,10 @@ public class Reservation {
         return new Reservation(this.id, this.name, time, this.theme, this.status, this.createdAt);
     }
 
+    public Reservation withStatus(Status status) {
+        return new Reservation(this.id, this.name, this.time, this.theme, status, this.createdAt);
+    }
+
     public Reservation promote() {
         if (this.status != Status.WAITING) {
             throw new IllegalStateException("WAITING 상태만 예약으로 가능합니다.");
@@ -75,12 +79,7 @@ public class Reservation {
         return this.status.equals(Status.RESERVED);
     }
 
-    public void validateCancelBy(String name, LocalDateTime dateTime) {
-        validateOwnedBy(name);
-        time.validateExpired(dateTime);
-    }
-
-    public void validateUpdateBy(String name, LocalDateTime dateTime) {
+    public void validateChangeableBy(String name, LocalDateTime dateTime) {
         validateOwnedBy(name);
         time.validateExpired(dateTime);
     }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -89,4 +89,16 @@ public class Reservation {
             throw new ForbiddenRequestException();
         }
     }
+
+    public void validateExpired(LocalDateTime dateTime) {
+        time.validateExpired(dateTime);
+    }
+
+    public Long getThemeId() {
+        return theme.getId();
+    }
+
+    public Long getTimeId() {
+        return time.getId();
+    }
 }

--- a/src/main/java/roomescape/reservation/exception/DuplicateReservationException.java
+++ b/src/main/java/roomescape/reservation/exception/DuplicateReservationException.java
@@ -2,8 +2,8 @@ package roomescape.reservation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class DuplicateReservationException extends BusinessException {
     public DuplicateReservationException() {

--- a/src/main/java/roomescape/reservation/exception/ForbiddenRequestException.java
+++ b/src/main/java/roomescape/reservation/exception/ForbiddenRequestException.java
@@ -1,8 +1,8 @@
 package roomescape.reservation.exception;
 
 import org.springframework.http.HttpStatus;
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class ForbiddenRequestException extends BusinessException {
     public ForbiddenRequestException() {

--- a/src/main/java/roomescape/reservation/exception/PastReservationException.java
+++ b/src/main/java/roomescape/reservation/exception/PastReservationException.java
@@ -2,8 +2,8 @@ package roomescape.reservation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class PastReservationException extends BusinessException {
     public PastReservationException(ErrorCode errorCode) {

--- a/src/main/java/roomescape/reservation/exception/ReservationNotFoundException.java
+++ b/src/main/java/roomescape/reservation/exception/ReservationNotFoundException.java
@@ -2,8 +2,8 @@ package roomescape.reservation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class ReservationNotFoundException extends BusinessException {
     public ReservationNotFoundException(Long id) {

--- a/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
@@ -5,11 +5,8 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
-import roomescape.reservation.controller.dto.ReservationTimeResponse;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Status;
-import roomescape.reservation.repository.dto.ReservationWithWaitingOrder;
-import roomescape.theme.controller.dto.ThemeResponse;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.ReservationTime;
 
@@ -62,15 +59,6 @@ public class JdbcReservationRepository implements ReservationRepository {
                 id
         );
         return results.stream().findFirst();
-    }
-
-    @Override
-    public boolean update(Long id, Long timeId, LocalDateTime now) {
-        int affected = jdbcTemplate.update(
-                "UPDATE reservation SET time_id = ?, created_at = ? WHERE id = ?",
-                timeId, now, id
-        );
-        return affected > 0;
     }
 
     @Override
@@ -142,27 +130,6 @@ public class JdbcReservationRepository implements ReservationRepository {
         return exists != null && exists == 1;
     }
 
-    @Override
-    public Optional<Long> findEarliestWaiting(Long timeId, Long themeId) {
-        return jdbcTemplate.query(
-                "SELECT id FROM reservation "
-                        + "WHERE time_id = ? "
-                        + "AND theme_id = ? "
-                        + "AND status = 'WAITING' "
-                        + "ORDER BY created_at ASC "
-                        + "LIMIT 1",
-                (rs, rowNum) -> rs.getLong("id"),
-                timeId, themeId
-        ).stream().findFirst();
-    }
-
-    @Override
-    public void promoteToReserved(Long waitingId) {
-        jdbcTemplate.update(
-                "UPDATE reservation SET status = 'RESERVED' where id = ?",
-                waitingId);
-    }
-
     private static class ReservationRowMapper implements RowMapper<Reservation> {
         @Override
         public Reservation mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -197,56 +164,6 @@ public class JdbcReservationRepository implements ReservationRepository {
                     createdAt
             ).withId(rs.getLong("id"));
         }
-    }
-
-    @Override
-    public List<ReservationWithWaitingOrder> findAllByName(String name) {
-        String sql = """
-                SELECT r.id,
-                       r.name,
-                       r.status,
-                       t.id AS theme_id,
-                       t.name AS theme_name,
-                       t.description AS theme_description,
-                       t.image_url AS theme_image_url,
-                       rt.id AS time_id,
-                       rt.start_time,
-                       rt.end_time,
-                       COALESCE(ranked.rank, 0) AS orderWaiting
-                  FROM reservation r
-                  JOIN theme t ON r.theme_id = t.id
-                  JOIN reservation_time rt ON r.time_id = rt.id
-                  LEFT JOIN (
-                      SELECT id,
-                             ROW_NUMBER() OVER (
-                                 PARTITION BY theme_id, time_id
-                                 ORDER BY created_at ASC
-                             ) AS rank
-                      FROM reservation
-                      WHERE status = 'WAITING'
-                  ) ranked ON r.id = ranked.id
-                  WHERE r.name = ?;
-                """;
-        return jdbcTemplate.query(sql, (rs, rowNum) -> {
-            ReservationTime time = new ReservationTime(
-                    rs.getLong("time_id"),
-                    rs.getObject("start_time", LocalDateTime.class),
-                    rs.getObject("end_time", LocalDateTime.class)
-            );
-            Theme theme = new Theme(
-                    rs.getString("theme_name"),
-                    rs.getString("theme_description"),
-                    rs.getString("theme_image_url")
-            ).withId(rs.getLong("theme_id"));
-            return new ReservationWithWaitingOrder(
-                    rs.getLong("id"),
-                    rs.getString("name"),
-                    ReservationTimeResponse.from(time),
-                    ThemeResponse.from(theme),
-                    Status.valueOf(rs.getString("status")),
-                    rs.getInt("orderWaiting")
-            );
-        }, name);
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/repository/JdbcSlotRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcSlotRepository.java
@@ -1,0 +1,35 @@
+package roomescape.reservation.repository;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcSlotRepository implements SlotRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcSlotRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void ensure(Long themeId, Long timeId) {
+        try {
+            jdbcTemplate.update(
+                    "INSERT INTO reservation_slot (theme_id, time_id) " +
+                            "VALUES (?, ?)",
+                    themeId, timeId);
+        } catch (DuplicateKeyException ignored) {
+        }
+    }
+
+    @Override
+    public void lock(Long themeId, Long timeId) {
+        jdbcTemplate.queryForObject(
+                "SELECT id FROM reservation_slot " +
+                        "WHERE theme_id = ? AND time_id = ? " +
+                        "FOR UPDATE",
+                Long.class, themeId, timeId);
+    }
+}

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -1,11 +1,9 @@
 package roomescape.reservation.repository;
 
 import roomescape.reservation.domain.Reservation;
-import roomescape.reservation.repository.dto.ReservationWithWaitingOrder;
 import roomescape.time.domain.ReservationTime;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,29 +12,22 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long id);
 
-    Reservation save(Reservation reservation);
+    List<Reservation> findByName(String name);
 
-    boolean update(Long id, Long timeId, LocalDateTime now);
-
-    Reservation update(Reservation reservation);
+    List<Reservation> findAllWaitingBy(Long timeId, Long themeId);
 
     List<Long> findTimeIdsByThemeIdAndDate(Long themeId, LocalDate date);
 
-    boolean deleteById(Long id);
+    Reservation save(Reservation reservation);
 
-    boolean isDuplicated(Long themeId, ReservationTime time);
+    Reservation update(Reservation reservation);
+
+    boolean deleteById(Long id);
 
     boolean existsByTimeId(Long timeId);
 
-    Optional<Long> findEarliestWaiting(Long timeId, Long themeId);
-
-    void promoteToReserved(Long waitingId);
-
-    List<ReservationWithWaitingOrder> findAllByName(String name);
-
-    List<Reservation> findByName(String name);
+    boolean isDuplicated(Long themeId, ReservationTime time);
 
     boolean isDuplicatedWithName(String name, Long themeId, ReservationTime time);
 
-    List<Reservation> findAllWaitingBy(Long timeId, Long themeId);
 }

--- a/src/main/java/roomescape/reservation/repository/SlotRepository.java
+++ b/src/main/java/roomescape/reservation/repository/SlotRepository.java
@@ -1,0 +1,8 @@
+package roomescape.reservation.repository;
+
+public interface SlotRepository {
+
+    void ensure(Long themeId, Long timeId);
+
+    void lock(Long themeId, Long timeId);
+}

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -28,17 +28,19 @@ public class ReservationServiceImpl implements ReservationService {
     private final TimeService timeService;
     private final ThemeRepository themeRepository;
     private final HolidayService holidayService;
+    private final SlotService slotService;
 
     public ReservationServiceImpl(
             ReservationRepository reservationRepository,
             TimeService timeService,
             ThemeRepository themeRepository,
-            HolidayService holidayService
+            HolidayService holidayService, SlotService slotService
     ) {
         this.reservationRepository = reservationRepository;
         this.timeService = timeService;
         this.themeRepository = themeRepository;
         this.holidayService = holidayService;
+        this.slotService = slotService;
     }
 
     @Override
@@ -60,6 +62,9 @@ public class ReservationServiceImpl implements ReservationService {
             throw new IllegalArgumentException("휴일은 예약이 불가합니다.");
         }
 
+        slotService.ensure(request.themeId(), request.timeId());
+        slotService.lock(request.themeId(), request.timeId());
+
         if (reservationRepository.isDuplicatedWithName(request.name(), request.themeId(), time)) {
             throw new DuplicateReservationException();
         }
@@ -72,10 +77,24 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancel(Long id) {
-        boolean deleted = reservationRepository.deleteById(id);
-        if (!deleted) {
-            throw new ReservationNotFoundException(id);
+        Reservation reservationForSlotKey = reservationRepository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id));
+
+        slotService.ensure(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+        slotService.lock(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id));
+        reservation.getTime().validateExpired(LocalDateTime.now());
+        if (reservation.isReserved()) {
+            ReservationWaitings waitings = new ReservationWaitings(
+                    reservationRepository.findAllWaitingBy(
+                            reservation.getTime().getId(),
+                            reservation.getTheme().getId()));
+            waitings.earliest()
+                    .map(Reservation::promote)
+                    .ifPresent(reservationRepository::update);
         }
+        reservationRepository.deleteById(id);
     }
 
     @Override
@@ -96,10 +115,14 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancelForUser(Long id, String name) {
+        Reservation reservationForSlotKey = reservationRepository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id));
+        slotService.ensure(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+        slotService.lock(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
-        reservation.validateCancelBy(name, LocalDateTime.now());
-
+        reservation.validateChangeableBy(name, LocalDateTime.now());
         if (reservation.isReserved()) {
             ReservationWaitings waitings = new ReservationWaitings(
                     reservationRepository.findAllWaitingBy(
@@ -118,20 +141,38 @@ public class ReservationServiceImpl implements ReservationService {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
         LocalDateTime now = LocalDateTime.now();
-        reservation.validateUpdateBy(name, now);
+        reservation.validateChangeableBy(name, now);
 
         ReservationTime newTime = timeService.findById(timeId);
         newTime.validateExpired(now);
-
         if (holidayService.isHoliday(newTime.getDate())) {
             throw new IllegalArgumentException("휴일은 예약이 불가합니다.");
         }
 
-        if (reservationRepository.isDuplicated(reservation.getTheme().getId(), newTime)) {
+        if (reservationRepository.isDuplicatedWithName(name, reservation.getTheme().getId(), newTime)) {
             throw new DuplicateReservationException();
         }
 
-        Reservation updatedReservation = reservation.withTime(newTime).withCreatedAt(now);
-        return reservationRepository.update(updatedReservation);
+        if (reservation.isReserved()) {
+            ReservationWaitings waitings = new ReservationWaitings(
+                    reservationRepository.findAllWaitingBy(
+                            reservation.getTime().getId(),
+                            reservation.getTheme().getId()));
+            waitings.earliest()
+                    .map(Reservation::promote)
+                    .ifPresent(reservationRepository::update);
+        }
+
+        if (reservationRepository.isDuplicated(reservation.getTheme().getId(), newTime)) {
+            return reservationRepository.update(reservation
+                    .withTime(newTime)
+                    .withStatus(Status.WAITING)
+                    .withCreatedAt(now));
+        }
+
+        return reservationRepository.update(reservation
+                .withTime(newTime)
+                .withStatus(Status.RESERVED)
+                .withCreatedAt(now));
     }
 }

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -51,6 +51,9 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public Reservation create(ReservationSaveServiceRequest request) {
+        slotService.ensure(request.themeId(), request.timeId());
+        slotService.lock(request.themeId(), request.timeId());
+
         LocalDateTime now = LocalDateTime.now();
         ReservationTime time = timeService.findById(request.timeId());
         time.validateExpired(now);
@@ -61,9 +64,6 @@ public class ReservationServiceImpl implements ReservationService {
         if (holidayService.isHoliday(time.getDate())) {
             throw new IllegalArgumentException("휴일은 예약이 불가합니다.");
         }
-
-        slotService.ensure(request.themeId(), request.timeId());
-        slotService.lock(request.themeId(), request.timeId());
 
         if (reservationRepository.isDuplicatedWithName(request.name(), request.themeId(), time)) {
             throw new DuplicateReservationException();

--- a/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/reservation/service/ReservationServiceImpl.java
@@ -80,16 +80,16 @@ public class ReservationServiceImpl implements ReservationService {
         Reservation reservationForSlotKey = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
 
-        slotService.ensure(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
-        slotService.lock(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+        slotService.ensure(reservationForSlotKey.getThemeId(), reservationForSlotKey.getTimeId());
+        slotService.lock(reservationForSlotKey.getThemeId(), reservationForSlotKey.getTimeId());
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
-        reservation.getTime().validateExpired(LocalDateTime.now());
+        reservation.validateExpired(LocalDateTime.now());
         if (reservation.isReserved()) {
             ReservationWaitings waitings = new ReservationWaitings(
                     reservationRepository.findAllWaitingBy(
-                            reservation.getTime().getId(),
-                            reservation.getTheme().getId()));
+                            reservation.getTimeId(),
+                            reservation.getThemeId()));
             waitings.earliest()
                     .map(Reservation::promote)
                     .ifPresent(reservationRepository::update);
@@ -106,8 +106,8 @@ public class ReservationServiceImpl implements ReservationService {
                         reservation,
                         new ReservationWaitings(
                                 reservationRepository.findAllWaitingBy(
-                                        reservation.getTime().getId(),
-                                        reservation.getTheme().getId()))))
+                                        reservation.getTimeId(),
+                                        reservation.getThemeId()))))
                 .map(ReservationWithWaitingOrderResponse::from)
                 .toList();
     }
@@ -117,8 +117,8 @@ public class ReservationServiceImpl implements ReservationService {
     public void cancelForUser(Long id, String name) {
         Reservation reservationForSlotKey = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
-        slotService.ensure(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
-        slotService.lock(reservationForSlotKey.getTheme().getId(), reservationForSlotKey.getTime().getId());
+        slotService.ensure(reservationForSlotKey.getThemeId(), reservationForSlotKey.getTimeId());
+        slotService.lock(reservationForSlotKey.getThemeId(), reservationForSlotKey.getTimeId());
 
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(id));
@@ -126,8 +126,8 @@ public class ReservationServiceImpl implements ReservationService {
         if (reservation.isReserved()) {
             ReservationWaitings waitings = new ReservationWaitings(
                     reservationRepository.findAllWaitingBy(
-                            reservation.getTime().getId(),
-                            reservation.getTheme().getId()));
+                            reservation.getTimeId(),
+                            reservation.getThemeId()));
             waitings.earliest()
                     .map(Reservation::promote)
                     .ifPresent(reservationRepository::update);
@@ -149,21 +149,21 @@ public class ReservationServiceImpl implements ReservationService {
             throw new IllegalArgumentException("휴일은 예약이 불가합니다.");
         }
 
-        if (reservationRepository.isDuplicatedWithName(name, reservation.getTheme().getId(), newTime)) {
+        if (reservationRepository.isDuplicatedWithName(name, reservation.getThemeId(), newTime)) {
             throw new DuplicateReservationException();
         }
 
         if (reservation.isReserved()) {
             ReservationWaitings waitings = new ReservationWaitings(
                     reservationRepository.findAllWaitingBy(
-                            reservation.getTime().getId(),
-                            reservation.getTheme().getId()));
+                            reservation.getTimeId(),
+                            reservation.getThemeId()));
             waitings.earliest()
                     .map(Reservation::promote)
                     .ifPresent(reservationRepository::update);
         }
 
-        if (reservationRepository.isDuplicated(reservation.getTheme().getId(), newTime)) {
+        if (reservationRepository.isDuplicated(reservation.getThemeId(), newTime)) {
             return reservationRepository.update(reservation
                     .withTime(newTime)
                     .withStatus(Status.WAITING)

--- a/src/main/java/roomescape/reservation/service/SlotService.java
+++ b/src/main/java/roomescape/reservation/service/SlotService.java
@@ -1,0 +1,26 @@
+package roomescape.reservation.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.reservation.repository.SlotRepository;
+
+@Service
+public class SlotService {
+
+    private final SlotRepository slotRepository;
+
+    public SlotService(SlotRepository slotRepository) {
+        this.slotRepository = slotRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void ensure(Long themeId, Long timeId) {
+        slotRepository.ensure(themeId, timeId);
+    }
+
+    @Transactional
+    public void lock(Long themeId, Long timeId) {
+        slotRepository.lock(themeId, timeId);
+    }
+}

--- a/src/main/java/roomescape/theme/exception/ThemeNotFoundException.java
+++ b/src/main/java/roomescape/theme/exception/ThemeNotFoundException.java
@@ -2,8 +2,8 @@ package roomescape.theme.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class ThemeNotFoundException extends BusinessException {
     public ThemeNotFoundException(Long id) {

--- a/src/main/java/roomescape/time/domain/ReservationTime.java
+++ b/src/main/java/roomescape/time/domain/ReservationTime.java
@@ -1,6 +1,6 @@
 package roomescape.time.domain;
 
-import roomescape.error.ErrorCode;
+import roomescape.global.error.ErrorCode;
 import roomescape.reservation.exception.PastReservationException;
 
 import java.time.LocalDate;

--- a/src/main/java/roomescape/time/exception/ReservationTimeConflictException.java
+++ b/src/main/java/roomescape/time/exception/ReservationTimeConflictException.java
@@ -2,8 +2,8 @@ package roomescape.time.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class ReservationTimeConflictException extends BusinessException {
     public ReservationTimeConflictException(Long id) {

--- a/src/main/java/roomescape/time/exception/TimeNotFoundException.java
+++ b/src/main/java/roomescape/time/exception/TimeNotFoundException.java
@@ -2,8 +2,8 @@ package roomescape.time.exception;
 
 import org.springframework.http.HttpStatus;
 
-import roomescape.error.BusinessException;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.BusinessException;
+import roomescape.global.error.ErrorCode;
 
 public class TimeNotFoundException extends BusinessException {
     public TimeNotFoundException(Long id) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS reservation;
+DROP TABLE IF EXISTS reservation_slot;
 DROP TABLE IF EXISTS reservation_time;
 DROP TABLE IF EXISTS theme;
 DROP TABLE IF EXISTS holiday;
@@ -18,6 +19,17 @@ CREATE TABLE theme
     description VARCHAR(255) NOT NULL,
     image_url   VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
+);
+
+CREATE TABLE reservation_slot
+(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    theme_id BIGINT NOT NULL,
+    time_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (theme_id) REFERENCES theme (id),
+    FOREIGN KEY (time_id) REFERENCES reservation_time (id),
+    CONSTRAINT uk_reservationslot_theme_time UNIQUE (theme_id, time_id)
 );
 
 CREATE TABLE reservation

--- a/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import roomescape.error.ErrorCode;
+import roomescape.global.error.ErrorCode;
 import roomescape.reservation.controller.dto.ReservationTimeResponse;
 import roomescape.reservation.controller.dto.ReservationWithWaitingOrderResponse;
 import roomescape.reservation.domain.Reservation;

--- a/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Status;
-import roomescape.reservation.repository.dto.ReservationWithWaitingOrder;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.JdbcThemeRepository;
 import roomescape.time.domain.ReservationTime;
@@ -16,8 +14,6 @@ import roomescape.time.repository.JdbcTimeRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,8 +23,6 @@ class JdbcReservationRepositoryTest {
 
     @Autowired
     private JdbcReservationRepository reservationRepository;
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
     @Autowired
     private JdbcThemeRepository themeRepository;
     @Autowired
@@ -76,45 +70,6 @@ class JdbcReservationRepositoryTest {
         assertThat(saved.getTime().getStartAt()).isEqualTo(time.getStartAt());
         assertThat(saved.getTime().getEndAt()).isEqualTo(time.getEndAt());
         assertThat(saved.getStatus()).isEqualTo(Status.RESERVED);
-    }
-
-    @DisplayName("가장 오래된 WAITING 대기의 id 값을 가져온다.")
-    @Test
-    void findEarliestWaiting_예약_대기_id_반환_테스트() {
-        // given
-        Theme theme = insertTheme("테마");
-        ReservationTime time = insertTime(
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(3));
-        Reservation existing = insertReservation("어셔1", time, theme, Status.WAITING, LocalDateTime.now().plusHours(1));
-        insertReservation("어셔2", time, theme, Status.WAITING, LocalDateTime.now().plusHours(2));
-        insertReservation("어셔3", time, theme, Status.WAITING, LocalDateTime.now().plusHours(3));
-
-        // when
-        Optional<Long> id = reservationRepository.findEarliestWaiting(time.getId(), theme.getId());
-
-        // then
-        assertThat(id).isPresent();
-        assertThat(id.get()).isEqualTo(existing.getId());
-    }
-
-    @DisplayName("예약 대기 상태를 RESERVED로 승격한다.")
-    @Test
-    void promoteToReserved_예약_대기_승격_테스트() {
-        // given
-        Theme theme = insertTheme("테마");
-        ReservationTime time = insertTime(
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(3));
-        Reservation waiting = insertReservation("어셔1", time, theme, Status.WAITING, LocalDateTime.now().plusHours(1));
-
-        // when
-        reservationRepository.promoteToReserved(waiting.getId());
-        Optional<Reservation> reservation = reservationRepository.findById(waiting.getId());
-
-        // then
-        assertThat(reservation).isPresent();
-        assertThat(reservation.get().getStatus()).isEqualTo(Status.RESERVED);
     }
 
     @DisplayName("특정 날짜와 테마의 예약이 존재한다면 true를 반환한다")
@@ -181,31 +136,6 @@ class JdbcReservationRepositoryTest {
 
         // then
         assertThat(result).isFalse();
-    }
-
-    @DisplayName("대기 순번을 포함한 예약 전체 정보를 조회한다.")
-    @Test
-    void findAllByName_대기_순번_포함_예약_대기_정보_조회() {
-        // given
-        Theme theme = insertTheme("테마");
-        ReservationTime time1 = insertTime(
-                LocalDateTime.now().plusHours(1),
-                LocalDateTime.now().plusHours(3));
-        ReservationTime time2 = insertTime(
-                LocalDateTime.now().plusHours(3),
-                LocalDateTime.now().plusHours(5));
-        insertReservation("어셔1", time1, theme, Status.RESERVED, LocalDateTime.now().plusHours(1));
-        insertReservation("어셔2", time1, theme, Status.WAITING, LocalDateTime.now().plusHours(2));
-        insertReservation("어셔3", time1, theme, Status.WAITING, LocalDateTime.now().plusHours(3));
-        insertReservation("어셔3", time2, theme, Status.RESERVED, LocalDateTime.now().plusHours(3));
-
-        // when
-        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAllByName("어셔3");
-
-        // then
-        assertThat(reservations).hasSize(2);
-        assertThat(reservations.get(0).waitingOrder()).isEqualTo(2);
-        assertThat(reservations.get(1).waitingOrder()).isEqualTo(0);
     }
 
     private Reservation insertReservation(String name, ReservationTime time, Theme theme, Status status, LocalDateTime createdAt) {

--- a/src/test/java/roomescape/reservation/service/ReservationAtomicityTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationAtomicityTest.java
@@ -1,0 +1,119 @@
+package roomescape.reservation.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.Status;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.ReservationTime;
+import roomescape.time.repository.TimeRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ReservationAtomicityTest {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private ThemeRepository themeRepository;
+    @Autowired
+    private TimeRepository timeRepository;
+
+    @MockitoSpyBean
+    private ReservationRepository reservationRepository;
+
+    private long reservedId;
+    private long waitingId;
+    private long newTimeId;
+    private long oldTimeId;
+
+    @BeforeEach
+    void setUp() {
+        Theme theme = themeRepository.save(
+                new Theme("원자성테마", "테스트", "https://test.test/x.png"));
+
+        LocalDateTime oldStart = LocalDateTime.now().plusDays(7);
+        ReservationTime oldTime = timeRepository.save(oldStart, oldStart.plusHours(2));
+        oldTimeId = oldTime.getId();
+
+        LocalDateTime newStart = LocalDateTime.now().plusDays(8);
+        ReservationTime newTime = timeRepository.save(
+                newStart, newStart.plusHours(2));
+        newTimeId = newTime.getId();
+        Reservation reserved = reservationRepository.save(
+                new Reservation("예약중임", oldTime, theme, Status.RESERVED,
+                        LocalDateTime.now().minusHours(2)));
+        reservedId = reserved.getId();
+
+        Reservation waiting = reservationRepository.save(
+                new Reservation("예약대기중임", oldTime, theme, Status.WAITING,
+                        LocalDateTime.now().minusHours(1)));
+        waitingId = waiting.getId();
+
+        clearInvocations(reservationRepository);
+    }
+
+    @DisplayName("cancelForUser 중 deleteById가 실패하면 예약 승격도 함께 롤백 됨")
+    @Test
+    void cancelForUser_원자성_롤백_테스트() {
+        // given
+        doThrow(new RuntimeException("db 에러 발생"))
+                .when(reservationRepository).deleteById(reservedId);
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.cancelForUser(reservedId, "예약중임"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(reservationRepository).update(any());
+        String waitingStatus = jdbcTemplate.queryForObject(
+                "SELECT status FROM reservation WHERE id = ?",
+                String.class, waitingId);
+        assertThat(Status.valueOf(waitingStatus)).isEqualTo(Status.WAITING);
+
+        Integer reservedExists = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation WHERE id = ?",
+                Integer.class, reservedId);
+        assertThat(reservedExists).isEqualTo(1);
+    }
+
+    @DisplayName("사용자 예약 update를 실패하면 자동 승격도 함께 롤백된다.")
+    @Test
+    void update_원자성_롤백_테스트() {
+        // given
+        doThrow(new RuntimeException("DB 장애"))
+                .when(reservationRepository).update(argThat(r ->
+                        r != null && r.getId() != null && r.getId() == reservedId));
+
+        // when
+        assertThatThrownBy(() -> reservationService.update(reservedId, newTimeId, "예약중임"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(reservationRepository).update(argThat(r ->
+                r != null && r.getId() != null && r.getId() == waitingId
+                        && r.getStatus() == Status.RESERVED));
+
+        String status = jdbcTemplate.queryForObject(
+                "SELECT status FROM reservation WHERE id = ?", String.class, waitingId);
+        assertThat(Status.valueOf(status)).isEqualTo(Status.WAITING);
+
+        Long timeId = jdbcTemplate.queryForObject(
+                "SELECT time_id FROM reservation WHERE id = ?", Long.class, reservedId);
+        assertThat(timeId).isEqualTo(oldTimeId);
+    }
+}

--- a/src/test/java/roomescape/reservation/service/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationConcurrencyTest.java
@@ -1,0 +1,80 @@
+package roomescape.reservation.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.exception.DuplicateReservationException;
+import roomescape.reservation.service.dto.ReservationSaveServiceRequest;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.JdbcThemeRepository;
+import roomescape.time.domain.ReservationTime;
+import roomescape.time.repository.JdbcTimeRepository;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ReservationConcurrencyTest {
+
+    @Autowired private ReservationService reservationService;
+    @Autowired private JdbcTimeRepository timeRepository;
+    @Autowired private JdbcThemeRepository themeRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @DisplayName("같은 슬롯에 N명이 동시에 예약하면, RESERVED는 정확히 1개 저장되고 나머지는 WAITING 예약으로 저장된다.")
+    @Test
+    void 동시_생성_요청_시_RESERVED예약은_1개_생성() throws InterruptedException {
+        // given
+        Theme theme = insertTheme("테마");
+        ReservationTime time = insertTime(
+                LocalDateTime.of(2030, 6, 5, 10, 0),
+                LocalDateTime.of(2030, 6, 5, 12, 0));
+
+        int numThreads = 8;
+        CountDownLatch doneSignal = new CountDownLatch(numThreads);
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger duplicateCount = new AtomicInteger();
+
+        for (int i = 0; i < numThreads; i++) {
+            executorService.execute(() -> {
+                try {
+                    reservationService.create(
+                            new ReservationSaveServiceRequest("same_user", theme.getId(), time.getId()));
+                    successCount.getAndIncrement();
+                } catch (DuplicateReservationException e) {
+                    duplicateCount.getAndIncrement();
+                } finally {
+                    doneSignal.countDown();
+                }
+            });
+        }
+        doneSignal.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertAll(
+                () -> assertThat(successCount.get()).isEqualTo(1),
+                () -> assertThat(duplicateCount.get()).isEqualTo(numThreads - 1));
+    }
+
+    private Theme insertTheme(String name) {
+        return themeRepository.save(
+                new Theme(name, "설명", "imageUrl")
+        );
+    }
+
+    private ReservationTime insertTime(LocalDateTime start, LocalDateTime end) {
+        return timeRepository.save(start, end);
+    }
+}

--- a/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceImplTest.java
@@ -1,9 +1,9 @@
 package roomescape.reservation.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.holiday.service.HolidayService;
@@ -41,23 +41,17 @@ class ReservationServiceImplTest {
 
     @Mock
     private ReservationRepository reservationRepository;
-
     @Mock
     private TimeService timeService;
-
     @Mock
     private ThemeRepository themeRepository;
-
     @Mock
     private HolidayService holidayService;
+    @Mock
+    private SlotService slotService;
 
+    @InjectMocks
     private ReservationServiceImpl reservationService;
-
-    @BeforeEach
-    void setUp() {
-        reservationService = new ReservationServiceImpl(
-                reservationRepository, timeService, themeRepository, holidayService);
-    }
 
     @DisplayName("정상 입력이고 대기가 없는 경우, 저장된 예약을 반환한다.")
     @Test
@@ -225,6 +219,10 @@ class ReservationServiceImplTest {
     @Test
     void cancel_정상_취소() {
         // given
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        ReservationTime time = new ReservationTime(1L, FUTURE_START, FUTURE_END);
+        Reservation reservation = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository.deleteById(1L)).thenReturn(true);
 
         // when
@@ -333,7 +331,8 @@ class ReservationServiceImplTest {
     void cancelForUser_지난_슬롯_예약이면_예외() {
         // given
         ReservationTime time = new ReservationTime(1L, PAST_START, PAST_END);
-        Reservation past = new Reservation("라이", time, null, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        Reservation past = new Reservation("라이", time, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(past));
 
         // when & then
@@ -430,7 +429,7 @@ class ReservationServiceImplTest {
                 .isInstanceOf(PastReservationException.class);
     }
 
-    @DisplayName("변경하려는 슬롯이 이미 차 있는 경우, DuplicateReservationException이 발생한다.")
+    @DisplayName("변경하려는 슬롯이 이미 차 있는 경우, Waiting 상태로 변경한다.")
     @Test
     void update_중복_슬롯으로_변경하면_예외() {
         // given
@@ -438,13 +437,79 @@ class ReservationServiceImplTest {
         ReservationTime newTime = new ReservationTime(2L,
                 LocalDateTime.of(2030, 6, 1, 14, 0),
                 LocalDateTime.of(2030, 6, 1, 16, 0));
-        Reservation existing = new Reservation("라이", oldTime, new Theme("name", "description", "https://img.test/a.png").withId(1L), Status.RESERVED, LocalDateTime.now()).withId(1L);
+        Theme theme = new Theme("name", "description", "https://img.test/a.png").withId(1L);
+        Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        Reservation updated = existing.withTime(newTime).withStatus(Status.WAITING);
+
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(timeService.findById(2L)).thenReturn(newTime);
+        when(reservationRepository.isDuplicatedWithName("라이", 1L, newTime)).thenReturn(false);
+        when(reservationRepository.findAllWaitingBy(1L, 1L)).thenReturn(List.of());
         when(reservationRepository.isDuplicated(1L, newTime)).thenReturn(true);
+        when(reservationRepository.update(any(Reservation.class))).thenReturn(updated);
 
-        // when & then
-        assertThatThrownBy(() -> reservationService.update(1L, 2L, "라이"))
-                .isInstanceOf(DuplicateReservationException.class);
+        // when
+        Reservation result = reservationService.update(1L, 2L, "라이");
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(Status.WAITING);
+        assertThat(result.getTime()).isEqualTo(newTime);
+    }
+
+    @DisplayName("자기가 RESERVED이고, 같은 슬롯에 대기가 있으면, 변경 시 대기가 자동으로 승격된다.")
+    @Test
+    void update_예약대기_자동_승격() {
+        // given
+        ReservationTime oldTime = new ReservationTime(1L, FUTURE_START, FUTURE_END);
+        ReservationTime newTime = new ReservationTime(2L,
+                LocalDateTime.of(2030, 6, 1, 14, 0),
+                LocalDateTime.of(2030, 6, 1, 16, 0));
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        Reservation existing = new Reservation("라이", oldTime, theme, Status.RESERVED, LocalDateTime.now()).withId(1L);
+        Reservation oldestWaiting = new Reservation("어셔", oldTime, theme, Status.WAITING,
+                LocalDateTime.of(2030, 5, 1, 10, 0)).withId(2L);
+        Reservation updated = existing.withTime(newTime);
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(timeService.findById(2L)).thenReturn(newTime);
+        when(reservationRepository.isDuplicatedWithName("라이", 1L, newTime)).thenReturn(false);
+        when(reservationRepository.findAllWaitingBy(1L, 1L)).thenReturn(List.of(oldestWaiting));
+        when(reservationRepository.isDuplicated(1L, newTime)).thenReturn(false);
+        when(reservationRepository.update(any(Reservation.class))).thenReturn(updated);
+
+        // when
+        reservationService.update(1L, 2L, "라이");
+
+        // then
+        verify(reservationRepository).update(argThat(r ->
+                r.getId().equals(oldestWaiting.getId()) && r.getStatus() == Status.RESERVED));
+        verify(reservationRepository).update(argThat(r ->
+                r.getId().equals(existing.getId()) && r.getTime().equals(newTime)));
+    }
+
+    @DisplayName("자기가 WAITING 이면 원 슬롯 자동 승격은 일어나지 않는다.")
+    @Test
+    void update_자기_WAITING이면_자동_대기_승격_패스() {
+        // given
+        ReservationTime oldTime = new ReservationTime(1L, FUTURE_START, FUTURE_END);
+        ReservationTime newTime = new ReservationTime(2L,
+                LocalDateTime.of(2030, 6, 1, 14, 0),
+                LocalDateTime.of(2030, 6, 1, 16, 0));
+        Theme theme = new Theme("테마", "설명", "https://img.test/a.png").withId(1L);
+        Reservation existing = new Reservation("라이", oldTime, theme, Status.WAITING, LocalDateTime.now()).withId(1L);
+        Reservation updated = existing.withStatus(Status.RESERVED);
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(timeService.findById(2L)).thenReturn(newTime);
+        when(reservationRepository.isDuplicatedWithName("라이", 1L, newTime)).thenReturn(false);
+        when(reservationRepository.isDuplicated(1L, newTime)).thenReturn(false);
+        when(reservationRepository.update(any(Reservation.class))).thenReturn(updated);
+
+        // when
+        reservationService.update(1L, 2L, "라이");
+
+        // then
+        verify(reservationRepository, times(1)).update(any(Reservation.class));
+        verify(reservationRepository, never()).findAllWaitingBy(any(), any());
     }
 }

--- a/src/test/java/roomescape/theme/service/ThemeServiceImplTest.java
+++ b/src/test/java/roomescape/theme/service/ThemeServiceImplTest.java
@@ -28,17 +28,10 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ThemeServiceImplTest {
 
-    @Mock
-    private ThemeRepository themeRepository;
-
-    @Mock
-    private TimeService timeService;
-
-    @Mock
-    private HolidayRepository holidayRepository;
-
-    @Mock
-    private ReservationRepository reservationRepository;
+    @Mock private ThemeRepository themeRepository;
+    @Mock private TimeService timeService;
+    @Mock private HolidayRepository holidayRepository;
+    @Mock private ReservationRepository reservationRepository;
 
     private ThemeServiceImpl themeService;
 


### PR DESCRIPTION
안녕하세요 베루스😁
사이클2도 잘 부탁드립니다!
리뷰 마구마구 주시면 열심히 고민하고, 공부해서 반영해보겠습니다
감사합니다!!

<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

## 1. 트랜잭션 원자성 검증
트랜잭션 중간에 예외를 임의로 주입해서 롤백시켜서 확인하는 방식 자체가 처음이라, 이런 흐름이 원자성을 검증하는 방법으로 자연스러운 접근인지 궁금합니다.

`@Transactional`이 제가 의도하는 대로 롤백이 일어나는지 별도로 검증하고 싶었습니다.
트랜잭션 중간 단계인 `deleteById`랑 `update`가 실패했을 때 앞에 일어난 DB 작업들이 롤백되는지 테스트하기 위해 `@MockitoSpyBean`으로 예외를 임의로 주입했고, 코드상으로 시도 후에 읽기 작업을 통해 DB상태가 변경 전과 동일한 지 검증했습니다.

처음에는 transactional이 스프링에서 지원해주는 라이브러리니깐 롤백과 커밋을 보장해주니 데이터 일관성은 지켜줄거야라는 생각이어서 테스트가 없어도 된다고 생각했습니다. 다만 고민해보니 지금 단계에서는 트랜잭션이 하나만 존재해서 괜찮지만, 여러 트랜잭션이 전파로 일어났을 경우 어떤 트랜잭션은 데이터가 롤백돼야 하고, 커밋돼야 하는 상황이 발생한다면 제가 기대하는 대로 동작이 일어나는지 검증해야 한다고 생각했습니다. 

## 2. 동시성 고려
동시성을 어디서 고려하고 처리 책임을 가져야 하는 지 의문이 있습니다. 더불어 지금 단계에서 동시성을 고려하는 게 맞는 지 궁금합니다.

이번 사이클의 미션 요구사항에는 동시성 관련 키워드가 전혀없지만, 크루들 사이에서 동시성 이야기가 많이 나와서 한 번 적용해보고 싶다는 욕심..?이 생겨 예약 삽입에 한정해 적용해봤습니다.
더불어 사이클 1에서부터 막연하게 동시성을 한 번 고려해볼까 정도의 생각으로 `reservation` 테이블의 유니크 제약을 뺐습니다. 사이클2에서 동시성을 고려하다 보니, 삽입 단게에서 할 수 잇는 방법으로 별도의 `reservation_slot` 테이블에 `(theme_id, time_id)` 복합 유니크 키를 두고 그 행에 비관적 락을 거는 형태로 접근했습니다.

이렇게 접근하다보니 몇 가지 의문이 들었습니다.
1. 삽입용 테이블의 데이터를 계속 예약 테이블과 일관성 있게 맞춰야 한다.
2. 동시성을 애플리케이션 레벨에서부터 잡도록 하는 게 맞는가
차라리 다시 `reservation` 자체에 유니크 키를 다시 두고 예약 관련 테이블을 새로 만드는 게 더 좋지 않았을까 하는 생각이 들었습니다. 그리고 문제의 본질은 두 트랜잭션이 거의 동시에 빈 예약이라는 사실을 읽는 것인데, 그걸 막으려고 애플리케이션에서 락을 거는 것이 자연스러운지에 대한 부분이이었습니다.

락을 직접 걸지 않아도 DB가 최종 방어선이 되는 방향이 가능해보였습니다. 예약의 `RESERVED` 행에 한정한 부분 유니크 인덱스를 두면, 두 트랜잭션이 없는 슬롯에 INSERT를 시도해도 하나의 삽입은 거부하기 때문에 애플리케이션에서 직접 고려하지 않아도 된다고 생각합니다. 물론 H2는 부분 인덱스를 지원하지 않아 다른 방향으로 갔지만 애플리케이션이 동시성을 잡는다보다 DB가 끝까지 책임이지고 애플리케이션은 결과만 다룬다는 쪽이 더 자연스러운 게 아닐까하는 생각이 들었습니다.