### PR TITLE
[🚀 사이클2 - 미션 (예약 대기)] 모아 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,38 @@
 ## 기능 구현 목록
 
-- [x] 같은 슬롯(날짜, 시간, 테마가 겹치는 예약 가능한 단위를 지칭)에 대해 같은 사용자가 예약을 할 경우 거부한다
-- [x] 이미 다른 사용자가 예약한 슬롯에 대해 예약을 할 경우 대기로 넘어간다
-- [x] '내 예약 목록' 조회시 예약 상태와 대기 상태를 구분하여 보여준다
+### 예약 / 대기
+
+- [x] 같은 슬롯(날짜·시간·테마가 겹치는 예약 단위)에 같은 사용자가 다시 예약하면 거부한다
+- [x] 이미 다른 사용자가 예약한 슬롯이면 대기(WAITING)로 등록된다
+- [x] 신청한 순서(`enqueued_at`)대로 대기 순번이 부여된다
+- [x] '내 예약 목록' 조회 시 예약(CONFIRMED)·대기(WAITING)·취소(CANCELED) 상태를 구분해 보여준다
 - [x] 사용자 UI에서 대기 순번을 보여준다
-- [x] 예약 취소 또는 대기 취소한 사용자가 있을 경우 뒷 순번 사용자의 순번이 줄어든다
-- [x] 신청한 순서대로 순번이 부여된다
+
+### 취소 / 승급 (이번 사이클)
+
+- [x] 예약 취소는 행을 삭제하지 않고 상태를 CANCELED로 바꾸는 **soft delete**로 처리한다
+- [x] 확정 예약이 취소되면 같은 슬롯의 1순위 대기자(가장 먼저 줄 선 사람)를 **자동으로 확정 승급**한다
+- [x] 취소·승급은 하나의 트랜잭션으로 원자적으로 처리한다
+- [x] 취소·승급으로 남은 대기자의 순번이 조회 시 자동으로 당겨진다
+- [x] '내 예약 목록'에서는 본인의 취소 이력도 함께 보여준다 (관리자 목록·인기 테마 집계에서는 취소 건 제외)
+
+### 동시성
+
+- [x] 같은 빈 슬롯에 동시에 예약해도 확정은 정확히 1건만 생성된다
+- [x] 같은 예약을 동시에 취소해도 대기자 이중 승급이 발생하지 않는다
+- [x] 예약 변경과 신규 예약이 같은 슬롯에 동시에 들어와도 확정은 1건을 유지한다
 
 ## 어드민 API
 
 ### 예약 관리
 
-| 기능    | Method / URL                      | 요청 본문                           | 응답                                                   |
-|-------|-----------------------------------|---------------------------------|------------------------------------------------------|
-| 예약 조회 | `GET /admin/reservations`         | -                               | `[{id, name, date, time, theme, waitingOrder}, ...]` |
-| 예약 추가 | `POST /admin/reservations`        | `{name, date, timeId, themeId}` | `{id, name, date, time, theme, waitingOrder}`        |
-| 예약 삭제 | `DELETE /admin/reservations/{id}` | -                               | `200 OK`                                             |
+| 기능    | Method / URL                      | 요청 본문                                   | 응답                                                                   |
+|-------|-----------------------------------|-----------------------------------------|----------------------------------------------------------------------|
+| 예약 조회 | `GET /admin/reservations`         | -                                       | `[{id, reserverName, date, time, theme, waitingOrder, status}, ...]` |
+| 예약 추가 | `POST /admin/reservations`        | `{reserverName, date, timeId, themeId}` | `{id, reserverName, date, time, theme, waitingOrder, status}`        |
+| 예약 취소 | `DELETE /admin/reservations/{id}` | -                                       | `200 OK` (soft delete + 대기자 자동 승급)                                   |
+
+> 예약 취소는 행을 삭제하지 않고 `status`를 `CANCELED`로 바꾼다. 조회(`GET /admin/reservations`)에서는 취소 건이 제외된다.
 
 ### 시간 관리
 
@@ -36,14 +53,24 @@
 ## 사용자 API
 
 > **사용자 흐름:** 테마를 본다 → 날짜를 고른다 → 그 조건에서 예약 가능한 시간을 본다 → 시간을 골라 예약한다.
->
 
-| 기능          | Method / URL                                                 | 요청 본문                           | 응답                                                            |
-|-------------|--------------------------------------------------------------|---------------------------------|---------------------------------------------------------------|
-| 테마 목록 조회    | `GET /user/themes`                                           | -                               | `[{id, name, description, thumbnail}, ...]`                   |
-| 예약 가능 시간 조회 | `GET /user/themes/{themeId}/available-times?date=YYYY-MM-DD` | -                               | `[{id, startAt}, ...]`                                        |
-| 사용자 예약 추가   | `POST /user/reservations`                                    | `{name, date, timeId, themeId}` | `{id, name, date, time, theme}`                               |
-| 본인 예약 조회    | `GET /user/reservations?name={name}`                         | -                               | `[{id, name, date, time, theme, waitingOrder}, ...]`          |
-| 본인 예약 변경    | `PATCH /user/reservations/{id}`                              | `{name, date, timeId}`          | `{id, name, date, time, theme}`                               |
-| 본인 예약 취소    | `DELETE /user/reservations/{id}?name={name}`                 | -                               | `204 No Content`                                              |
-| 인기 테마 조회    | `GET /user/themes/popular`                                   | -                               | `[{id, name, description, thumbnail, reservationCount}, ...]` |
+| 기능          | Method / URL                                                 | 요청 본문                                   | 응답                                                                   |
+|-------------|--------------------------------------------------------------|-----------------------------------------|----------------------------------------------------------------------|
+| 테마 목록 조회    | `GET /user/themes`                                           | -                                       | `[{id, name, description, thumbnail}, ...]`                          |
+| 예약 가능 시간 조회 | `GET /user/themes/{themeId}/available-times?date=YYYY-MM-DD` | -                                       | `[{id, startAt}, ...]`                                               |
+| 사용자 예약 추가   | `POST /user/reservations`                                    | `{reserverName, date, timeId, themeId}` | `{id, reserverName, date, time, theme, waitingOrder, status}`        |
+| 본인 예약 조회    | `GET /user/reservations?reserverName={reserverName}`         | -                                       | `[{id, reserverName, date, time, theme, waitingOrder, status}, ...]` |
+| 본인 예약 변경    | `PATCH /user/reservations/{id}`                              | `{reserverName, date, timeId}`          | `{id, reserverName, date, time, theme, waitingOrder, status}`        |
+| 본인 예약 취소    | `DELETE /user/reservations/{id}?reserverName={reserverName}` | -                                       | `204 No Content` (soft delete + 대기자 자동 승급)                           |
+| 인기 테마 조회    | `GET /user/themes/popular`                                   | -                                       | `[{id, name, description, thumbnail, reservationCount}, ...]`        |
+
+- `status`: `CONFIRMED`(확정) / `WAITING`(대기) / `CANCELED`(취소)
+- `waitingOrder`: 대기 순번(확정·취소는 0). 본인 예약 조회는 취소 건도 함께 반환한다.
+- 인기 테마(`reservationCount`)는 최근 7일 기준이며 취소된 예약은 집계에서 제외한다.
+
+## 설계 메모 (주요 결정)
+
+- **상태 저장 + 단일 테이블**: 예약/대기/취소를 별도 테이블로 나누지 않고 `reservation` 한 테이블의 `status` 컬럼으로 표현한다. 대기 순번은 별도로 저장하지 않고 조회 시 서브쿼리로 계산한다(취소 건 제외).
+- **순번 정렬 키 `enqueued_at`**: 대기 순번은 "큐에 들어온 시각"인 `enqueued_at`으로 정한다. 수정 시각(`updated_at`)은 감사용으로만 쓰며 순번 계산에 사용하지 않는다(슬롯 변경 시에만 `enqueued_at`을 갱신해 재입장 처리).
+- **soft delete**: 취소는 행 삭제가 아니라 `status = CANCELED`로 보존한다. 조회·중복검사·인기집계에서는 취소 건을 제외하고, '내 예약'에서만 이력으로 노출한다.
+- **동시성(비관 락)**: "슬롯당 확정 1건" 같은 조건부 유일성은 단순 UNIQUE로 표현할 수 없어(H2는 부분 유니크 인덱스 미지원), 생성·취소·변경이 같은 `theme` 행을 `SELECT ... FOR UPDATE`로 잠가 슬롯 진입을 직렬화한다.

--- a/src/main/java/roomescape/controller/AdminReservationController.java
+++ b/src/main/java/roomescape/controller/AdminReservationController.java
@@ -41,9 +41,9 @@ public class AdminReservationController {
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable
+    public void cancel(@PathVariable
                        @Positive(message = "id는 0보다 커야합니다.")
                        Long id) {
-        reservationService.delete(id);
+        reservationService.cancel(id);
     }
 }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -12,21 +12,32 @@ public class Reservation {
     private final ReservationTime time;
 
     private final Theme theme;
+    private final ReservationStatus status;
 
-    public Reservation(Long id, String reserverName, LocalDate date, ReservationTime time, Theme theme) {
-        validate(reserverName, date, time, theme);
+    public Reservation(Long id, String reserverName, LocalDate date, ReservationTime time, Theme theme,
+                       ReservationStatus status) {
+        validate(reserverName, date, time, theme, status);
         this.id = id;
         this.reserverName = reserverName;
         this.date = date;
         this.time = time;
         this.theme = theme;
+        this.status = status;
     }
 
-    private static void validate(String reserverName, LocalDate date, ReservationTime time, Theme theme) {
+    private static void validate(String reserverName, LocalDate date, ReservationTime time, Theme theme,
+                                 ReservationStatus status) {
         validateReserverName(reserverName);
         validateDate(date);
         validateTime(time);
         validateTheme(theme);
+        validateStatus(status);
+    }
+
+    private static void validateStatus(ReservationStatus status) {
+        if (status == null) {
+            throw new DomainValidationException("예약 상태는 비어 있을 수 없습니다.");
+        }
     }
 
     private static void validateReserverName(String reserverName) {
@@ -76,5 +87,25 @@ public class Reservation {
 
     public Theme getTheme() {
         return theme;
+    }
+
+    public ReservationStatus getStatus() {
+        return status;
+    }
+
+    public boolean isConfirmed() {
+        return status == ReservationStatus.CONFIRMED;
+    }
+
+    public boolean isWaiting() {
+        return status == ReservationStatus.WAITING;
+    }
+
+    public boolean isCanceled() {
+        return status == ReservationStatus.CANCELED;
+    }
+
+    public boolean isActive() {
+        return status != ReservationStatus.CANCELED;
     }
 }

--- a/src/main/java/roomescape/domain/ReservationStatus.java
+++ b/src/main/java/roomescape/domain/ReservationStatus.java
@@ -2,5 +2,6 @@ package roomescape.domain;
 
 public enum ReservationStatus {
     CONFIRMED,
-    WAITING
+    WAITING,
+    CANCELED
 }

--- a/src/main/java/roomescape/domain/ReservationWithWaitingOrder.java
+++ b/src/main/java/roomescape/domain/ReservationWithWaitingOrder.java
@@ -1,10 +1,6 @@
-package roomescape.service.dto;
+package roomescape.domain;
 
 import java.time.LocalDate;
-import roomescape.domain.ReservationStatus;
-import roomescape.domain.ReservationTime;
-import roomescape.domain.Theme;
-import roomescape.domain.WaitingOrder;
 
 public record ReservationWithWaitingOrder(Long id,
                                           String reserverName,

--- a/src/main/java/roomescape/domain/WaitingOrder.java
+++ b/src/main/java/roomescape/domain/WaitingOrder.java
@@ -5,22 +5,15 @@ import roomescape.domain.exception.DomainValidationException;
 
 public class WaitingOrder {
 
-    private static final long CONFIRMED_ORDER = 0L;
+    private static final long MIN_ORDER = 0L;
 
     private final long order;
 
     public WaitingOrder(long order) {
-        if (order < CONFIRMED_ORDER) {
+        if (order < MIN_ORDER) {
             throw new DomainValidationException("대기 순번은 0 이상이어야 합니다.");
         }
         this.order = order;
-    }
-
-    public ReservationStatus status() {
-        if (order == CONFIRMED_ORDER) {
-            return ReservationStatus.CONFIRMED;
-        }
-        return ReservationStatus.WAITING;
     }
 
     public long value() {

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -20,7 +20,7 @@ import roomescape.domain.WaitingOrder;
 import roomescape.domain.ReservationWithWaitingOrder;
 
 @Repository
-public class JdbcReservationRepository implements ReservationRepository {
+public class JdbcReservationRepository implements ReservationRepository, LockedReservationWriter {
 
     private static final String CANCELED = ReservationStatus.CANCELED.name();
     private static final String WAITING = ReservationStatus.WAITING.name();
@@ -185,11 +185,10 @@ public class JdbcReservationRepository implements ReservationRepository {
                     "테마 락은 트랜잭션 안에서만 획득할 수 있습니다: themeId=" + themeId);
         }
         Optional<Theme> lockedTheme = lockTheme(themeId);
-        return action.execute(lockedTheme);
+        return action.execute(lockedTheme, this);
     }
 
-    @Override
-    public Optional<Theme> lockTheme(Long themeId) {
+    private Optional<Theme> lockTheme(Long themeId) {
         String sql = "SELECT id, name, description, thumbnail_url FROM theme WHERE id = ? FOR UPDATE";
         try {
             Theme theme = jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new Theme(

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
@@ -20,11 +21,16 @@ import roomescape.service.dto.ReservationWithWaitingOrder;
 @Repository
 public class JdbcReservationRepository implements ReservationRepository {
 
+    private static final String CANCELED = ReservationStatus.CANCELED.name();
+    private static final String WAITING = ReservationStatus.WAITING.name();
+    private static final String CONFIRMED = ReservationStatus.CONFIRMED.name();
+
     private static final String SELECT_BASE = """
             SELECT
                 r.id AS reservation_id,
                 r.reserver_name AS reserver_name,
                 r.date AS reservation_date,
+                r.status AS status,
                 t.id AS time_id,
                 t.start_at AS time_start_at,
                 th.id AS theme_id,
@@ -41,19 +47,24 @@ public class JdbcReservationRepository implements ReservationRepository {
                 r.id           AS reservation_id,
                 r.reserver_name AS reserver_name,
                 r.date         AS reservation_date,
+                r.status       AS status,
                 t.id           AS time_id,
                 t.start_at     AS time_start_at,
                 th.id          AS theme_id,
                 th.name        AS theme_name,
                 th.description AS theme_description,
                 th.thumbnail_url AS theme_thumbnail,
-                (SELECT COUNT(*)
-                   FROM reservation r2
-                  WHERE r2.date = r.date
-                    AND r2.time_id = r.time_id
-                    AND r2.theme_id = r.theme_id
-                    AND (r2.updated_at < r.updated_at
-                         OR (r2.updated_at = r.updated_at AND r2.id < r.id))) AS waiting_order
+                CASE WHEN r.status = 'WAITING' THEN
+                    (SELECT COUNT(*)
+                       FROM reservation r2
+                      WHERE r2.date = r.date
+                        AND r2.time_id = r.time_id
+                        AND r2.theme_id = r.theme_id
+                        AND r2.status <> 'CANCELED'
+                        AND (r2.enqueued_at < r.enqueued_at
+                             OR (r2.enqueued_at = r.enqueued_at AND r2.id < r.id)))
+                ELSE 0
+                END AS waiting_order
             FROM reservation r
             INNER JOIN reservation_time t ON r.time_id = t.id
             INNER JOIN theme th ON r.theme_id = th.id
@@ -72,7 +83,8 @@ public class JdbcReservationRepository implements ReservationRepository {
                     rs.getString("theme_name"),
                     rs.getString("theme_description"),
                     rs.getString("theme_thumbnail")
-            )
+            ),
+            ReservationStatus.valueOf(rs.getString("status"))
     );
 
     private static final RowMapper<ReservationWithWaitingOrder> RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER = (rs, rowNum) -> new ReservationWithWaitingOrder(
@@ -89,6 +101,7 @@ public class JdbcReservationRepository implements ReservationRepository {
                     rs.getString("theme_description"),
                     rs.getString("theme_thumbnail")
             ),
+            ReservationStatus.valueOf(rs.getString("status")),
             new WaitingOrder(rs.getLong("waiting_order"))
     );
 
@@ -100,7 +113,8 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public List<ReservationWithWaitingOrder> findAll() {
-        return jdbcTemplate.query(SELECT_BASE_WITH_WAITING_ORDER, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER);
+        String sql = SELECT_BASE_WITH_WAITING_ORDER + " WHERE r.status <> '" + CANCELED + "'";
+        return jdbcTemplate.query(sql, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER);
     }
 
     @Override
@@ -122,7 +136,8 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public ReservationWithWaitingOrder save(Reservation reservation) {
-        String sql = "INSERT INTO reservation (reserver_name, date, time_id, theme_id) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at) "
+                + "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)";
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
         jdbcTemplate.update(connection -> {
@@ -131,6 +146,7 @@ public class JdbcReservationRepository implements ReservationRepository {
             ps.setDate(2, Date.valueOf(reservation.getDate()));
             ps.setLong(3, reservation.getTime().getId());
             ps.setLong(4, reservation.getTheme().getId());
+            ps.setString(5, reservation.getStatus().name());
             return ps;
         }, keyHolder);
 
@@ -140,13 +156,17 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public ReservationWithWaitingOrder update(Reservation reservation) {
-        String sql = "UPDATE reservation SET reserver_name = ?, date = ?, time_id = ?, theme_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        String sql = "UPDATE reservation "
+                + "SET reserver_name = ?, date = ?, time_id = ?, theme_id = ?, status = ?, "
+                + "enqueued_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+                + "WHERE id = ?";
         jdbcTemplate.update(
                 sql,
                 reservation.getReserverName(),
                 Date.valueOf(reservation.getDate()),
                 reservation.getTime().getId(),
                 reservation.getTheme().getId(),
+                reservation.getStatus().name(),
                 reservation.getId()
         );
         return findWithWaitingOrderById(reservation.getId());
@@ -163,6 +183,44 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public void cancel(Long id) {
+        jdbcTemplate.update(
+                "UPDATE reservation SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                CANCELED, id
+        );
+    }
+
+    @Override
+    public boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId) {
+        List<Long> ids = jdbcTemplate.query(
+                "SELECT id FROM reservation "
+                        + "WHERE date = ? AND time_id = ? AND theme_id = ? AND status = ? "
+                        + "ORDER BY enqueued_at, id LIMIT 1",
+                (rs, rowNum) -> rs.getLong("id"),
+                Date.valueOf(date), timeId, themeId, WAITING
+        );
+        if (ids.isEmpty()) {
+            return false;
+        }
+        jdbcTemplate.update(
+                "UPDATE reservation SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                CONFIRMED, ids.getFirst()
+        );
+        return true;
+    }
+
+    @Override
+    public boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation "
+                        + "WHERE date = ? AND time_id = ? AND theme_id = ? AND status = ?",
+                Integer.class,
+                Date.valueOf(date), timeId, themeId, CONFIRMED
+        );
+        return count != null && count > 0;
+    }
+
+    @Override
     public boolean existsById(Long id) {
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM reservation WHERE id = ?",
@@ -176,9 +234,10 @@ public class JdbcReservationRepository implements ReservationRepository {
     public boolean existsByReserverNameAndDateAndTimeIdAndThemeId(String reserverName, LocalDate date, Long timeId,
                                                                   Long themeId) {
         Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM reservation WHERE reserver_name = ? AND date = ? AND time_id = ? AND theme_id = ?",
+                "SELECT COUNT(*) FROM reservation "
+                        + "WHERE reserver_name = ? AND date = ? AND time_id = ? AND theme_id = ? AND status <> ?",
                 Integer.class,
-                reserverName, Date.valueOf(date), timeId, themeId
+                reserverName, Date.valueOf(date), timeId, themeId, CANCELED
         );
         return count != null && count > 0;
     }
@@ -187,9 +246,11 @@ public class JdbcReservationRepository implements ReservationRepository {
     public boolean existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
             String reserverName, LocalDate date, Long timeId, Long themeId, Long id) {
         Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM reservation WHERE reserver_name = ? AND date = ? AND time_id = ? AND theme_id = ? AND id <> ?",
+                "SELECT COUNT(*) FROM reservation "
+                        + "WHERE reserver_name = ? AND date = ? AND time_id = ? AND theme_id = ? "
+                        + "AND status <> ? AND id <> ?",
                 Integer.class,
-                reserverName, Date.valueOf(date), timeId, themeId, id
+                reserverName, Date.valueOf(date), timeId, themeId, CANCELED, id
         );
         return count != null && count > 0;
     }

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -152,28 +152,14 @@ public class JdbcReservationRepository implements ReservationRepository, LockedR
         }, keyHolder);
 
         Long id = keyHolder.getKey().longValue();
-        return findWithWaitingOrderById(id);
-    }
-
-    @Override
-    public ReservationWithWaitingOrder update(Reservation reservation) {
-        return updateInternal(reservation, false);
+        return findWithWaitingOrderById(id).orElseThrow();
     }
 
     @Override
     public ReservationWithWaitingOrder updateAndRequeue(Reservation reservation) {
-        return updateInternal(reservation, true);
-    }
-
-    private ReservationWithWaitingOrder updateInternal(Reservation reservation, boolean renewQueueOrder) {
-        String enqueuedAtClause = "";
-        if (renewQueueOrder) {
-            enqueuedAtClause = "enqueued_at = CURRENT_TIMESTAMP, ";
-        }
         String sql = "UPDATE reservation "
                 + "SET reserver_name = ?, date = ?, time_id = ?, theme_id = ?, status = ?, "
-                + enqueuedAtClause
-                + "updated_at = CURRENT_TIMESTAMP "
+                + "enqueued_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
                 + "WHERE id = ?";
         jdbcTemplate.update(
                 sql,
@@ -184,12 +170,18 @@ public class JdbcReservationRepository implements ReservationRepository, LockedR
                 reservation.getStatus().name(),
                 reservation.getId()
         );
-        return findWithWaitingOrderById(reservation.getId());
+        return findWithWaitingOrderById(reservation.getId()).orElseThrow();
     }
 
-    private ReservationWithWaitingOrder findWithWaitingOrderById(Long id) {
+    @Override
+    public Optional<ReservationWithWaitingOrder> findWithWaitingOrderById(Long id) {
         String sql = SELECT_BASE_WITH_WAITING_ORDER + " WHERE r.id = ?";
-        return jdbcTemplate.queryForObject(sql, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER, id);
+        try {
+            return Optional.ofNullable(
+                    jdbcTemplate.queryForObject(sql, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER, id));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -183,8 +183,19 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public void lockTheme(Long themeId) {
-        jdbcTemplate.queryForObject("SELECT id FROM theme WHERE id = ? FOR UPDATE", Long.class, themeId);
+    public Optional<Theme> lockTheme(Long themeId) {
+        String sql = "SELECT id, name, description, thumbnail_url FROM theme WHERE id = ? FOR UPDATE";
+        try {
+            Theme theme = jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new Theme(
+                    rs.getLong("id"),
+                    rs.getString("name"),
+                    rs.getString("description"),
+                    rs.getString("thumbnail_url")
+            ), themeId);
+            return Optional.ofNullable(theme);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -178,11 +178,6 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public void deleteById(Long id) {
-        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
-    }
-
-    @Override
     public Optional<Theme> lockTheme(Long themeId) {
         String sql = "SELECT id, name, description, thumbnail_url FROM theme WHERE id = ? FOR UPDATE";
         try {

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -183,6 +183,11 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public void lockTheme(Long themeId) {
+        jdbcTemplate.queryForObject("SELECT id FROM theme WHERE id = ? FOR UPDATE", Long.class, themeId);
+    }
+
+    @Override
     public void cancel(Long id) {
         jdbcTemplate.update(
                 "UPDATE reservation SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -113,7 +113,7 @@ public class JdbcReservationRepository implements ReservationRepository, LockedR
     }
 
     @Override
-    public List<ReservationWithWaitingOrder> findAll() {
+    public List<ReservationWithWaitingOrder> findAllActive() {
         String sql = SELECT_BASE_WITH_WAITING_ORDER + " WHERE r.status <> '" + CANCELED + "'";
         return jdbcTemplate.query(sql, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER);
     }

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -16,7 +16,7 @@ import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 
 @Repository
 public class JdbcReservationRepository implements ReservationRepository {

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
@@ -175,6 +176,16 @@ public class JdbcReservationRepository implements ReservationRepository {
     private ReservationWithWaitingOrder findWithWaitingOrderById(Long id) {
         String sql = SELECT_BASE_WITH_WAITING_ORDER + " WHERE r.id = ?";
         return jdbcTemplate.queryForObject(sql, RESERVATION_WITH_WAITING_ORDER_ROW_MAPPER, id);
+    }
+
+    @Override
+    public <T> T executeWithThemeLock(Long themeId, ThemeLockedAction<T> action) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            throw new IllegalStateException(
+                    "테마 락은 트랜잭션 안에서만 획득할 수 있습니다: themeId=" + themeId);
+        }
+        Optional<Theme> lockedTheme = lockTheme(themeId);
+        return action.execute(lockedTheme);
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -157,9 +157,23 @@ public class JdbcReservationRepository implements ReservationRepository, LockedR
 
     @Override
     public ReservationWithWaitingOrder update(Reservation reservation) {
+        return updateInternal(reservation, false);
+    }
+
+    @Override
+    public ReservationWithWaitingOrder updateAndRequeue(Reservation reservation) {
+        return updateInternal(reservation, true);
+    }
+
+    private ReservationWithWaitingOrder updateInternal(Reservation reservation, boolean renewQueueOrder) {
+        String enqueuedAtClause = "";
+        if (renewQueueOrder) {
+            enqueuedAtClause = "enqueued_at = CURRENT_TIMESTAMP, ";
+        }
         String sql = "UPDATE reservation "
                 + "SET reserver_name = ?, date = ?, time_id = ?, theme_id = ?, status = ?, "
-                + "enqueued_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+                + enqueuedAtClause
+                + "updated_at = CURRENT_TIMESTAMP "
                 + "WHERE id = ?";
         jdbcTemplate.update(
                 sql,

--- a/src/main/java/roomescape/repository/JdbcThemeRepository.java
+++ b/src/main/java/roomescape/repository/JdbcThemeRepository.java
@@ -107,6 +107,7 @@ public class JdbcThemeRepository implements ThemeRepository {
                 INNER JOIN reservation r ON t.id = r.theme_id
                 WHERE r.date >= DATEADD('DAY', -7, CURRENT_DATE)
                   AND r.date <  CURRENT_DATE
+                  AND r.status <> 'CANCELED'
                 GROUP BY t.id, t.name, t.description, t.thumbnail_url
                 ORDER BY reservation_count DESC
                 LIMIT 10

--- a/src/main/java/roomescape/repository/LockedReservationWriter.java
+++ b/src/main/java/roomescape/repository/LockedReservationWriter.java
@@ -1,0 +1,16 @@
+package roomescape.repository;
+
+import java.time.LocalDate;
+import roomescape.domain.Reservation;
+import roomescape.domain.ReservationWithWaitingOrder;
+
+public interface LockedReservationWriter {
+
+    ReservationWithWaitingOrder save(Reservation reservation);
+
+    ReservationWithWaitingOrder update(Reservation reservation);
+
+    void cancel(Long id);
+
+    boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
+}

--- a/src/main/java/roomescape/repository/LockedReservationWriter.java
+++ b/src/main/java/roomescape/repository/LockedReservationWriter.java
@@ -10,6 +10,8 @@ public interface LockedReservationWriter {
 
     ReservationWithWaitingOrder update(Reservation reservation);
 
+    ReservationWithWaitingOrder updateAndRequeue(Reservation reservation);
+
     void cancel(Long id);
 
     boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);

--- a/src/main/java/roomescape/repository/LockedReservationWriter.java
+++ b/src/main/java/roomescape/repository/LockedReservationWriter.java
@@ -8,8 +8,6 @@ public interface LockedReservationWriter {
 
     ReservationWithWaitingOrder save(Reservation reservation);
 
-    ReservationWithWaitingOrder update(Reservation reservation);
-
     ReservationWithWaitingOrder updateAndRequeue(Reservation reservation);
 
     void cancel(Long id);

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -18,8 +18,6 @@ public interface ReservationRepository {
 
     ReservationWithWaitingOrder update(Reservation reservation);
 
-    void deleteById(Long id);
-
     void cancel(Long id);
 
     Optional<Theme> lockTheme(Long themeId);

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import roomescape.domain.Reservation;
+import roomescape.domain.Theme;
 import roomescape.service.dto.ReservationWithWaitingOrder;
 
 public interface ReservationRepository {
@@ -21,7 +22,7 @@ public interface ReservationRepository {
 
     void cancel(Long id);
 
-    void lockTheme(Long themeId);
+    Optional<Theme> lockTheme(Long themeId);
 
     boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
 

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import roomescape.domain.Reservation;
-import roomescape.domain.Theme;
 import roomescape.domain.ReservationWithWaitingOrder;
 
 public interface ReservationRepository {
@@ -14,17 +13,7 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long id);
 
-    ReservationWithWaitingOrder save(Reservation reservation);
-
-    ReservationWithWaitingOrder update(Reservation reservation);
-
-    void cancel(Long id);
-
-    Optional<Theme> lockTheme(Long themeId);
-
     <T> T executeWithThemeLock(Long themeId, ThemeLockedAction<T> action);
-
-    boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
 
     boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId);
 

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -22,6 +22,8 @@ public interface ReservationRepository {
 
     Optional<Theme> lockTheme(Long themeId);
 
+    <T> T executeWithThemeLock(Long themeId, ThemeLockedAction<T> action);
+
     boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
 
     boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId);

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -13,6 +13,8 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long id);
 
+    Optional<ReservationWithWaitingOrder> findWithWaitingOrderById(Long id);
+
     <T> T executeWithThemeLock(Long themeId, ThemeLockedAction<T> action);
 
     boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId);

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import roomescape.domain.Reservation;
 import roomescape.domain.Theme;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 
 public interface ReservationRepository {
     List<ReservationWithWaitingOrder> findAll();

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -19,6 +19,12 @@ public interface ReservationRepository {
 
     void deleteById(Long id);
 
+    void cancel(Long id);
+
+    boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
+
+    boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId);
+
     boolean existsById(Long id);
 
     boolean existsByReserverNameAndDateAndTimeIdAndThemeId(String reserverName, LocalDate date, Long timeId, Long themeId);

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -7,7 +7,7 @@ import roomescape.domain.Reservation;
 import roomescape.domain.ReservationWithWaitingOrder;
 
 public interface ReservationRepository {
-    List<ReservationWithWaitingOrder> findAll();
+    List<ReservationWithWaitingOrder> findAllActive();
 
     List<ReservationWithWaitingOrder> findByReserverName(String reserverName);
 

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -21,6 +21,8 @@ public interface ReservationRepository {
 
     void cancel(Long id);
 
+    void lockTheme(Long themeId);
+
     boolean promoteEarliestWaiting(LocalDate date, Long timeId, Long themeId);
 
     boolean existsActiveConfirmed(LocalDate date, Long timeId, Long themeId);

--- a/src/main/java/roomescape/repository/ThemeLockedAction.java
+++ b/src/main/java/roomescape/repository/ThemeLockedAction.java
@@ -5,5 +5,5 @@ import roomescape.domain.Theme;
 
 @FunctionalInterface
 public interface ThemeLockedAction<T> {
-    T execute(Optional<Theme> lockedTheme);
+    T execute(Optional<Theme> lockedTheme, LockedReservationWriter writer);
 }

--- a/src/main/java/roomescape/repository/ThemeLockedAction.java
+++ b/src/main/java/roomescape/repository/ThemeLockedAction.java
@@ -1,0 +1,9 @@
+package roomescape.repository;
+
+import java.util.Optional;
+import roomescape.domain.Theme;
+
+@FunctionalInterface
+public interface ThemeLockedAction<T> {
+    T execute(Optional<Theme> lockedTheme);
+}

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -103,18 +103,21 @@ public class AdminReservationService {
 
     @Transactional
     public void cancel(Reservation reservation) {
-        if (reservation.isCanceled()) {
+        reservationRepository.lockTheme(reservation.getTheme().getId());
+        Reservation current = reservationRepository.findById(reservation.getId())
+                .orElseThrow(() -> new ReservationNotFoundException(
+                        "존재하지 않는 예약입니다: reservationId=" + reservation.getId()));
+        if (current.isCanceled()) {
             return;
         }
-        reservationRepository.lockTheme(reservation.getTheme().getId());
-        reservationRepository.cancel(reservation.getId());
-        if (reservation.isConfirmed()) {
+        reservationRepository.cancel(current.getId());
+        if (current.isConfirmed()) {
             boolean promoted = reservationRepository.promoteEarliestWaiting(
-                    reservation.getDate(),
-                    reservation.getTime().getId(),
-                    reservation.getTheme().getId()
+                    current.getDate(),
+                    current.getTime().getId(),
+                    current.getTheme().getId()
             );
-            log.info("예약 취소 후 승급 처리: reservationId={}, promoted={}", reservation.getId(), promoted);
+            log.info("예약 취소 후 승급 처리: reservationId={}, promoted={}", current.getId(), promoted);
         }
     }
 }

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -52,7 +52,7 @@ public class AdminReservationService {
                             "존재하지 않는 시간입니다: timeId=" + command.timeId());
                 });
 
-        return reservationRepository.executeWithThemeLock(command.themeId(), lockedTheme -> {
+        return reservationRepository.executeWithThemeLock(command.themeId(), (lockedTheme, writer) -> {
             Theme theme = lockedTheme.orElseThrow(() -> {
                 log.warn("존재하지 않는 테마로 예약 생성 시도: themeId={}", command.themeId());
                 return new ThemeNotFoundException(
@@ -63,7 +63,7 @@ public class AdminReservationService {
 
             ReservationStatus status = decideStatus(command.date(), command.timeId(), command.themeId());
             Reservation reservation = new Reservation(null, command.reserverName(), command.date(), time, theme, status);
-            ReservationWithWaitingOrder saved = reservationRepository.save(reservation);
+            ReservationWithWaitingOrder saved = writer.save(reservation);
             log.info("예약 생성 완료: reservationId={}, reserverName={}, date={}, timeId={}, themeId={}, status={}",
                     saved.id(), saved.reserverName(), saved.date(), command.timeId(), command.themeId(), saved.status());
             return ReservationResult.from(saved);
@@ -93,16 +93,16 @@ public class AdminReservationService {
                     log.warn("존재하지 않는 예약 취소 시도: reservationId={}", id);
                     return new ReservationNotFoundException("존재하지 않는 예약입니다: reservationId=" + id);
                 });
-        reservationRepository.executeWithThemeLock(reservation.getTheme().getId(), lockedTheme -> {
+        reservationRepository.executeWithThemeLock(reservation.getTheme().getId(), (lockedTheme, writer) -> {
             Reservation current = reservationRepository.findById(id)
                     .orElseThrow(() -> new ReservationNotFoundException(
                             "존재하지 않는 예약입니다: reservationId=" + id));
             if (current.isCanceled()) {
                 return null;
             }
-            reservationRepository.cancel(current.getId());
+            writer.cancel(current.getId());
             if (current.isConfirmed()) {
-                boolean promoted = reservationRepository.promoteEarliestWaiting(
+                boolean promoted = writer.promoteEarliestWaiting(
                         current.getDate(),
                         current.getTime().getId(),
                         current.getTheme().getId()

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -1,10 +1,12 @@
 package roomescape.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.repository.ReservationRepository;
@@ -61,11 +63,17 @@ public class AdminReservationService {
 
         validateNoConflict(command);
 
-        Reservation reservation = new Reservation(null, command.reserverName(), command.date(), time, theme);
+        ReservationStatus status = decideStatus(command.date(), command.timeId(), command.themeId());
+        Reservation reservation = new Reservation(null, command.reserverName(), command.date(), time, theme, status);
         ReservationWithWaitingOrder saved = reservationRepository.save(reservation);
-        log.info("예약 생성 완료: reservationId={}, reserverName={}, date={}, timeId={}, themeId={}",
-                saved.id(), saved.reserverName(), saved.date(), command.timeId(), command.themeId());
+        log.info("예약 생성 완료: reservationId={}, reserverName={}, date={}, timeId={}, themeId={}, status={}",
+                saved.id(), saved.reserverName(), saved.date(), command.timeId(), command.themeId(), saved.status());
         return ReservationResult.from(saved);
+    }
+
+    private ReservationStatus decideStatus(LocalDate date, Long timeId, Long themeId) {
+        boolean alreadyConfirmed = reservationRepository.existsActiveConfirmed(date, timeId, themeId);
+        return alreadyConfirmed ? ReservationStatus.WAITING : ReservationStatus.CONFIRMED;
     }
 
     private void validateNoConflict(ReservationCreateCommand command) {
@@ -80,10 +88,26 @@ public class AdminReservationService {
     }
 
     public void delete(Long id) {
-        if (!reservationRepository.existsById(id)) {
-            log.warn("존재하지 않는 예약 삭제 시도: reservationId={}", id);
-            throw new ReservationNotFoundException("존재하지 않는 예약입니다: reservationId=" + id);
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 예약 삭제 시도: reservationId={}", id);
+                    return new ReservationNotFoundException("존재하지 않는 예약입니다: reservationId=" + id);
+                });
+        cancel(reservation);
+    }
+
+    public void cancel(Reservation reservation) {
+        if (reservation.isCanceled()) {
+            return;
         }
-        reservationRepository.deleteById(id);
+        reservationRepository.cancel(reservation.getId());
+        if (reservation.isConfirmed()) {
+            boolean promoted = reservationRepository.promoteEarliestWaiting(
+                    reservation.getDate(),
+                    reservation.getTime().getId(),
+                    reservation.getTheme().getId()
+            );
+            log.info("예약 취소 후 승급 처리: reservationId={}, promoted={}", reservation.getId(), promoted);
+        }
     }
 }

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -12,7 +12,6 @@ import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
-import roomescape.repository.ThemeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
 import roomescape.service.dto.ReservationResult;
 import roomescape.service.dto.ReservationWithWaitingOrder;
@@ -28,16 +27,13 @@ public class AdminReservationService {
 
     private final ReservationRepository reservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
-    private final ThemeRepository themeRepository;
 
     public AdminReservationService(
             ReservationRepository reservationRepository,
-            ReservationTimeRepository reservationTimeRepository,
-            ThemeRepository themeRepository
+            ReservationTimeRepository reservationTimeRepository
     ) {
         this.reservationRepository = reservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
-        this.themeRepository = themeRepository;
     }
 
 
@@ -56,14 +52,12 @@ public class AdminReservationService {
                             "존재하지 않는 시간입니다: timeId=" + command.timeId());
                 });
 
-        Theme theme = themeRepository.findById(command.themeId())
+        Theme theme = reservationRepository.lockTheme(command.themeId())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 테마로 예약 생성 시도: themeId={}", command.themeId());
                     return new ThemeNotFoundException(
                             "존재하지 않는 테마입니다: themeId=" + command.themeId());
                 });
-
-        reservationRepository.lockTheme(theme.getId());
 
         validateNoConflict(command);
 

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -38,7 +38,7 @@ public class AdminReservationService {
 
 
     public List<ReservationResult> findAll() {
-        return reservationRepository.findAll().stream()
+        return reservationRepository.findAllActive().stream()
                 .map(ReservationResult::from)
                 .toList();
     }

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -86,21 +86,16 @@ public class AdminReservationService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void cancel(Long id) {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> {
-                    log.warn("존재하지 않는 예약 삭제 시도: reservationId={}", id);
+                    log.warn("존재하지 않는 예약 취소 시도: reservationId={}", id);
                     return new ReservationNotFoundException("존재하지 않는 예약입니다: reservationId=" + id);
                 });
-        cancel(reservation);
-    }
-
-    @Transactional
-    public void cancel(Reservation reservation) {
         reservationRepository.lockTheme(reservation.getTheme().getId());
-        Reservation current = reservationRepository.findById(reservation.getId())
+        Reservation current = reservationRepository.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException(
-                        "존재하지 않는 예약입니다: reservationId=" + reservation.getId()));
+                        "존재하지 않는 예약입니다: reservationId=" + id));
         if (current.isCanceled()) {
             return;
         }

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -14,7 +14,7 @@ import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
 import roomescape.service.dto.ReservationResult;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.service.exception.ReservationConflictException;
 import roomescape.service.exception.ReservationNotFoundException;
 import roomescape.service.exception.ReservationTimeNotFoundException;

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
@@ -46,6 +47,7 @@ public class AdminReservationService {
                 .toList();
     }
 
+    @Transactional
     public ReservationResult create(ReservationCreateCommand command) {
         ReservationTime time = reservationTimeRepository.findById(command.timeId())
                 .orElseThrow(() -> {
@@ -60,6 +62,8 @@ public class AdminReservationService {
                     return new ThemeNotFoundException(
                             "존재하지 않는 테마입니다: themeId=" + command.themeId());
                 });
+
+        reservationRepository.lockTheme(theme.getId());
 
         validateNoConflict(command);
 
@@ -87,6 +91,7 @@ public class AdminReservationService {
         }
     }
 
+    @Transactional
     public void delete(Long id) {
         Reservation reservation = reservationRepository.findById(id)
                 .orElseThrow(() -> {
@@ -96,10 +101,12 @@ public class AdminReservationService {
         cancel(reservation);
     }
 
+    @Transactional
     public void cancel(Reservation reservation) {
         if (reservation.isCanceled()) {
             return;
         }
+        reservationRepository.lockTheme(reservation.getTheme().getId());
         reservationRepository.cancel(reservation.getId());
         if (reservation.isConfirmed()) {
             boolean promoted = reservationRepository.promoteEarliestWaiting(

--- a/src/main/java/roomescape/service/AdminReservationService.java
+++ b/src/main/java/roomescape/service/AdminReservationService.java
@@ -52,21 +52,22 @@ public class AdminReservationService {
                             "존재하지 않는 시간입니다: timeId=" + command.timeId());
                 });
 
-        Theme theme = reservationRepository.lockTheme(command.themeId())
-                .orElseThrow(() -> {
-                    log.warn("존재하지 않는 테마로 예약 생성 시도: themeId={}", command.themeId());
-                    return new ThemeNotFoundException(
-                            "존재하지 않는 테마입니다: themeId=" + command.themeId());
-                });
+        return reservationRepository.executeWithThemeLock(command.themeId(), lockedTheme -> {
+            Theme theme = lockedTheme.orElseThrow(() -> {
+                log.warn("존재하지 않는 테마로 예약 생성 시도: themeId={}", command.themeId());
+                return new ThemeNotFoundException(
+                        "존재하지 않는 테마입니다: themeId=" + command.themeId());
+            });
 
-        validateNoConflict(command);
+            validateNoConflict(command);
 
-        ReservationStatus status = decideStatus(command.date(), command.timeId(), command.themeId());
-        Reservation reservation = new Reservation(null, command.reserverName(), command.date(), time, theme, status);
-        ReservationWithWaitingOrder saved = reservationRepository.save(reservation);
-        log.info("예약 생성 완료: reservationId={}, reserverName={}, date={}, timeId={}, themeId={}, status={}",
-                saved.id(), saved.reserverName(), saved.date(), command.timeId(), command.themeId(), saved.status());
-        return ReservationResult.from(saved);
+            ReservationStatus status = decideStatus(command.date(), command.timeId(), command.themeId());
+            Reservation reservation = new Reservation(null, command.reserverName(), command.date(), time, theme, status);
+            ReservationWithWaitingOrder saved = reservationRepository.save(reservation);
+            log.info("예약 생성 완료: reservationId={}, reserverName={}, date={}, timeId={}, themeId={}, status={}",
+                    saved.id(), saved.reserverName(), saved.date(), command.timeId(), command.themeId(), saved.status());
+            return ReservationResult.from(saved);
+        });
     }
 
     private ReservationStatus decideStatus(LocalDate date, Long timeId, Long themeId) {
@@ -92,21 +93,23 @@ public class AdminReservationService {
                     log.warn("존재하지 않는 예약 취소 시도: reservationId={}", id);
                     return new ReservationNotFoundException("존재하지 않는 예약입니다: reservationId=" + id);
                 });
-        reservationRepository.lockTheme(reservation.getTheme().getId());
-        Reservation current = reservationRepository.findById(id)
-                .orElseThrow(() -> new ReservationNotFoundException(
-                        "존재하지 않는 예약입니다: reservationId=" + id));
-        if (current.isCanceled()) {
-            return;
-        }
-        reservationRepository.cancel(current.getId());
-        if (current.isConfirmed()) {
-            boolean promoted = reservationRepository.promoteEarliestWaiting(
-                    current.getDate(),
-                    current.getTime().getId(),
-                    current.getTheme().getId()
-            );
-            log.info("예약 취소 후 승급 처리: reservationId={}, promoted={}", current.getId(), promoted);
-        }
+        reservationRepository.executeWithThemeLock(reservation.getTheme().getId(), lockedTheme -> {
+            Reservation current = reservationRepository.findById(id)
+                    .orElseThrow(() -> new ReservationNotFoundException(
+                            "존재하지 않는 예약입니다: reservationId=" + id));
+            if (current.isCanceled()) {
+                return null;
+            }
+            reservationRepository.cancel(current.getId());
+            if (current.isConfirmed()) {
+                boolean promoted = reservationRepository.promoteEarliestWaiting(
+                        current.getDate(),
+                        current.getTime().getId(),
+                        current.getTheme().getId()
+                );
+                log.info("예약 취소 후 승급 처리: reservationId={}, promoted={}", current.getId(), promoted);
+            }
+            return null;
+        });
     }
 }

--- a/src/main/java/roomescape/service/ThemeService.java
+++ b/src/main/java/roomescape/service/ThemeService.java
@@ -2,6 +2,7 @@ package roomescape.service;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.Theme;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ThemeRepository;
@@ -42,15 +43,19 @@ public class ThemeService {
         return ThemeResult.from(saved);
     }
 
+    @Transactional
     public void delete(Long id) {
         if (!themeRepository.existsById(id)) {
             throw new ThemeNotFoundException("존재하지 않는 테마입니다: themeId=" + id);
         }
-        if (reservationRepository.existsByThemeId(id)) {
-            throw new ThemeInUseException(
-                    "예약이 존재하는 테마는 삭제할 수 없습니다: themeId=" + id);
-        }
-        themeRepository.deleteById(id);
+        reservationRepository.executeWithThemeLock(id, (lockedTheme, writer) -> {
+            if (reservationRepository.existsByThemeId(id)) {
+                throw new ThemeInUseException(
+                        "예약이 존재하는 테마는 삭제할 수 없습니다: themeId=" + id);
+            }
+            themeRepository.deleteById(id);
+            return null;
+        });
     }
 
     public List<PopularThemeResult> findPopular() {

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -86,35 +86,37 @@ public class UserReservationService {
                 });
         validateNotPast(command.date(), newTime.getStartAt(), "과거 시점으로 변경할 수 없습니다");
         Long themeId = reservation.getTheme().getId();
-        reservationRepository.lockTheme(themeId);
-        validateNoConflict(command, themeId);
 
-        LocalDate oldDate = reservation.getDate();
-        Long oldTimeId = reservation.getTime().getId();
-        boolean slotChanged = !(oldDate.equals(command.date()) && oldTimeId.equals(command.timeId()));
-        boolean wasConfirmed = reservation.isConfirmed();
+        return reservationRepository.executeWithThemeLock(themeId, lockedTheme -> {
+            validateNoConflict(command, themeId);
 
-        ReservationStatus newStatus = reservation.getStatus();
-        if (slotChanged) {
-            newStatus = reservationRepository.existsActiveConfirmed(command.date(), command.timeId(), themeId)
-                    ? ReservationStatus.WAITING
-                    : ReservationStatus.CONFIRMED;
-        }
+            LocalDate oldDate = reservation.getDate();
+            Long oldTimeId = reservation.getTime().getId();
+            boolean slotChanged = !(oldDate.equals(command.date()) && oldTimeId.equals(command.timeId()));
+            boolean wasConfirmed = reservation.isConfirmed();
 
-        Reservation updated = new Reservation(
-                reservation.getId(),
-                reservation.getReserverName(),
-                command.date(),
-                newTime,
-                reservation.getTheme(),
-                newStatus
-        );
-        var result = reservationRepository.update(updated);
+            ReservationStatus newStatus = reservation.getStatus();
+            if (slotChanged) {
+                newStatus = reservationRepository.existsActiveConfirmed(command.date(), command.timeId(), themeId)
+                        ? ReservationStatus.WAITING
+                        : ReservationStatus.CONFIRMED;
+            }
 
-        if (slotChanged && wasConfirmed) {
-            reservationRepository.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
-        }
-        return ReservationResult.from(result);
+            Reservation updated = new Reservation(
+                    reservation.getId(),
+                    reservation.getReserverName(),
+                    command.date(),
+                    newTime,
+                    reservation.getTheme(),
+                    newStatus
+            );
+            var result = reservationRepository.update(updated);
+
+            if (slotChanged && wasConfirmed) {
+                reservationRepository.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
+            }
+            return ReservationResult.from(result);
+        });
     }
 
     private Reservation findReservation(Long id) {

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
@@ -110,7 +111,12 @@ public class UserReservationService {
                     reservation.getTheme(),
                     newStatus
             );
-            var result = writer.update(updated);
+            ReservationWithWaitingOrder result;
+            if (slotChanged) {
+                result = writer.updateAndRequeue(updated);
+            } else {
+                result = writer.update(updated);
+            }
 
             if (slotChanged && wasConfirmed) {
                 writer.promoteEarliestWaiting(oldDate, oldTimeId, themeId);

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -87,7 +87,7 @@ public class UserReservationService {
         validateNotPast(command.date(), newTime.getStartAt(), "과거 시점으로 변경할 수 없습니다");
         Long themeId = reservation.getTheme().getId();
 
-        return reservationRepository.executeWithThemeLock(themeId, lockedTheme -> {
+        return reservationRepository.executeWithThemeLock(themeId, (lockedTheme, writer) -> {
             validateNoConflict(command, themeId);
 
             LocalDate oldDate = reservation.getDate();
@@ -110,10 +110,10 @@ public class UserReservationService {
                     reservation.getTheme(),
                     newStatus
             );
-            var result = reservationRepository.update(updated);
+            var result = writer.update(updated);
 
             if (slotChanged && wasConfirmed) {
-                reservationRepository.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
+                writer.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
             }
             return ReservationResult.from(result);
         });

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -86,21 +86,26 @@ public class UserReservationService {
                             "존재하지 않는 시간입니다: timeId=" + command.timeId());
                 });
         validateNotPast(command.date(), newTime.getStartAt(), "과거 시점으로 변경할 수 없습니다");
-        Long themeId = reservation.getTheme().getId();
 
+        boolean slotChanged = !(reservation.getDate().equals(command.date())
+                && reservation.getTime().getId().equals(command.timeId()));
+        if (!slotChanged) {
+            return ReservationResult.from(loadWithWaitingOrder(command.id()));
+        }
+
+        Long themeId = reservation.getTheme().getId();
         return reservationRepository.executeWithThemeLock(themeId, (lockedTheme, writer) -> {
             validateNoConflict(command, themeId);
 
             LocalDate oldDate = reservation.getDate();
             Long oldTimeId = reservation.getTime().getId();
-            boolean slotChanged = !(oldDate.equals(command.date()) && oldTimeId.equals(command.timeId()));
             boolean wasConfirmed = reservation.isConfirmed();
 
-            ReservationStatus newStatus = reservation.getStatus();
-            if (slotChanged) {
-                newStatus = reservationRepository.existsActiveConfirmed(command.date(), command.timeId(), themeId)
-                        ? ReservationStatus.WAITING
-                        : ReservationStatus.CONFIRMED;
+            ReservationStatus newStatus;
+            if (reservationRepository.existsActiveConfirmed(command.date(), command.timeId(), themeId)) {
+                newStatus = ReservationStatus.WAITING;
+            } else {
+                newStatus = ReservationStatus.CONFIRMED;
             }
 
             Reservation updated = new Reservation(
@@ -111,18 +116,19 @@ public class UserReservationService {
                     reservation.getTheme(),
                     newStatus
             );
-            ReservationWithWaitingOrder result;
-            if (slotChanged) {
-                result = writer.updateAndRequeue(updated);
-            } else {
-                result = writer.update(updated);
-            }
+            ReservationWithWaitingOrder result = writer.updateAndRequeue(updated);
 
-            if (slotChanged && wasConfirmed) {
+            if (wasConfirmed) {
                 writer.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
             }
             return ReservationResult.from(result);
         });
+    }
+
+    private ReservationWithWaitingOrder loadWithWaitingOrder(Long id) {
+        return reservationRepository.findWithWaitingOrderById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(
+                        "존재하지 않는 예약입니다: reservationId=" + id));
     }
 
     private Reservation findReservation(Long id) {

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
@@ -63,7 +64,7 @@ public class UserReservationService {
                 reservation.getTime().getStartAt(),
                 "과거 예약은 취소할 수 없습니다"
         );
-        reservationRepository.deleteById(id);
+        reservationService.cancel(reservation);
     }
 
     public ReservationResult update(ReservationUpdateCommand command) {
@@ -82,16 +83,35 @@ public class UserReservationService {
                             "존재하지 않는 시간입니다: timeId=" + command.timeId());
                 });
         validateNotPast(command.date(), newTime.getStartAt(), "과거 시점으로 변경할 수 없습니다");
-        validateNoConflict(command, reservation.getTheme().getId());
+        Long themeId = reservation.getTheme().getId();
+        validateNoConflict(command, themeId);
+
+        LocalDate oldDate = reservation.getDate();
+        Long oldTimeId = reservation.getTime().getId();
+        boolean slotChanged = !(oldDate.equals(command.date()) && oldTimeId.equals(command.timeId()));
+        boolean wasConfirmed = reservation.isConfirmed();
+
+        ReservationStatus newStatus = reservation.getStatus();
+        if (slotChanged) {
+            newStatus = reservationRepository.existsActiveConfirmed(command.date(), command.timeId(), themeId)
+                    ? ReservationStatus.WAITING
+                    : ReservationStatus.CONFIRMED;
+        }
 
         Reservation updated = new Reservation(
                 reservation.getId(),
                 reservation.getReserverName(),
                 command.date(),
                 newTime,
-                reservation.getTheme()
+                reservation.getTheme(),
+                newStatus
         );
-        return ReservationResult.from(reservationRepository.update(updated));
+        var result = reservationRepository.update(updated);
+
+        if (slotChanged && wasConfirmed) {
+            reservationRepository.promoteEarliestWaiting(oldDate, oldTimeId, themeId);
+        }
+        return ReservationResult.from(result);
     }
 
     private Reservation findReservation(Long id) {

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -65,7 +65,7 @@ public class UserReservationService {
                 reservation.getTime().getStartAt(),
                 "과거 예약은 취소할 수 없습니다"
         );
-        reservationService.cancel(reservation);
+        reservationService.cancel(id);
     }
 
     @Transactional

--- a/src/main/java/roomescape/service/UserReservationService.java
+++ b/src/main/java/roomescape/service/UserReservationService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
@@ -67,6 +68,7 @@ public class UserReservationService {
         reservationService.cancel(reservation);
     }
 
+    @Transactional
     public ReservationResult update(ReservationUpdateCommand command) {
         Reservation reservation = findReservation(command.id());
         validateOwner(reservation, command.reserverName());
@@ -84,6 +86,7 @@ public class UserReservationService {
                 });
         validateNotPast(command.date(), newTime.getStartAt(), "과거 시점으로 변경할 수 없습니다");
         Long themeId = reservation.getTheme().getId();
+        reservationRepository.lockTheme(themeId);
         validateNoConflict(command, themeId);
 
         LocalDate oldDate = reservation.getDate();

--- a/src/main/java/roomescape/service/dto/ReservationResult.java
+++ b/src/main/java/roomescape/service/dto/ReservationResult.java
@@ -22,7 +22,7 @@ public record ReservationResult(
                 ReservationTimeResult.from(reservation.time()),
                 ThemeResult.from(reservation.theme()),
                 waitingOrder.value(),
-                waitingOrder.status()
+                reservation.status()
         );
     }
 }

--- a/src/main/java/roomescape/service/dto/ReservationResult.java
+++ b/src/main/java/roomescape/service/dto/ReservationResult.java
@@ -2,6 +2,7 @@ package roomescape.service.dto;
 
 import java.time.LocalDate;
 import roomescape.domain.ReservationStatus;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.domain.WaitingOrder;
 
 public record ReservationResult(

--- a/src/main/java/roomescape/service/dto/ReservationWithWaitingOrder.java
+++ b/src/main/java/roomescape/service/dto/ReservationWithWaitingOrder.java
@@ -1,6 +1,7 @@
 package roomescape.service.dto;
 
 import java.time.LocalDate;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
@@ -10,5 +11,6 @@ public record ReservationWithWaitingOrder(Long id,
                                           LocalDate date,
                                           ReservationTime time,
                                           Theme theme,
+                                          ReservationStatus status,
                                           WaitingOrder waitingOrder) {
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -208,29 +208,42 @@ VALUES ('user5', DATEADD('DAY', 12, CURRENT_DATE), 5, 1);
 -- 인기 슬롯: 동일 (날짜+시간+테마)에 여러 유저 예약 (대기열 테스트용)
 -- ============================================
 
--- 슬롯 A: 내일 15:00 무인도 탈출 (theme_id=1)
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user2', DATEADD('DAY', 1, CURRENT_DATE), 6, 1);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user6', DATEADD('DAY', 1, CURRENT_DATE), 6, 1);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user11', DATEADD('DAY', 1, CURRENT_DATE), 6, 1);
+-- 각 슬롯: 먼저 줄 선 1명이 확정(CONFIRMED), 나머지는 대기(WAITING).
+-- enqueued_at을 1초씩 늦춰 대기 순번이 결정적으로 정해지게 한다.
 
--- 슬롯 B: 7일 후 14:00 도시 탈출 (theme_id=2)
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user3', DATEADD('DAY', 7, CURRENT_DATE), 5, 2);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user8', DATEADD('DAY', 7, CURRENT_DATE), 5, 2);
+-- 슬롯 A: 내일 15:00 무인도 탈출 (theme_id=1) — 확정 1 + 대기 2
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user2', DATEADD('DAY', 1, CURRENT_DATE), 6, 1, 'CONFIRMED', DATEADD('SECOND', 0, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user6', DATEADD('DAY', 1, CURRENT_DATE), 6, 1, 'WAITING', DATEADD('SECOND', 1, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user11', DATEADD('DAY', 1, CURRENT_DATE), 6, 1, 'WAITING', DATEADD('SECOND', 2, CURRENT_TIMESTAMP));
 
--- 슬롯 C: 3일 후 15:00 열기구 탈출 (theme_id=3)
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user14', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user17', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user20', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
-INSERT INTO reservation (reserver_name, date, time_id, theme_id)
-VALUES ('user24', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
+-- 슬롯 B: 7일 후 14:00 도시 탈출 (theme_id=2) — 확정 1 + 대기 1
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user3', DATEADD('DAY', 7, CURRENT_DATE), 5, 2, 'CONFIRMED', DATEADD('SECOND', 0, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user8', DATEADD('DAY', 7, CURRENT_DATE), 5, 2, 'WAITING', DATEADD('SECOND', 1, CURRENT_TIMESTAMP));
+
+-- 슬롯 C: 3일 후 15:00 열기구 탈출 (theme_id=3) — 확정 1 + 대기 3
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user14', DATEADD('DAY', 3, CURRENT_DATE), 6, 3, 'CONFIRMED', DATEADD('SECOND', 0, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user17', DATEADD('DAY', 3, CURRENT_DATE), 6, 3, 'WAITING', DATEADD('SECOND', 1, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user20', DATEADD('DAY', 3, CURRENT_DATE), 6, 3, 'WAITING', DATEADD('SECOND', 2, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user24', DATEADD('DAY', 3, CURRENT_DATE), 6, 3, 'WAITING', DATEADD('SECOND', 3, CURRENT_TIMESTAMP));
+
+-- 슬롯 D: 2일 후 13:00 도시 탈출 (theme_id=2) — 확정 1 + 대기 3 (긴 대기열)
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user7', DATEADD('DAY', 2, CURRENT_DATE), 4, 2, 'CONFIRMED', DATEADD('SECOND', 0, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user1', DATEADD('DAY', 2, CURRENT_DATE), 4, 2, 'WAITING', DATEADD('SECOND', 1, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user5', DATEADD('DAY', 2, CURRENT_DATE), 4, 2, 'WAITING', DATEADD('SECOND', 2, CURRENT_TIMESTAMP));
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at)
+VALUES ('user9', DATEADD('DAY', 2, CURRENT_DATE), 4, 2, 'WAITING', DATEADD('SECOND', 3, CURRENT_TIMESTAMP));
 
 -- 취소된 예약 데이터 (soft delete / 내 예약 취소 이력 표시 확인용)
 INSERT INTO reservation (reserver_name, date, time_id, theme_id, status)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -231,3 +231,14 @@ INSERT INTO reservation (reserver_name, date, time_id, theme_id)
 VALUES ('user20', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
 INSERT INTO reservation (reserver_name, date, time_id, theme_id)
 VALUES ('user24', DATEADD('DAY', 3, CURRENT_DATE), 6, 3);
+
+-- 취소된 예약 데이터 (soft delete / 내 예약 취소 이력 표시 확인용)
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status)
+VALUES ('user1', DATEADD('DAY', 2, CURRENT_DATE), 3, 2, 'CANCELED');
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status)
+VALUES ('user1', DATEADD('DAY', 4, CURRENT_DATE), 5, 1, 'CANCELED');
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status)
+VALUES ('user2', DATEADD('DAY', 2, CURRENT_DATE), 4, 2, 'CANCELED');
+-- 과거(최근 7일 내) 취소 건: 인기 테마 집계에서 제외되는지 확인용
+INSERT INTO reservation (reserver_name, date, time_id, theme_id, status)
+VALUES ('user5', DATEADD('DAY', -3, CURRENT_DATE), 1, 1, 'CANCELED');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -23,10 +23,11 @@ CREATE TABLE reservation (
                              date    DATE NOT NULL,
                              time_id BIGINT NOT NULL,
                              theme_id BIGINT NOT NULL,
+                             status VARCHAR(20) NOT NULL DEFAULT 'CONFIRMED',
+                             enqueued_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                              updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                              PRIMARY KEY (id),
                              FOREIGN KEY (time_id) REFERENCES reservation_time (id),
-                             FOREIGN KEY (theme_id) REFERENCES theme (id),
-                             UNIQUE (reserver_name, date, time_id, theme_id)
+                             FOREIGN KEY (theme_id) REFERENCES theme (id)
 );

--- a/src/main/resources/static/my-reservations.html
+++ b/src/main/resources/static/my-reservations.html
@@ -217,6 +217,15 @@
             color: #86868b;
         }
 
+        .status-canceled {
+            background: #fff0f0;
+            color: #ff3b30;
+        }
+
+        .res-card.canceled {
+            opacity: 0.6;
+        }
+
         .res-when {
             margin: 0;
             color: #666;
@@ -306,6 +315,9 @@
     }
 
     function statusBadge(status, waitingOrder, past) {
+        if (status === 'CANCELED') {
+            return '<span class="status-badge status-canceled">취소됨</span>';
+        }
         if (past) {
             return '<span class="status-badge status-past">지난 예약</span>';
         }
@@ -321,12 +333,14 @@
 
     function cardHtml(r) {
         const past = isPast(r.date, r.time.startAt);
-        const actions = past ? '' : `
+        const canceled = r.status === 'CANCELED';
+        const locked = past || canceled;
+        const actions = locked ? '' : `
                     <div class="res-actions">
                         <button class="btn btn-light btn-edit">변경</button>
                         <button class="btn btn-danger btn-cancel">취소</button>
                     </div>`;
-        const editForm = past ? '' : `
+        const editForm = locked ? '' : `
                 <div class="res-edit hidden">
                     <p class="step-label">새 날짜</p>
                     <input type="date" class="edit-date">
@@ -337,7 +351,7 @@
                     <button class="submit-btn btn-save" disabled>변경 저장</button>
                 </div>`;
         return `
-            <div class="res-card" data-id="${r.id}" data-theme-id="${r.theme.id}">
+            <div class="res-card${canceled ? ' canceled' : ''}" data-id="${r.id}" data-theme-id="${r.theme.id}">
                 <div class="res-head">
                     <div>
                         <p class="res-theme">${r.theme.name} ${statusBadge(r.status, r.waitingOrder, past)}</p>

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -20,17 +20,18 @@ class ReservationTest {
             "갯벌이 많은 무인도를 탈출하는 흥미진진 대탈출!",
             "https://picsum.photos/seed/roomescape1/800/600.jpg"
     );
+    private static final ReservationStatus VALID_STATUS = ReservationStatus.CONFIRMED;
 
     @Test
     @DisplayName("이름,날짜,시간이 모두 유효하면 예약을 생성한다")
     void 이름_날짜_시간이_모두_유효하면_예약을_생성한다() {
-        assertDoesNotThrow(() -> new Reservation(1L, "브라운", VALID_DATE, VALID_TIME, VALID_THEME));
+        assertDoesNotThrow(() -> new Reservation(1L, "브라운", VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS));
     }
 
     @Test
     @DisplayName("id가 null이어도 예약을 생성할 수 있다")
     void id가_null이어도_예약을_생성할_수_있다() {
-        assertDoesNotThrow(() -> new Reservation(null, "브라운", VALID_DATE, VALID_TIME, VALID_THEME));
+        assertDoesNotThrow(() -> new Reservation(null, "브라운", VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS));
     }
 
     @Test
@@ -38,7 +39,7 @@ class ReservationTest {
     void throwWhenNameIsNull() {
         DomainValidationException exception = assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, null, VALID_DATE, VALID_TIME, VALID_THEME)
+                () -> new Reservation(1L, null, VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS)
         );
         assertEquals("예약자 이름은 비어 있을 수 없습니다.", exception.getMessage());
     }
@@ -48,7 +49,7 @@ class ReservationTest {
     void 이름이_빈문자열이면_예외가_발생한다() {
         assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, "", VALID_DATE, VALID_TIME, VALID_THEME)
+                () -> new Reservation(1L, "", VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS)
         );
     }
 
@@ -57,7 +58,7 @@ class ReservationTest {
     void 이름이_공백만으로_이루어져_있으면_예외가_발생한다() {
         assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, "   ", VALID_DATE, VALID_TIME, VALID_THEME)
+                () -> new Reservation(1L, "   ", VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS)
         );
     }
 
@@ -67,7 +68,7 @@ class ReservationTest {
         String name = "밥".repeat(31);
         DomainValidationException exception = assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, name, VALID_DATE, VALID_TIME, VALID_THEME)
+                () -> new Reservation(1L, name, VALID_DATE, VALID_TIME, VALID_THEME, VALID_STATUS)
         );
         assertEquals("예약자 이름은 30자를 초과할 수 없습니다.", exception.getMessage());
     }
@@ -77,7 +78,7 @@ class ReservationTest {
     void 날짜가_null이면_예외가_발생한다() {
         DomainValidationException exception = assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, "브라운", null, VALID_TIME, VALID_THEME)
+                () -> new Reservation(1L, "브라운", null, VALID_TIME, VALID_THEME, VALID_STATUS)
         );
         assertEquals("예약 날짜는 비어 있을 수 없습니다.", exception.getMessage());
     }
@@ -87,7 +88,7 @@ class ReservationTest {
     void 시간이_null이면_예외가_발생한다() {
         DomainValidationException exception = assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, "브라운", VALID_DATE, null, VALID_THEME)
+                () -> new Reservation(1L, "브라운", VALID_DATE, null, VALID_THEME, VALID_STATUS)
         );
         assertEquals("예약 시간은 비어 있을 수 없습니다.", exception.getMessage());
     }
@@ -97,8 +98,18 @@ class ReservationTest {
     void 테마가_null이면_예외가_발생한다() {
         DomainValidationException exception = assertThrows(
                 DomainValidationException.class,
-                () -> new Reservation(1L, "브라운", VALID_DATE, VALID_TIME, null)
+                () -> new Reservation(1L, "브라운", VALID_DATE, VALID_TIME, null, VALID_STATUS)
         );
         assertEquals("예약 테마는 비어 있을 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("상태가 null이면 예외가 발생한다")
+    void 상태가_null이면_예외가_발생한다() {
+        DomainValidationException exception = assertThrows(
+                DomainValidationException.class,
+                () -> new Reservation(1L, "브라운", VALID_DATE, VALID_TIME, VALID_THEME, null)
+        );
+        assertEquals("예약 상태는 비어 있을 수 없습니다.", exception.getMessage());
     }
 }

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -264,13 +264,33 @@ class JdbcReservationRepositoryTest {
                 ReservationStatus.CONFIRMED, now.minusSeconds(10));
         insertReservation("user2", DATE, time13, theme, ReservationStatus.CONFIRMED, now.minusSeconds(5));
 
-        reservationRepository.update(new Reservation(user1.getId(), "user1", DATE, time13, theme,
+        reservationRepository.updateAndRequeue(new Reservation(user1.getId(), "user1", DATE, time13, theme,
                 ReservationStatus.WAITING));
 
         long user2Order = reservationRepository.findByReserverName("user2").getFirst().waitingOrder().value();
         long user1Order = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
         assertThat(user2Order).isEqualTo(0L);
         assertThat(user1Order).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("update는 enqueued_at을 보존하여 대기 순번이 유지된다")
+    void update는_대기_순번을_유지한다() {
+        ReservationTime time = insertTime(LocalTime.of(10, 0));
+        Theme theme = insertTheme("무인도 탈출");
+        Instant base = Instant.now().minusSeconds(10);
+        insertReservation("confirmed", DATE, time, theme, ReservationStatus.CONFIRMED, base);
+        Reservation user1 = insertReservation("user1", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(1));
+        insertReservation("user2", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(2));
+
+        long before = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
+        assertThat(before).isEqualTo(1L);
+
+        reservationRepository.update(new Reservation(user1.getId(), "user1", DATE, time, theme,
+                ReservationStatus.WAITING));
+
+        long after = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
+        assertThat(after).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -104,18 +104,6 @@ class JdbcReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("id로 예약을 삭제한다")
-    void deleteById() {
-        ReservationTime time = insertTime(LocalTime.of(10, 0));
-        Theme theme = insertTheme("무인도 탈출");
-        Reservation saved = insertReservation("브라운", DATE, time, theme);
-
-        reservationRepository.deleteById(saved.getId());
-
-        assertThat(reservationRepository.findById(saved.getId())).isEmpty();
-    }
-
-    @Test
     @DisplayName("취소(soft delete)하면 행은 남고 상태가 CANCELED가 된다")
     void cancel() {
         ReservationTime time = insertTime(LocalTime.of(10, 0));

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -96,7 +96,7 @@ class JdbcReservationRepositoryTest {
         Reservation saved = insertReservation("브라운", DATE, time, theme);
 
         LocalDate newDate = LocalDate.of(2099, 1, 1);
-        reservationRepository.update(
+        reservationRepository.updateAndRequeue(
                 new Reservation(saved.getId(), "브라운", newDate, time, theme, ReservationStatus.CONFIRMED));
 
         Reservation updated = reservationRepository.findById(saved.getId()).orElseThrow();
@@ -271,26 +271,6 @@ class JdbcReservationRepositoryTest {
         long user1Order = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
         assertThat(user2Order).isEqualTo(0L);
         assertThat(user1Order).isEqualTo(1L);
-    }
-
-    @Test
-    @DisplayName("update는 enqueued_at을 보존하여 대기 순번이 유지된다")
-    void update는_대기_순번을_유지한다() {
-        ReservationTime time = insertTime(LocalTime.of(10, 0));
-        Theme theme = insertTheme("무인도 탈출");
-        Instant base = Instant.now().minusSeconds(10);
-        insertReservation("confirmed", DATE, time, theme, ReservationStatus.CONFIRMED, base);
-        Reservation user1 = insertReservation("user1", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(1));
-        insertReservation("user2", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(2));
-
-        long before = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
-        assertThat(before).isEqualTo(1L);
-
-        reservationRepository.update(new Reservation(user1.getId(), "user1", DATE, time, theme,
-                ReservationStatus.WAITING));
-
-        long after = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
-        assertThat(after).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -19,7 +19,7 @@ import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 
 @JdbcTest
 @Import(JdbcReservationRepository.class)

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -56,7 +56,7 @@ class JdbcReservationRepositoryTest {
         insertReservation("브라운", DATE, time, theme);
         insertReservation("리사", DATE, time, theme);
 
-        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAll();
+        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAllActive();
 
         assertThat(reservations).hasSize(2);
     }
@@ -70,7 +70,7 @@ class JdbcReservationRepositoryTest {
         Reservation canceled = insertReservation("리사", DATE, time, theme,
                 ReservationStatus.CANCELED, Instant.now());
 
-        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAll();
+        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAllActive();
 
         assertThat(reservations)
                 .extracting(ReservationWithWaitingOrder::id)

--- a/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcReservationRepositoryTest.java
@@ -1,7 +1,6 @@
 package roomescape.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -13,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
@@ -42,10 +41,11 @@ class JdbcReservationRepositoryTest {
         Theme theme = insertTheme("무인도 탈출");
 
         ReservationWithWaitingOrder saved = reservationRepository.save(
-                new Reservation(null, "브라운", DATE, time, theme));
+                new Reservation(null, "브라운", DATE, time, theme, ReservationStatus.CONFIRMED));
 
         assertThat(saved.id()).isNotNull();
         assertThat(saved.reserverName()).isEqualTo("브라운");
+        assertThat(saved.status()).isEqualTo(ReservationStatus.CONFIRMED);
     }
 
     @Test
@@ -59,6 +59,22 @@ class JdbcReservationRepositoryTest {
         List<ReservationWithWaitingOrder> reservations = reservationRepository.findAll();
 
         assertThat(reservations).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("취소된 예약은 전체 조회에서 제외된다")
+    void findAllExcludesCanceled() {
+        ReservationTime time = insertTime(LocalTime.of(10, 0));
+        Theme theme = insertTheme("무인도 탈출");
+        insertReservation("브라운", DATE, time, theme);
+        Reservation canceled = insertReservation("리사", DATE, time, theme,
+                ReservationStatus.CANCELED, Instant.now());
+
+        List<ReservationWithWaitingOrder> reservations = reservationRepository.findAll();
+
+        assertThat(reservations)
+                .extracting(ReservationWithWaitingOrder::id)
+                .doesNotContain(canceled.getId());
     }
 
     @Test
@@ -81,7 +97,7 @@ class JdbcReservationRepositoryTest {
 
         LocalDate newDate = LocalDate.of(2099, 1, 1);
         reservationRepository.update(
-                new Reservation(saved.getId(), "브라운", newDate, time, theme));
+                new Reservation(saved.getId(), "브라운", newDate, time, theme, ReservationStatus.CONFIRMED));
 
         Reservation updated = reservationRepository.findById(saved.getId()).orElseThrow();
         assertThat(updated.getDate()).isEqualTo(newDate);
@@ -100,14 +116,44 @@ class JdbcReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("id 존재 여부를 확인한다")
-    void existsById() {
+    @DisplayName("취소(soft delete)하면 행은 남고 상태가 CANCELED가 된다")
+    void cancel() {
         ReservationTime time = insertTime(LocalTime.of(10, 0));
         Theme theme = insertTheme("무인도 탈출");
         Reservation saved = insertReservation("브라운", DATE, time, theme);
 
-        assertThat(reservationRepository.existsById(saved.getId())).isTrue();
-        assertThat(reservationRepository.existsById(999L)).isFalse();
+        reservationRepository.cancel(saved.getId());
+
+        Reservation canceled = reservationRepository.findById(saved.getId()).orElseThrow();
+        assertThat(canceled.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("슬롯에 활성 확정 예약이 있는지 확인한다")
+    void existsActiveConfirmed() {
+        ReservationTime time = insertTime(LocalTime.of(10, 0));
+        Theme theme = insertTheme("무인도 탈출");
+        insertReservation("브라운", DATE, time, theme, ReservationStatus.CONFIRMED, Instant.now());
+
+        assertThat(reservationRepository.existsActiveConfirmed(DATE, time.getId(), theme.getId())).isTrue();
+        assertThat(reservationRepository.existsActiveConfirmed(
+                LocalDate.of(2099, 1, 1), time.getId(), theme.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("확정 취소 후 첫 대기자를 승급한다")
+    void promoteEarliestWaiting() {
+        ReservationTime time = insertTime(LocalTime.of(10, 0));
+        Theme theme = insertTheme("무인도 탈출");
+        Instant base = Instant.now();
+        insertReservation("루드비코", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(1));
+        Reservation earlier = insertReservation("모아", DATE, time, theme, ReservationStatus.WAITING, base);
+
+        boolean promoted = reservationRepository.promoteEarliestWaiting(DATE, time.getId(), theme.getId());
+
+        assertThat(promoted).isTrue();
+        assertThat(reservationRepository.findById(earlier.getId()).orElseThrow().getStatus())
+                .isEqualTo(ReservationStatus.CONFIRMED);
     }
 
     @Test
@@ -122,6 +168,17 @@ class JdbcReservationRepositoryTest {
                 .isTrue();
         assertThat(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 "브라운", LocalDate.of(2099, 1, 1), time.getId(), theme.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("취소된 예약은 중복 검사에서 제외된다")
+    void existsByReserverNameExcludesCanceled() {
+        ReservationTime time = insertTime(LocalTime.of(10, 0));
+        Theme theme = insertTheme("무인도 탈출");
+        insertReservation("브라운", DATE, time, theme, ReservationStatus.CANCELED, Instant.now());
+
+        assertThat(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
+                "브라운", DATE, time.getId(), theme.getId())).isFalse();
     }
 
     @Test
@@ -163,42 +220,29 @@ class JdbcReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("앞에 존재하는 예약 수에 따라 적절한 대기 순번을 부여한다")
+    @DisplayName("확정은 0번, 대기는 앞에 있는 활성 예약 수만큼 순번을 부여한다")
     void findByReserverName() {
         ReservationTime time = insertTime(LocalTime.of(10, 0));
         Theme theme = insertTheme("무인도 탈출");
         Instant base = Instant.now();
-        Reservation first = insertReservationWithUpdatedAt("루드비코", DATE, time, theme, base);
-        Reservation second = insertReservationWithUpdatedAt("모아", DATE, time, theme, base.plusSeconds(1));
-        Reservation third = insertReservationWithUpdatedAt("브라운", DATE, time, theme, base.plusSeconds(2));
+        Reservation first = insertReservation("루드비코", DATE, time, theme, ReservationStatus.CONFIRMED, base);
+        Reservation second = insertReservation("모아", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(1));
+        Reservation third = insertReservation("브라운", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(2));
 
         assertThat(reservationRepository.findByReserverName("루드비코"))
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(
-                        new ReservationWithWaitingOrder(first.getId(), "루드비코", DATE, time, theme, new WaitingOrder(0)));
+                .containsExactlyInAnyOrder(new ReservationWithWaitingOrder(
+                        first.getId(), "루드비코", DATE, time, theme, ReservationStatus.CONFIRMED, new WaitingOrder(0)));
 
         assertThat(reservationRepository.findByReserverName("모아"))
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(
-                        new ReservationWithWaitingOrder(second.getId(), "모아", DATE, time, theme, new WaitingOrder(1)));
+                .containsExactlyInAnyOrder(new ReservationWithWaitingOrder(
+                        second.getId(), "모아", DATE, time, theme, ReservationStatus.WAITING, new WaitingOrder(1)));
 
         assertThat(reservationRepository.findByReserverName("브라운"))
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(
-                        new ReservationWithWaitingOrder(third.getId(), "브라운", DATE, time, theme, new WaitingOrder(2)));
-    }
-
-    @Test
-    @DisplayName("같은 사용자는 같은 슬롯에 중복 대기할 수 없다")
-    void 중복_예약을_시도하면_예외를_던진다() {
-        ReservationTime time = insertTime(LocalTime.of(10, 0));
-        Theme theme = insertTheme("무인도 탈출");
-        Instant base = Instant.now();
-        insertReservationWithUpdatedAt("루드비코", DATE, time, theme, base);
-
-        assertThatThrownBy(() -> insertReservationWithUpdatedAt("루드비코", DATE, time, theme, base))
-                .isExactlyInstanceOf(DuplicateKeyException.class);
-
+                .containsExactlyInAnyOrder(new ReservationWithWaitingOrder(
+                        third.getId(), "브라운", DATE, time, theme, ReservationStatus.WAITING, new WaitingOrder(2)));
     }
 
     @Test
@@ -207,21 +251,17 @@ class JdbcReservationRepositoryTest {
         ReservationTime time = insertTime(LocalTime.of(10, 0));
         Theme theme = insertTheme("무인도 탈출");
         Instant base = Instant.now();
-        Reservation reservation1 = insertReservationWithUpdatedAt("루드비코", DATE, time, theme, base);
-        insertReservationWithUpdatedAt("모아", DATE, time, theme, base.plusSeconds(1));
-        insertReservationWithUpdatedAt("브라운", DATE, time, theme, base.plusSeconds(2));
+        Reservation confirmed = insertReservation("루드비코", DATE, time, theme, ReservationStatus.CONFIRMED, base);
+        insertReservation("모아", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(1));
+        insertReservation("브라운", DATE, time, theme, ReservationStatus.WAITING, base.plusSeconds(2));
 
-        List<ReservationWithWaitingOrder> list = reservationRepository.findByReserverName("브라운");
-        long waitingOrder = list.getFirst().waitingOrder().value();
-        assertThat(waitingOrder).isEqualTo(2L);
+        long before = reservationRepository.findByReserverName("브라운").getFirst().waitingOrder().value();
+        assertThat(before).isEqualTo(2L);
 
-        reservationRepository.deleteById(reservation1.getId());
-        assertThat(reservationRepository.findById(reservation1.getId())).isEmpty();
+        reservationRepository.cancel(confirmed.getId());
 
-        List<ReservationWithWaitingOrder> list2 = reservationRepository.findByReserverName("브라운");
-        long waitingOrder2 = list2.getFirst().waitingOrder().value();
-        assertThat(waitingOrder2).isEqualTo(1L);
-
+        long after = reservationRepository.findByReserverName("브라운").getFirst().waitingOrder().value();
+        assertThat(after).isEqualTo(1L);
     }
 
     @Test
@@ -232,14 +272,13 @@ class JdbcReservationRepositoryTest {
         ReservationTime time13 = insertTime(LocalTime.of(13, 0));
         Instant now = Instant.now();
 
-        // user1이 먼저 11시를, user2가 나중에 13시를 예약 (user1.updated_at < user2.updated_at, 둘 다 과거)
-        Reservation user1 = insertReservationWithUpdatedAt("user1", DATE, time11, theme, now.minusSeconds(10));
-        insertReservationWithUpdatedAt("user2", DATE, time13, theme, now.minusSeconds(5));
+        Reservation user1 = insertReservation("user1", DATE, time11, theme,
+                ReservationStatus.CONFIRMED, now.minusSeconds(10));
+        insertReservation("user2", DATE, time13, theme, ReservationStatus.CONFIRMED, now.minusSeconds(5));
 
-        // user1이 user2가 선점한 13시 슬롯으로 변경
-        reservationRepository.update(new Reservation(user1.getId(), "user1", DATE, time13, theme));
+        reservationRepository.update(new Reservation(user1.getId(), "user1", DATE, time13, theme,
+                ReservationStatus.WAITING));
 
-        // user2는 확정(0번), 나중에 끼어든 user1은 대기(1번) 이어야 한다
         long user2Order = reservationRepository.findByReserverName("user2").getFirst().waitingOrder().value();
         long user1Order = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
         assertThat(user2Order).isEqualTo(0L);
@@ -247,22 +286,23 @@ class JdbcReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("updated_at이 동률이면 id가 작은 예약이 확정(0번)이 된다")
-    void updated_at_동률이면_id로_순번을_가른다() {
+    @DisplayName("enqueued_at이 동률이면 id가 작은 대기가 먼저 순번을 받는다")
+    void enqueued_at_동률이면_id로_순번을_가른다() {
         ReservationTime time = insertTime(LocalTime.of(10, 0));
         Theme theme = insertTheme("무인도 탈출");
-        Instant sameInstant = Instant.now().minusSeconds(10);
+        Instant base = Instant.now().minusSeconds(10);
 
-        // 두 예약이 정확히 같은 updated_at을 가져도 한 슬롯에 확정은 1명이어야 한다
-        Reservation first = insertReservationWithUpdatedAt("user1", DATE, time, theme, sameInstant);
-        Reservation second = insertReservationWithUpdatedAt("user2", DATE, time, theme, sameInstant);
+        insertReservation("confirmed", DATE, time, theme, ReservationStatus.CONFIRMED, base);
+        Instant sameInstant = base.plusSeconds(1);
+        Reservation first = insertReservation("user1", DATE, time, theme, ReservationStatus.WAITING, sameInstant);
+        Reservation second = insertReservation("user2", DATE, time, theme, ReservationStatus.WAITING, sameInstant);
 
         long firstOrder = reservationRepository.findByReserverName("user1").getFirst().waitingOrder().value();
         long secondOrder = reservationRepository.findByReserverName("user2").getFirst().waitingOrder().value();
 
         assertThat(first.getId()).isLessThan(second.getId());
-        assertThat(firstOrder).isEqualTo(0L);
-        assertThat(secondOrder).isEqualTo(1L);
+        assertThat(firstOrder).isEqualTo(1L);
+        assertThat(secondOrder).isEqualTo(2L);
     }
 
     private ReservationTime insertTime(LocalTime startAt) {
@@ -281,22 +321,17 @@ class JdbcReservationRepositoryTest {
     }
 
     private Reservation insertReservation(String name, LocalDate date, ReservationTime time, Theme theme) {
-        jdbcTemplate.update(
-                "INSERT INTO reservation (reserver_name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
-                name, date.toString(), time.getId(), theme.getId()
-        );
-        long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Long.class);
-        return new Reservation(id, name, date, time, theme);
+        return insertReservation(name, date, time, theme, ReservationStatus.CONFIRMED, Instant.now());
     }
 
-    private Reservation insertReservationWithUpdatedAt(String name, LocalDate date, ReservationTime time, Theme theme,
-                                                       Instant updatedAt) {
+    private Reservation insertReservation(String name, LocalDate date, ReservationTime time, Theme theme,
+                                          ReservationStatus status, Instant enqueuedAt) {
         jdbcTemplate.update(
-                "INSERT INTO reservation (reserver_name, date, time_id, theme_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-                name, date.toString(), time.getId(), theme.getId(),
-                Timestamp.from(updatedAt), Timestamp.from(updatedAt)
+                "INSERT INTO reservation (reserver_name, date, time_id, theme_id, status, enqueued_at) "
+                        + "VALUES (?, ?, ?, ?, ?, ?)",
+                name, date.toString(), time.getId(), theme.getId(), status.name(), Timestamp.from(enqueuedAt)
         );
         long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Long.class);
-        return new Reservation(id, name, date, time, theme);
+        return new Reservation(id, name, date, time, theme, status);
     }
 }

--- a/src/test/java/roomescape/repository/JdbcThemeRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcThemeRepositoryTest.java
@@ -102,6 +102,22 @@ class JdbcThemeRepositoryTest {
         assertThat(popular.get(0).reservationCount()).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("취소된 예약은 인기 테마 집계에서 제외된다")
+    void findPopularExcludesCanceled() {
+        long themeId = insertTheme("무인도 탈출");
+        long timeId = insertTime(LocalTime.of(10, 0));
+        LocalDate recent = LocalDate.now().minusDays(1);
+        insertReservation("브라운", recent, timeId, themeId, "CONFIRMED");
+        insertReservation("리사", recent, timeId, themeId, "CANCELED");
+        insertReservation("모아", recent, timeId, themeId, "CANCELED");
+
+        List<PopularTheme> popular = themeRepository.findPopular();
+
+        assertThat(popular).hasSize(1);
+        assertThat(popular.get(0).reservationCount()).isEqualTo(1);
+    }
+
     private long insertTheme(String name) {
         jdbcTemplate.update(
                 "INSERT INTO theme (name, description, thumbnail_url) VALUES (?, ?, ?)",
@@ -119,6 +135,13 @@ class JdbcThemeRepositoryTest {
         jdbcTemplate.update(
                 "INSERT INTO reservation (reserver_name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
                 name, date.toString(), timeId, themeId
+        );
+    }
+
+    private void insertReservation(String name, LocalDate date, long timeId, long themeId, String status) {
+        jdbcTemplate.update(
+                "INSERT INTO reservation (reserver_name, date, time_id, theme_id, status) VALUES (?, ?, ?, ?, ?)",
+                name, date.toString(), timeId, themeId, status
         );
     }
 }

--- a/src/test/java/roomescape/service/ReservationCancelRollbackTest.java
+++ b/src/test/java/roomescape/service/ReservationCancelRollbackTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import roomescape.repository.ReservationRepository;
+import roomescape.repository.JdbcReservationRepository;
 import roomescape.service.dto.ReservationCreateCommand;
 
 @SpringBootTest
@@ -25,7 +25,7 @@ class ReservationCancelRollbackTest {
     private AdminReservationService reservationService;
 
     @MockitoSpyBean
-    private ReservationRepository reservationRepository;
+    private JdbcReservationRepository reservationRepository;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/src/test/java/roomescape/service/ReservationCancelRollbackTest.java
+++ b/src/test/java/roomescape/service/ReservationCancelRollbackTest.java
@@ -1,0 +1,72 @@
+package roomescape.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import roomescape.repository.ReservationRepository;
+import roomescape.service.dto.ReservationCreateCommand;
+
+@SpringBootTest
+class ReservationCancelRollbackTest {
+
+    private static final LocalDate DATE = LocalDate.of(2099, 12, 31);
+
+    @Autowired
+    private AdminReservationService reservationService;
+
+    @MockitoSpyBean
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("취소 후 승급 처리가 실패하면 취소까지 함께 롤백된다")
+    void 승급_실패_시_취소가_롤백된다() {
+        long timeId = insertTime();
+        long themeId = insertTheme("롤백테마-취소승급");
+        long confirmedId = reservationService.create(
+                new ReservationCreateCommand("owner", DATE, timeId, themeId)).id();
+        long waiterId = reservationService.create(
+                new ReservationCreateCommand("waiter", DATE, timeId, themeId)).id();
+
+        doThrow(new RuntimeException("승급 실패 시뮬레이션"))
+                .when(reservationRepository).promoteEarliestWaiting(any(LocalDate.class), anyLong(), anyLong());
+
+        assertThatThrownBy(() -> reservationService.cancel(confirmedId))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(statusOf(confirmedId))
+                .as("승급이 실패하면 같은 트랜잭션의 취소도 롤백되어 확정 상태가 유지되어야 한다")
+                .isEqualTo("CONFIRMED");
+        assertThat(statusOf(waiterId))
+                .as("롤백되었으므로 대기자는 승급되지 않고 대기 상태를 유지해야 한다")
+                .isEqualTo("WAITING");
+    }
+
+    private String statusOf(long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reservation WHERE id = ?", String.class, id);
+    }
+
+    private long insertTime() {
+        jdbcTemplate.update("INSERT INTO reservation_time (start_at) VALUES (?)", "10:00");
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation_time", Long.class);
+    }
+
+    private long insertTheme(String name) {
+        jdbcTemplate.update(
+                "INSERT INTO theme (name, description, thumbnail_url) VALUES (?, '설명', 'http://x')", name);
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM theme", Long.class);
+    }
+}

--- a/src/test/java/roomescape/service/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/service/ReservationConcurrencyTest.java
@@ -31,7 +31,7 @@ class ReservationConcurrencyTest {
     @DisplayName("같은 빈 슬롯에 동시에 예약하면 확정은 정확히 1건이어야 한다")
     void 동시에_같은_슬롯을_예약해도_확정은_하나여야_한다() throws InterruptedException {
         long timeId = insertTime();
-        long themeId = insertTheme();
+        long themeId = insertTheme("동시성테마-생성");
 
         ExecutorService pool = Executors.newFixedThreadPool(CONCURRENCY);
         CountDownLatch ready = new CountDownLatch(CONCURRENCY);
@@ -65,6 +65,47 @@ class ReservationConcurrencyTest {
                 .isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("같은 확정 예약을 동시에 취소해도 승급은 한 번만 일어나 확정은 1건을 유지한다")
+    void 동시에_같은_확정예약을_취소해도_확정은_하나여야_한다() throws InterruptedException {
+        long timeId = insertTime();
+        long themeId = insertTheme("동시성테마-취소");
+        long confirmedId = reservationService.create(
+                new ReservationCreateCommand("owner", DATE, timeId, themeId)).id();
+        for (int i = 0; i < 5; i++) {
+            reservationService.create(new ReservationCreateCommand("waiter" + i, DATE, timeId, themeId));
+        }
+
+        int threads = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    reservationService.delete(confirmedId);
+                } catch (Exception ignored) {
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        pool.shutdown();
+
+        int confirmed = countConfirmed(timeId, themeId);
+        assertThat(confirmed)
+                .as("확정 취소 시 첫 대기자 1명만 승급되어야 한다(이중 승급 금지)")
+                .isEqualTo(1);
+    }
+
     private int countConfirmed(long timeId, long themeId) {
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM reservation "
@@ -78,9 +119,9 @@ class ReservationConcurrencyTest {
         return jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation_time", Long.class);
     }
 
-    private long insertTheme() {
+    private long insertTheme(String name) {
         jdbcTemplate.update(
-                "INSERT INTO theme (name, description, thumbnail_url) VALUES ('동시성테마', '설명', 'http://x')");
+                "INSERT INTO theme (name, description, thumbnail_url) VALUES (?, '설명', 'http://x')", name);
         return jdbcTemplate.queryForObject("SELECT MAX(id) FROM theme", Long.class);
     }
 }

--- a/src/test/java/roomescape/service/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/service/ReservationConcurrencyTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.service.dto.ReservationCreateCommand;
+import roomescape.service.dto.ReservationUpdateCommand;
 
 @SpringBootTest
 class ReservationConcurrencyTest {
@@ -23,6 +24,9 @@ class ReservationConcurrencyTest {
 
     @Autowired
     private AdminReservationService reservationService;
+
+    @Autowired
+    private UserReservationService userReservationService;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -106,6 +110,57 @@ class ReservationConcurrencyTest {
                 .isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("빈 슬롯으로의 예약 변경과 신규 예약이 동시에 일어나도 확정은 1건이어야 한다")
+    void 변경_진입과_신규_예약이_경합해도_확정은_하나여야_한다() throws InterruptedException {
+        long fromTimeId = insertTime("10:00");
+        long toTimeId = insertTime("11:00");
+        long themeId = insertTheme("동시성테마-변경경합");
+        long moverId = reservationService.create(
+                new ReservationCreateCommand("mover", DATE, fromTimeId, themeId)).id();
+
+        int creators = 9;
+        int total = creators + 1;
+        ExecutorService pool = Executors.newFixedThreadPool(total);
+        CountDownLatch ready = new CountDownLatch(total);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(total);
+
+        pool.submit(() -> {
+            ready.countDown();
+            try {
+                start.await();
+                userReservationService.update(new ReservationUpdateCommand(moverId, "mover", DATE, toTimeId));
+            } catch (Exception ignored) {
+            } finally {
+                done.countDown();
+            }
+        });
+        for (int i = 0; i < creators; i++) {
+            String name = "newuser" + i;
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    reservationService.create(new ReservationCreateCommand(name, DATE, toTimeId, themeId));
+                } catch (Exception ignored) {
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        pool.shutdown();
+
+        int confirmed = countConfirmed(toTimeId, themeId);
+        assertThat(confirmed)
+                .as("변경 진입과 신규 예약이 경합해도 슬롯 확정은 1건이어야 한다")
+                .isEqualTo(1);
+    }
+
     private int countConfirmed(long timeId, long themeId) {
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM reservation "
@@ -115,7 +170,11 @@ class ReservationConcurrencyTest {
     }
 
     private long insertTime() {
-        jdbcTemplate.update("INSERT INTO reservation_time (start_at) VALUES ('10:00')");
+        return insertTime("10:00");
+    }
+
+    private long insertTime(String startAt) {
+        jdbcTemplate.update("INSERT INTO reservation_time (start_at) VALUES (?)", startAt);
         return jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation_time", Long.class);
     }
 

--- a/src/test/java/roomescape/service/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/service/ReservationConcurrencyTest.java
@@ -91,7 +91,7 @@ class ReservationConcurrencyTest {
                 ready.countDown();
                 try {
                     start.await();
-                    reservationService.delete(confirmedId);
+                    reservationService.cancel(confirmedId);
                 } catch (Exception ignored) {
                 } finally {
                     done.countDown();

--- a/src/test/java/roomescape/service/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/service/ReservationConcurrencyTest.java
@@ -1,0 +1,86 @@
+package roomescape.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import roomescape.service.dto.ReservationCreateCommand;
+
+@SpringBootTest
+class ReservationConcurrencyTest {
+
+    private static final LocalDate DATE = LocalDate.of(2099, 12, 31);
+    private static final int CONCURRENCY = 20;
+
+    @Autowired
+    private AdminReservationService reservationService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("같은 빈 슬롯에 동시에 예약하면 확정은 정확히 1건이어야 한다")
+    void 동시에_같은_슬롯을_예약해도_확정은_하나여야_한다() throws InterruptedException {
+        long timeId = insertTime();
+        long themeId = insertTheme();
+
+        ExecutorService pool = Executors.newFixedThreadPool(CONCURRENCY);
+        CountDownLatch ready = new CountDownLatch(CONCURRENCY);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(CONCURRENCY);
+        AtomicInteger failures = new AtomicInteger();
+
+        for (int i = 0; i < CONCURRENCY; i++) {
+            String name = "user" + i;
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    reservationService.create(new ReservationCreateCommand(name, DATE, timeId, themeId));
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        pool.shutdown();
+
+        int confirmed = countConfirmed(timeId, themeId);
+        assertThat(confirmed)
+                .as("같은 슬롯의 활성 확정 예약은 정원(1)을 넘으면 안 된다")
+                .isEqualTo(1);
+    }
+
+    private int countConfirmed(long timeId, long themeId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation "
+                        + "WHERE date = ? AND time_id = ? AND theme_id = ? AND status = 'CONFIRMED'",
+                Integer.class, Date.valueOf(DATE), timeId, themeId);
+        return count == null ? 0 : count;
+    }
+
+    private long insertTime() {
+        jdbcTemplate.update("INSERT INTO reservation_time (start_at) VALUES ('10:00')");
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation_time", Long.class);
+    }
+
+    private long insertTheme() {
+        jdbcTemplate.update(
+                "INSERT INTO theme (name, description, thumbnail_url) VALUES ('동시성테마', '설명', 'http://x')");
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM theme", Long.class);
+    }
+}

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -25,6 +25,7 @@ import roomescape.domain.ReservationTime;
 import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
+import roomescape.repository.LockedReservationWriter;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeLockedAction;
@@ -45,15 +46,14 @@ class ReservationServiceTest {
             "https://picsum.photos/seed/roomescape1/800/600.jpg"
     );
     private static final LocalDate VALID_RESERVATION_DATE = LocalDate.of(2026, 5, 9);
-    private static final ReservationCreateCommand VALID_COMMAND = new ReservationCreateCommand(
-            "브라운", VALID_RESERVATION_DATE, 1L, 1L
-    );
     private static final ReservationCreateCommand VALID_COMMAND_MOA = new ReservationCreateCommand(
             "모아", VALID_RESERVATION_DATE, 1L, 1L
     );
 
     @Mock
     private ReservationRepository reservationRepository;
+    @Mock
+    private LockedReservationWriter reservationWriter;
     @Mock
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
@@ -63,7 +63,7 @@ class ReservationServiceTest {
         given(reservationRepository.executeWithThemeLock(eq(1L), any()))
                 .willAnswer(invocation -> {
                     ThemeLockedAction<Object> action = invocation.getArgument(1);
-                    return action.execute(lockedTheme);
+                    return action.execute(lockedTheme, reservationWriter);
                 });
     }
 
@@ -98,7 +98,7 @@ class ReservationServiceTest {
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                 .willReturn(false);
-        given(reservationRepository.save(any(Reservation.class))).willReturn(saved);
+        given(reservationWriter.save(any(Reservation.class))).willReturn(saved);
 
         assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
@@ -106,7 +106,7 @@ class ReservationServiceTest {
         verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
-        verify(reservationRepository, times(1)).save(any(Reservation.class));
+        verify(reservationWriter, times(1)).save(any(Reservation.class));
     }
 
     @Test
@@ -164,8 +164,8 @@ class ReservationServiceTest {
 
         verify(reservationRepository, times(2)).findById(1L);
         verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
-        verify(reservationRepository, times(1)).cancel(1L);
-        verify(reservationRepository, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
+        verify(reservationWriter, times(1)).cancel(1L);
+        verify(reservationWriter, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
         verifyNoInteractions(reservationTimeRepository);
     }
 
@@ -181,7 +181,7 @@ class ReservationServiceTest {
             given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                     1L))
                     .willReturn(false);
-            given(reservationRepository.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
+            given(reservationWriter.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
                     1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
                     ReservationStatus.CONFIRMED, new WaitingOrder(0)));
 
@@ -192,7 +192,7 @@ class ReservationServiceTest {
             verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                     VALID_COMMAND_MOA.date(), 1L,
                     1L);
-            verify(reservationRepository, times(1)).save(any(Reservation.class));
+            verify(reservationWriter, times(1)).save(any(Reservation.class));
         }
 
         @Nested
@@ -229,7 +229,7 @@ class ReservationServiceTest {
                         .willReturn(false);
                 given(reservationRepository.existsActiveConfirmed(VALID_COMMAND_MOA.date(), 1L, 1L))
                         .willReturn(true);
-                given(reservationRepository.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
+                given(reservationWriter.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
                         1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
                         ReservationStatus.WAITING, new WaitingOrder(1)));
 
@@ -240,7 +240,7 @@ class ReservationServiceTest {
                 verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                         VALID_COMMAND_MOA.date(), 1L,
                         1L);
-                verify(reservationRepository, times(1)).save(any(Reservation.class));
+                verify(reservationWriter, times(1)).save(any(Reservation.class));
             }
         }
     }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
@@ -42,11 +43,12 @@ class ReservationServiceTest {
             "갯벌이 많은 무인도를 탈출하는 흥미진진 대탈출!",
             "https://picsum.photos/seed/roomescape1/800/600.jpg"
     );
+    private static final LocalDate VALID_RESERVATION_DATE = LocalDate.of(2026, 5, 9);
     private static final ReservationCreateCommand VALID_COMMAND = new ReservationCreateCommand(
-            "브라운", LocalDate.of(2026, 5, 9), 1L, 1L
+            "브라운", VALID_RESERVATION_DATE, 1L, 1L
     );
     private static final ReservationCreateCommand VALID_COMMAND_MOA = new ReservationCreateCommand(
-            "모아", LocalDate.of(2026, 5, 9), 1L, 1L
+            "모아", VALID_RESERVATION_DATE, 1L, 1L
     );
 
     @Mock
@@ -82,7 +84,8 @@ class ReservationServiceTest {
     @DisplayName("충돌이 없으면 정상적으로 예약을 생성한다")
     void 충돌이_없으면_정상적으로_예약을_생성한다() {
         ReservationWithWaitingOrder saved = new ReservationWithWaitingOrder(
-                1L, VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME, new WaitingOrder(0));
+                1L, VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED, new WaitingOrder(0));
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
         given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
@@ -132,26 +135,29 @@ class ReservationServiceTest {
     @Test
     @DisplayName("존재하지 않는 예약을 삭제하면 ReservationNotFoundException이 발생한다")
     void 존재하지_않는_예약_삭제시_예외가_발생한다() {
-        given(reservationRepository.existsById(1L)).willReturn(false);
+        given(reservationRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThrows(
                 ReservationNotFoundException.class,
                 () -> reservationService.delete(1L)
         );
 
-        verify(reservationRepository, times(1)).existsById(1L);
+        verify(reservationRepository, times(1)).findById(1L);
         verifyNoInteractions(reservationTimeRepository, themeRepository);
     }
 
     @Test
-    @DisplayName("존재하는 예약은 정상적으로 삭제된다")
-    void 존재하는_예약은_정상_삭제된다() {
-        given(reservationRepository.existsById(1L)).willReturn(true);
+    @DisplayName("확정 예약을 삭제하면 soft delete 후 첫 대기자를 승급한다")
+    void 확정_예약_삭제시_취소하고_승급한다() {
+        Reservation confirmed = new Reservation(
+                1L, "브라운", VALID_RESERVATION_DATE, VALID_TIME, VALID_THEME, ReservationStatus.CONFIRMED);
+        given(reservationRepository.findById(1L)).willReturn(Optional.of(confirmed));
 
         assertDoesNotThrow(() -> reservationService.delete(1L));
 
-        verify(reservationRepository, times(1)).existsById(1L);
-        verify(reservationRepository, times(1)).deleteById(1L);
+        verify(reservationRepository, times(1)).findById(1L);
+        verify(reservationRepository, times(1)).cancel(1L);
+        verify(reservationRepository, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
         verifyNoInteractions(reservationTimeRepository, themeRepository);
     }
 
@@ -168,7 +174,8 @@ class ReservationServiceTest {
                     1L))
                     .willReturn(false);
             given(reservationRepository.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
-                    1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME, new WaitingOrder(0)));
+                    1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
+                    ReservationStatus.CONFIRMED, new WaitingOrder(0)));
 
             assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
@@ -207,15 +214,16 @@ class ReservationServiceTest {
             @Test
             @DisplayName("기존 예약자와 다른 사용자의 예약 요청이라면 허용한다")
             void 사용자_이름이_다르면_예약_대기_순번을_부여한다() {
-                ReservationWithWaitingOrder saved = new ReservationWithWaitingOrder(
-                        1L, VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME, new WaitingOrder(0));
                 given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
                 given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
                 given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                         1L))
                         .willReturn(false);
+                given(reservationRepository.existsActiveConfirmed(VALID_COMMAND_MOA.date(), 1L, 1L))
+                        .willReturn(true);
                 given(reservationRepository.save(any(Reservation.class))).willReturn(new ReservationWithWaitingOrder(
-                        1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME, new WaitingOrder(1)));
+                        1L, "모아", VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
+                        ReservationStatus.WAITING, new WaitingOrder(1)));
 
                 assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -155,7 +155,7 @@ class ReservationServiceTest {
 
         assertDoesNotThrow(() -> reservationService.delete(1L));
 
-        verify(reservationRepository, times(1)).findById(1L);
+        verify(reservationRepository, times(2)).findById(1L);
         verify(reservationRepository, times(1)).cancel(1L);
         verify(reservationRepository, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
         verifyNoInteractions(reservationTimeRepository, themeRepository);

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -26,7 +26,7 @@ import roomescape.domain.WaitingOrder;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.service.exception.ReservationConflictException;
 import roomescape.service.exception.ReservationNotFoundException;
 import roomescape.service.exception.ReservationTimeNotFoundException;

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -25,7 +25,6 @@ import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
-import roomescape.repository.ThemeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
 import roomescape.service.dto.ReservationWithWaitingOrder;
 import roomescape.service.exception.ReservationConflictException;
@@ -55,8 +54,6 @@ class ReservationServiceTest {
     private ReservationRepository reservationRepository;
     @Mock
     private ReservationTimeRepository reservationTimeRepository;
-    @Mock
-    private ThemeRepository themeRepository;
     @InjectMocks
     private AdminReservationService reservationService;
 
@@ -64,7 +61,7 @@ class ReservationServiceTest {
     @DisplayName("같은 이름+날짜+시간+테마에 이미 예약이 있으면 ReservationConflictException이 발생한다")
     void 같은_날짜_시간_테마에_이미_예약이_있으면_예외가_발생한다() {
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
+        given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                 .willReturn(true);
@@ -75,7 +72,7 @@ class ReservationServiceTest {
         );
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(themeRepository, times(1)).findById(1L);
+        verify(reservationRepository, times(1)).lockTheme(1L);
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
     }
@@ -87,7 +84,7 @@ class ReservationServiceTest {
                 1L, VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
                 ReservationStatus.CONFIRMED, new WaitingOrder(0));
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
+        given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                 .willReturn(false);
@@ -96,7 +93,7 @@ class ReservationServiceTest {
         assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(themeRepository, times(1)).findById(1L);
+        verify(reservationRepository, times(1)).lockTheme(1L);
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
         verify(reservationRepository, times(1)).save(any(Reservation.class));
@@ -113,14 +110,14 @@ class ReservationServiceTest {
         );
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verifyNoInteractions(themeRepository, reservationRepository);
+        verifyNoInteractions(reservationRepository);
     }
 
     @Test
     @DisplayName("존재하지 않는 themeId로 예약을 생성하면 ThemeNotFoundException이 발생한다")
     void 존재하지_않는_themeId로_예약시_예외가_발생한다() {
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(themeRepository.findById(1L)).willReturn(Optional.empty());
+        given(reservationRepository.lockTheme(1L)).willReturn(Optional.empty());
 
         assertThrows(
                 ThemeNotFoundException.class,
@@ -128,8 +125,7 @@ class ReservationServiceTest {
         );
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(themeRepository, times(1)).findById(1L);
-        verifyNoInteractions(reservationRepository);
+        verify(reservationRepository, times(1)).lockTheme(1L);
     }
 
     @Test
@@ -143,7 +139,7 @@ class ReservationServiceTest {
         );
 
         verify(reservationRepository, times(1)).findById(1L);
-        verifyNoInteractions(reservationTimeRepository, themeRepository);
+        verifyNoInteractions(reservationTimeRepository);
     }
 
     @Test
@@ -158,7 +154,7 @@ class ReservationServiceTest {
         verify(reservationRepository, times(2)).findById(1L);
         verify(reservationRepository, times(1)).cancel(1L);
         verify(reservationRepository, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
-        verifyNoInteractions(reservationTimeRepository, themeRepository);
+        verifyNoInteractions(reservationTimeRepository);
     }
 
     @Nested
@@ -169,7 +165,7 @@ class ReservationServiceTest {
         void 해당_타임_슬롯에_예약이_없다면_예약을_허용한다() {
 
             given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-            given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
+            given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
             given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                     1L))
                     .willReturn(false);
@@ -180,7 +176,7 @@ class ReservationServiceTest {
             assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
             verify(reservationTimeRepository, times(1)).findById(1L);
-            verify(themeRepository, times(1)).findById(1L);
+            verify(reservationRepository, times(1)).lockTheme(1L);
             verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                     VALID_COMMAND_MOA.date(), 1L,
                     1L);
@@ -194,7 +190,7 @@ class ReservationServiceTest {
             @DisplayName("기존 예약자와 동일한 사용자의 예약 요청이라면 거부한다")
             void 사용자_이름이_같으면_ReservationConflictException을_던진다() {
                 given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-                given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
+                given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
                 given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                         VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                         .willReturn(true);
@@ -205,7 +201,7 @@ class ReservationServiceTest {
                 );
 
                 verify(reservationTimeRepository, times(1)).findById(1L);
-                verify(themeRepository, times(1)).findById(1L);
+                verify(reservationRepository, times(1)).lockTheme(1L);
                 verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                         VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
 
@@ -215,7 +211,7 @@ class ReservationServiceTest {
             @DisplayName("기존 예약자와 다른 사용자의 예약 요청이라면 허용한다")
             void 사용자_이름이_다르면_예약_대기_순번을_부여한다() {
                 given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-                given(themeRepository.findById(1L)).willReturn(Optional.of(VALID_THEME));
+                given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
                 given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                         1L))
                         .willReturn(false);
@@ -228,7 +224,7 @@ class ReservationServiceTest {
                 assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
                 verify(reservationTimeRepository, times(1)).findById(1L);
-                verify(themeRepository, times(1)).findById(1L);
+                verify(reservationRepository, times(1)).lockTheme(1L);
                 verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                         VALID_COMMAND_MOA.date(), 1L,
                         1L);

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -129,13 +129,13 @@ class ReservationServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 예약을 삭제하면 ReservationNotFoundException이 발생한다")
-    void 존재하지_않는_예약_삭제시_예외가_발생한다() {
+    @DisplayName("존재하지 않는 예약을 취소하면 ReservationNotFoundException이 발생한다")
+    void 존재하지_않는_예약_취소시_예외가_발생한다() {
         given(reservationRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThrows(
                 ReservationNotFoundException.class,
-                () -> reservationService.delete(1L)
+                () -> reservationService.cancel(1L)
         );
 
         verify(reservationRepository, times(1)).findById(1L);
@@ -143,13 +143,13 @@ class ReservationServiceTest {
     }
 
     @Test
-    @DisplayName("확정 예약을 삭제하면 soft delete 후 첫 대기자를 승급한다")
-    void 확정_예약_삭제시_취소하고_승급한다() {
+    @DisplayName("확정 예약을 취소하면 soft delete 후 첫 대기자를 승급한다")
+    void 확정_예약_취소시_취소하고_승급한다() {
         Reservation confirmed = new Reservation(
                 1L, "브라운", VALID_RESERVATION_DATE, VALID_TIME, VALID_THEME, ReservationStatus.CONFIRMED);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(confirmed));
 
-        assertDoesNotThrow(() -> reservationService.delete(1L));
+        assertDoesNotThrow(() -> reservationService.cancel(1L));
 
         verify(reservationRepository, times(2)).findById(1L);
         verify(reservationRepository, times(1)).cancel(1L);

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -3,6 +3,7 @@ package roomescape.service;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,12 +22,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
+import roomescape.repository.ThemeLockedAction;
 import roomescape.service.dto.ReservationCreateCommand;
-import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.service.exception.ReservationConflictException;
 import roomescape.service.exception.ReservationNotFoundException;
 import roomescape.service.exception.ReservationTimeNotFoundException;
@@ -57,11 +59,19 @@ class ReservationServiceTest {
     @InjectMocks
     private AdminReservationService reservationService;
 
+    private void stubThemeLock(Optional<Theme> lockedTheme) {
+        given(reservationRepository.executeWithThemeLock(eq(1L), any()))
+                .willAnswer(invocation -> {
+                    ThemeLockedAction<Object> action = invocation.getArgument(1);
+                    return action.execute(lockedTheme);
+                });
+    }
+
     @Test
     @DisplayName("같은 이름+날짜+시간+테마에 이미 예약이 있으면 ReservationConflictException이 발생한다")
     void 같은_날짜_시간_테마에_이미_예약이_있으면_예외가_발생한다() {
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
+        stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                 .willReturn(true);
@@ -72,7 +82,7 @@ class ReservationServiceTest {
         );
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(reservationRepository, times(1)).lockTheme(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
     }
@@ -84,7 +94,7 @@ class ReservationServiceTest {
                 1L, VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), VALID_TIME, VALID_THEME,
                 ReservationStatus.CONFIRMED, new WaitingOrder(0));
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
+        stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                 .willReturn(false);
@@ -93,7 +103,7 @@ class ReservationServiceTest {
         assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(reservationRepository, times(1)).lockTheme(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                 VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
         verify(reservationRepository, times(1)).save(any(Reservation.class));
@@ -117,7 +127,7 @@ class ReservationServiceTest {
     @DisplayName("존재하지 않는 themeId로 예약을 생성하면 ThemeNotFoundException이 발생한다")
     void 존재하지_않는_themeId로_예약시_예외가_발생한다() {
         given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-        given(reservationRepository.lockTheme(1L)).willReturn(Optional.empty());
+        stubThemeLock(Optional.empty());
 
         assertThrows(
                 ThemeNotFoundException.class,
@@ -125,7 +135,7 @@ class ReservationServiceTest {
         );
 
         verify(reservationTimeRepository, times(1)).findById(1L);
-        verify(reservationRepository, times(1)).lockTheme(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
     }
 
     @Test
@@ -148,10 +158,12 @@ class ReservationServiceTest {
         Reservation confirmed = new Reservation(
                 1L, "브라운", VALID_RESERVATION_DATE, VALID_TIME, VALID_THEME, ReservationStatus.CONFIRMED);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(confirmed));
+        stubThemeLock(Optional.of(VALID_THEME));
 
         assertDoesNotThrow(() -> reservationService.cancel(1L));
 
         verify(reservationRepository, times(2)).findById(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).cancel(1L);
         verify(reservationRepository, times(1)).promoteEarliestWaiting(VALID_RESERVATION_DATE, 1L, 1L);
         verifyNoInteractions(reservationTimeRepository);
@@ -165,7 +177,7 @@ class ReservationServiceTest {
         void 해당_타임_슬롯에_예약이_없다면_예약을_허용한다() {
 
             given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-            given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
+            stubThemeLock(Optional.of(VALID_THEME));
             given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                     1L))
                     .willReturn(false);
@@ -176,7 +188,7 @@ class ReservationServiceTest {
             assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
             verify(reservationTimeRepository, times(1)).findById(1L);
-            verify(reservationRepository, times(1)).lockTheme(1L);
+            verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
             verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                     VALID_COMMAND_MOA.date(), 1L,
                     1L);
@@ -190,7 +202,7 @@ class ReservationServiceTest {
             @DisplayName("기존 예약자와 동일한 사용자의 예약 요청이라면 거부한다")
             void 사용자_이름이_같으면_ReservationConflictException을_던진다() {
                 given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-                given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
+                stubThemeLock(Optional.of(VALID_THEME));
                 given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId(
                         VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L))
                         .willReturn(true);
@@ -201,7 +213,7 @@ class ReservationServiceTest {
                 );
 
                 verify(reservationTimeRepository, times(1)).findById(1L);
-                verify(reservationRepository, times(1)).lockTheme(1L);
+                verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
                 verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId(
                         VALID_COMMAND_MOA.reserverName(), VALID_COMMAND_MOA.date(), 1L, 1L);
 
@@ -211,7 +223,7 @@ class ReservationServiceTest {
             @DisplayName("기존 예약자와 다른 사용자의 예약 요청이라면 허용한다")
             void 사용자_이름이_다르면_예약_대기_순번을_부여한다() {
                 given(reservationTimeRepository.findById(1L)).willReturn(Optional.of(VALID_TIME));
-                given(reservationRepository.lockTheme(1L)).willReturn(Optional.of(VALID_THEME));
+                stubThemeLock(Optional.of(VALID_THEME));
                 given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeId("모아", VALID_COMMAND_MOA.date(), 1L,
                         1L))
                         .willReturn(false);
@@ -224,7 +236,7 @@ class ReservationServiceTest {
                 assertDoesNotThrow(() -> reservationService.create(VALID_COMMAND_MOA));
 
                 verify(reservationTimeRepository, times(1)).findById(1L);
-                verify(reservationRepository, times(1)).lockTheme(1L);
+                verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
                 verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeId("모아",
                         VALID_COMMAND_MOA.date(), 1L,
                         1L);

--- a/src/test/java/roomescape/service/ReservationUpdateRollbackTest.java
+++ b/src/test/java/roomescape/service/ReservationUpdateRollbackTest.java
@@ -1,0 +1,86 @@
+package roomescape.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import roomescape.repository.JdbcReservationRepository;
+import roomescape.service.dto.ReservationCreateCommand;
+import roomescape.service.dto.ReservationUpdateCommand;
+
+@SpringBootTest
+class ReservationUpdateRollbackTest {
+
+    private static final LocalDate DATE = LocalDate.of(2099, 12, 31);
+
+    @Autowired
+    private AdminReservationService reservationService;
+
+    @Autowired
+    private UserReservationService userReservationService;
+
+    @MockitoSpyBean
+    private JdbcReservationRepository reservationRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("다른 슬롯으로 변경 후 원래 슬롯 승급이 실패하면 변경까지 함께 롤백된다")
+    void 승급_실패_시_변경이_롤백된다() {
+        long fromTimeId = insertTime("10:00");
+        long toTimeId = insertTime("11:00");
+        long themeId = insertTheme("롤백테마-변경승급");
+        long ownerId = reservationService.create(
+                new ReservationCreateCommand("owner", DATE, fromTimeId, themeId)).id();
+        long waiterId = reservationService.create(
+                new ReservationCreateCommand("waiter", DATE, fromTimeId, themeId)).id();
+
+        doThrow(new RuntimeException("승급 실패 시뮬레이션"))
+                .when(reservationRepository).promoteEarliestWaiting(any(LocalDate.class), anyLong(), anyLong());
+
+        assertThatThrownBy(() -> userReservationService.update(
+                new ReservationUpdateCommand(ownerId, "owner", DATE, toTimeId)))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(timeIdOf(ownerId))
+                .as("승급이 실패하면 같은 트랜잭션의 슬롯 이동도 롤백되어 원래 시간대를 유지해야 한다")
+                .isEqualTo(fromTimeId);
+        assertThat(statusOf(ownerId))
+                .as("롤백되었으므로 원 예약은 확정 상태를 유지해야 한다")
+                .isEqualTo("CONFIRMED");
+        assertThat(statusOf(waiterId))
+                .as("롤백되었으므로 대기자는 승급되지 않고 대기 상태를 유지해야 한다")
+                .isEqualTo("WAITING");
+    }
+
+    private String statusOf(long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reservation WHERE id = ?", String.class, id);
+    }
+
+    private long timeIdOf(long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT time_id FROM reservation WHERE id = ?", Long.class, id);
+    }
+
+    private long insertTime(String startAt) {
+        jdbcTemplate.update("INSERT INTO reservation_time (start_at) VALUES (?)", startAt);
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation_time", Long.class);
+    }
+
+    private long insertTheme(String name) {
+        jdbcTemplate.update(
+                "INSERT INTO theme (name, description, thumbnail_url) VALUES (?, '설명', 'http://x')", name);
+        return jdbcTemplate.queryForObject("SELECT MAX(id) FROM theme", Long.class);
+    }
+}

--- a/src/test/java/roomescape/service/ThemeServiceTest.java
+++ b/src/test/java/roomescape/service/ThemeServiceTest.java
@@ -3,11 +3,13 @@ package roomescape.service;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.domain.Theme;
 import roomescape.repository.ReservationRepository;
+import roomescape.repository.ThemeLockedAction;
 import roomescape.repository.ThemeRepository;
 import roomescape.service.dto.ThemeCreateCommand;
 import roomescape.service.exception.ThemeConflictException;
@@ -37,6 +40,14 @@ class ThemeServiceTest {
     private ReservationRepository reservationRepository;
     @InjectMocks
     private ThemeService themeService;
+
+    private void stubThemeLock() {
+        given(reservationRepository.executeWithThemeLock(eq(1L), any()))
+                .willAnswer(invocation -> {
+                    ThemeLockedAction<Object> action = invocation.getArgument(1);
+                    return action.execute(Optional.empty(), null);
+                });
+    }
 
     @Test
     @DisplayName("같은 이름의 테마가 이미 있으면 ThemeConflictException이 발생한다")
@@ -85,6 +96,7 @@ class ThemeServiceTest {
     @DisplayName("예약이 존재하는 테마를 삭제하면 ThemeInUseException이 발생한다")
     void 예약이_존재하는_테마_삭제시_예외가_발생한다() {
         given(themeRepository.existsById(1L)).willReturn(true);
+        stubThemeLock();
         given(reservationRepository.existsByThemeId(1L)).willReturn(true);
 
         assertThrows(
@@ -93,6 +105,7 @@ class ThemeServiceTest {
         );
 
         verify(themeRepository, times(1)).existsById(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).existsByThemeId(1L);
     }
 
@@ -100,11 +113,13 @@ class ThemeServiceTest {
     @DisplayName("예약이 없는 테마는 정상적으로 삭제된다")
     void 예약이_없는_테마는_정상_삭제된다() {
         given(themeRepository.existsById(1L)).willReturn(true);
+        stubThemeLock();
         given(reservationRepository.existsByThemeId(1L)).willReturn(false);
 
         assertDoesNotThrow(() -> themeService.delete(1L));
 
         verify(themeRepository, times(1)).existsById(1L);
+        verify(reservationRepository, times(1)).executeWithThemeLock(eq(1L), any());
         verify(reservationRepository, times(1)).existsByThemeId(1L);
         verify(themeRepository, times(1)).deleteById(1L);
     }

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -131,7 +131,7 @@ class UserReservationServiceTest {
         userReservationService.cancel(1L, OWNER);
 
         verify(reservationRepository, times(1)).findById(1L);
-        verify(reservationService, times(1)).cancel(reservation);
+        verify(reservationService, times(1)).cancel(1L);
         verifyNoInteractions(reservationTimeRepository);
     }
 

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -25,6 +25,7 @@ import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
+import roomescape.repository.LockedReservationWriter;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeLockedAction;
@@ -60,6 +61,8 @@ class UserReservationServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
     @Mock
+    private LockedReservationWriter reservationWriter;
+    @Mock
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
     private UserReservationService userReservationService;
@@ -68,7 +71,7 @@ class UserReservationServiceTest {
         given(reservationRepository.executeWithThemeLock(eq(VALID_THEME.getId()), any()))
                 .willAnswer(invocation -> {
                     ThemeLockedAction<Object> action = invocation.getArgument(1);
-                    return action.execute(lockedTheme);
+                    return action.execute(lockedTheme, reservationWriter);
                 });
     }
 
@@ -202,7 +205,7 @@ class UserReservationServiceTest {
         stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L)).willReturn(false);
-        given(reservationRepository.update(any(Reservation.class))).willAnswer(inv -> {
+        given(reservationWriter.update(any(Reservation.class))).willAnswer(inv -> {
             Reservation r = inv.getArgument(0);
             return new ReservationWithWaitingOrder(
                     r.getId(), r.getReserverName(), r.getDate(), r.getTime(), r.getTheme(),
@@ -217,7 +220,7 @@ class UserReservationServiceTest {
         verify(reservationTimeRepository, times(1)).findById(2L);
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L);
-        verify(reservationRepository, times(1)).update(any(Reservation.class));
+        verify(reservationWriter, times(1)).update(any(Reservation.class));
         verifyNoInteractions(reservationService);
     }
 

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
+import roomescape.repository.ThemeLockedAction;
 import roomescape.service.dto.ReservationCreateCommand;
 import roomescape.service.dto.ReservationResult;
 import roomescape.service.dto.ReservationUpdateCommand;
@@ -61,6 +63,14 @@ class UserReservationServiceTest {
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
     private UserReservationService userReservationService;
+
+    private void stubThemeLock(Optional<Theme> lockedTheme) {
+        given(reservationRepository.executeWithThemeLock(eq(VALID_THEME.getId()), any()))
+                .willAnswer(invocation -> {
+                    ThemeLockedAction<Object> action = invocation.getArgument(1);
+                    return action.execute(lockedTheme);
+                });
+    }
 
     @Test
     @DisplayName("미래 시점에 예약하면 정상적으로 생성된다")
@@ -189,6 +199,7 @@ class UserReservationServiceTest {
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(2L)).willReturn(Optional.of(ANOTHER_TIME));
+        stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L)).willReturn(false);
         given(reservationRepository.update(any(Reservation.class))).willAnswer(inv -> {
@@ -290,6 +301,7 @@ class UserReservationServiceTest {
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(2L)).willReturn(Optional.of(ANOTHER_TIME));
+        stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L)).willReturn(true);
 

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -205,7 +205,7 @@ class UserReservationServiceTest {
         stubThemeLock(Optional.of(VALID_THEME));
         given(reservationRepository.existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L)).willReturn(false);
-        given(reservationWriter.update(any(Reservation.class))).willAnswer(inv -> {
+        given(reservationWriter.updateAndRequeue(any(Reservation.class))).willAnswer(inv -> {
             Reservation r = inv.getArgument(0);
             return new ReservationWithWaitingOrder(
                     r.getId(), r.getReserverName(), r.getDate(), r.getTime(), r.getTheme(),
@@ -220,7 +220,7 @@ class UserReservationServiceTest {
         verify(reservationTimeRepository, times(1)).findById(2L);
         verify(reservationRepository, times(1)).existsByReserverNameAndDateAndTimeIdAndThemeIdAndIdNot(
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L);
-        verify(reservationWriter, times(1)).update(any(Reservation.class));
+        verify(reservationWriter, times(1)).updateAndRequeue(any(Reservation.class));
         verifyNoInteractions(reservationService);
     }
 

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.WaitingOrder;
@@ -108,7 +109,7 @@ class UserReservationServiceTest {
     @DisplayName("이름으로 예약 목록을 조회한다")
     void 이름으로_예약_목록을_조회한다() {
         ReservationWithWaitingOrder reservation = new ReservationWithWaitingOrder(
-                1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME, new WaitingOrder(2));
+                1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME, ReservationStatus.WAITING, new WaitingOrder(2));
         given(reservationRepository.findByReserverName(OWNER)).willReturn(List.of(reservation));
 
         List<ReservationResult> results = userReservationService.findByReserverName(OWNER);
@@ -123,14 +124,15 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("본인 예약을 정상적으로 취소한다")
     void 본인_예약을_정상적으로_취소한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
 
         userReservationService.cancel(1L, OWNER);
 
         verify(reservationRepository, times(1)).findById(1L);
-        verify(reservationRepository, times(1)).deleteById(1L);
-        verifyNoInteractions(reservationService, reservationTimeRepository);
+        verify(reservationService, times(1)).cancel(reservation);
+        verifyNoInteractions(reservationTimeRepository);
     }
 
     @Test
@@ -150,7 +152,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("본인이 아닌 예약을 취소하면 UnauthorizedReservationException이 발생한다")
     void 본인이_아닌_예약_취소시_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
 
         assertThrows(
@@ -165,7 +168,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("과거 예약을 취소하면 PastReservationException이 발생한다")
     void 과거_예약_취소시_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, PAST_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, PAST_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
 
         assertThrows(
@@ -180,7 +184,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("본인 예약을 정상적으로 변경한다")
     void 본인_예약을_정상적으로_변경한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(2L)).willReturn(Optional.of(ANOTHER_TIME));
@@ -189,7 +194,8 @@ class UserReservationServiceTest {
         given(reservationRepository.update(any(Reservation.class))).willAnswer(inv -> {
             Reservation r = inv.getArgument(0);
             return new ReservationWithWaitingOrder(
-                    r.getId(), r.getReserverName(), r.getDate(), r.getTime(), r.getTheme(), new WaitingOrder(0));
+                    r.getId(), r.getReserverName(), r.getDate(), r.getTime(), r.getTheme(),
+                    r.getStatus(), new WaitingOrder(0));
         });
 
         ReservationResult result = userReservationService.update(command);
@@ -207,7 +213,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("본인이 아닌 예약을 변경하면 UnauthorizedReservationException이 발생한다")
     void 본인이_아닌_예약_변경시_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OTHER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
 
@@ -223,7 +230,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("존재하지 않는 timeId로 변경하면 ReservationTimeNotFoundException이 발생한다")
     void 존재하지_않는_timeId로_변경시_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 99L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(99L)).willReturn(Optional.empty());
@@ -241,7 +249,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("변경 시점이 과거이면 PastReservationException이 발생한다")
     void 변경_시점이_과거이면_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, PAST_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(2L)).willReturn(Optional.of(ANOTHER_TIME));
@@ -259,7 +268,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("기존 예약이 과거이면 PastReservationException이 발생한다")
     void 기존_예약이_과거이면_변경할_수_없다() {
-        Reservation reservation = new Reservation(1L, OWNER, PAST_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, PAST_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
 
@@ -275,7 +285,8 @@ class UserReservationServiceTest {
     @Test
     @DisplayName("본인이 이미 예약 또는 대기중인 시간으로 변경하면 ReservationConflictException이 발생한다")
     void 변경_시간_충돌시_예외가_발생한다() {
-        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME);
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.CONFIRMED);
         ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, ANOTHER_FUTURE_DATE, 2L);
         given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
         given(reservationTimeRepository.findById(2L)).willReturn(Optional.of(ANOTHER_TIME));

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -222,6 +223,24 @@ class UserReservationServiceTest {
                 OWNER, ANOTHER_FUTURE_DATE, 2L, VALID_THEME.getId(), 1L);
         verify(reservationWriter, times(1)).updateAndRequeue(any(Reservation.class));
         verifyNoInteractions(reservationService);
+    }
+
+    @Test
+    @DisplayName("같은 슬롯으로 변경하면 쓰기 없이 현재 상태를 반환한다")
+    void 같은_슬롯_변경은_쓰기없이_조회만_한다() {
+        Reservation reservation = new Reservation(1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME,
+                ReservationStatus.WAITING);
+        ReservationUpdateCommand command = new ReservationUpdateCommand(1L, OWNER, FUTURE_DATE, VALID_TIME.getId());
+        given(reservationRepository.findById(1L)).willReturn(Optional.of(reservation));
+        given(reservationTimeRepository.findById(VALID_TIME.getId())).willReturn(Optional.of(VALID_TIME));
+        given(reservationRepository.findWithWaitingOrderById(1L)).willReturn(Optional.of(new ReservationWithWaitingOrder(
+                1L, OWNER, FUTURE_DATE, VALID_TIME, VALID_THEME, ReservationStatus.WAITING, new WaitingOrder(3))));
+
+        ReservationResult result = userReservationService.update(command);
+
+        assertThat(result.waitingOrder()).isEqualTo(3L);
+        verify(reservationRepository, never()).executeWithThemeLock(any(), any());
+        verifyNoInteractions(reservationWriter);
     }
 
     @Test

--- a/src/test/java/roomescape/service/UserReservationServiceTest.java
+++ b/src/test/java/roomescape/service/UserReservationServiceTest.java
@@ -29,7 +29,7 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.service.dto.ReservationCreateCommand;
 import roomescape.service.dto.ReservationResult;
 import roomescape.service.dto.ReservationUpdateCommand;
-import roomescape.service.dto.ReservationWithWaitingOrder;
+import roomescape.domain.ReservationWithWaitingOrder;
 import roomescape.service.exception.PastReservationException;
 import roomescape.service.exception.ReservationConflictException;
 import roomescape.service.exception.ReservationNotFoundException;


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

안녕하세요 아서!
저번 사이클1에서 피드백 주신대로 이번 사이클2에서도 예약과 대기를 별도 테이블로 나누지 않고 `reservation` 단일 테이블 기반에서 상태를 추가하여 관리하는 방식을 채택했습니다.

* `status` : `CONFIRMED`, `WAITING`, `CANCELED`
* `enqueued_at` : 대기열 진입 시각
* `updated_at` : 수정 시각

마찬가지로 대기 순번은 별도 컬럼으로 저장하지 않고 조회 시 계산하도록 구현했습니다.

취소는 hard delete 대신 상태를 변경하는 방식으로 처리했고, 확정 예약이 취소되면 같은 슬롯의 1순위 대기자가 자동으로 확정되도록 구현했습니다. 취소와 승급은 하나의 트랜잭션으로 묶었습니다.

동시성 문제는 비관 락을 사용해 동일 슬롯에 대한 접근을 직렬화했습니다.


## 1. Hard Delete → Soft Delete 전환

기존에는 예약 취소 시 데이터를 삭제했습니다. 그런데 대기 기능을 추가하면서 "취소" 자체도 하나의 상태로 관리하는 편이 자연스럽다고 판단했습니다.

그래서 예약을 삭제하지 않고 `Reservation`테이블의 `status` 필드가 `CANCELED` 상태로 변경되도록 수정했습니다.

이 변경으로 인해 대기 순번 계산, 중복 검사, 인기 테마 집계 등에서는 취소된 예약을 제외하도록 수정했고, 반대로 "내 예약" 조회에서는 취소 이력을 함께 보여주도록 했습니다.



## 2. 트랜잭션 경계

대기자는 별도 승인 과정 없이 자동 승급하도록 구현했습니다.

현재는
* 예약 취소
* 대기자 승급

을 하나의 트랜잭션으로 처리하고 있습니다.

취소만 성공하거나 승급만 성공하는 상황이 생기면 슬롯 상태가 어색해질 수 있다고 생각했기 때문입니다.

반면 다른 크루분들 중에는 "취소는 무조건 성공해야 한다"는 이유로 승급을 별도의 트랜잭션으로 분리한 경우도 있었습니다.

현재 요구사항에서는 외부 시스템 연동이나 알림이 없어서 함께 묶는 쪽을 선택했는데, 이 판단이 적절했는지 궁금합니다.


## 3. 동시성 처리

기존에는 UNIQUE 제약으로 중복 예약을 방지했습니다.

하지만 이번에는

* 확정 예약 1건
* 대기 예약 N건
* 취소 예약 M건

이 동시에 존재할 수 있게 되면서 단순 UNIQUE로는 원하는 제약을 표현하기 어려웠습니다.
제가 보장하고 싶었던 부분은 취소를 제외하고 동일 슬롯에는 확정 예약이 하나만 존재한다 였습니다.
부분 유니크 인덱스를 고려했지만 H2에서는 지원하지 않아 다른 방법을 찾게 되었습니다.

결국 항상 존재하는 `theme` 행을 `SELECT ... FOR UPDATE`로 잠그고, 동일 슬롯에 대한 생성,취소,변경이 순차적으로 처리되도록 구현했습니다.

조건부 유일성을 DB 제약으로 표현하기 어려운 상황에서 비관 락을 선택한 것이 적절한 방향이였는지 궁금합니다!


## 4. `updated_at` → `enqueued_at` 분리

지난 리뷰에서 순번 기준으로 `updated_at`을 사용하는 것이 적절한지 고민해보라는 피드백을 받았습니다.

생각해보니 `updated_at`은 수정 이력을 위한 필드인데, 대기 순번까지 담당하고 있어 역할이 섞여 있었습니다.

실제로 예약 수정이 발생하면 순번 기준이 흔들릴 수도 있었습니다.

그래서 대기열 진입 시점을 나타내는 `enqueued_at`을 추가했고, 순번 계산은 해당 값을 기준으로 하도록 변경했습니다.


## 5. 테스트

계층별로 검증 대상을 나누어 테스트를 작성했습니다.

* 서비스 : 비즈니스 규칙 검증 (Mock 사용)
* 리포지토리 : 실제 DB를 사용해 SQL 검증
* 동시성 : ExecutorService 기반 테스트

특히 동시성 테스트는 동일 슬롯에 여러 요청을 동시에 보내어 락 적용 전후의 동작 차이를 확인하는 방식으로 작성했습니다.

처음 적용해보는 부분이라 아마 많이 부족할 수 있을 것이라 생각합니다 
테스트 범위나 방식에서 부족한 부분이 있다면 함께 피드백 부탁드립니다 🙇

이번 사이클2도 잘부탁드립니다!