### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 카키(남해윤) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/domain/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationRepository.java
@@ -154,6 +154,23 @@ public class ReservationRepository {
             .findFirst();
     }
 
+    public Optional<Reservation> findByIdForUpdate(Long id) {
+        String query = """
+            SELECT r.id AS reservation_id, r.name, r.date,
+                   t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
+                   th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
+                   th.image_url AS theme_image_url
+            FROM reservation r
+            JOIN reservation_time t ON r.time_id = t.id
+            JOIN theme th ON r.theme_id = th.id
+            WHERE r.id = ?
+            FOR UPDATE
+            """;
+
+        return jdbcTemplate.query(query, rowMapper, id).stream()
+            .findFirst();
+    }
+
     public boolean existsByIdForUpdate(Long id) {
         String query = "SELECT id FROM reservation WHERE id = ? FOR UPDATE";
         return !jdbcTemplate.query(query, (rs, rowNum) -> rs.getLong("id"), id).isEmpty();

--- a/src/main/java/roomescape/domain/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationRepository.java
@@ -164,7 +164,7 @@ public class ReservationRepository {
             JOIN reservation_time t ON r.time_id = t.id
             JOIN theme th ON r.theme_id = th.id
             WHERE r.id = ?
-            FOR UPDATE
+            FOR UPDATE OF r
             """;
 
         return jdbcTemplate.query(query, rowMapper, id).stream()

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -14,6 +14,7 @@ import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.theme.ThemeRepository;
+import roomescape.domain.waiting.WaitingRepository;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
 
@@ -23,15 +24,18 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
     private final ThemeRepository themeRepository;
+    private final WaitingRepository waitingRepository;
 
     public ReservationService(
         ReservationRepository reservationRepository,
         ReservationTimeRepository reservationTimeRepository,
-        ThemeRepository themeRepository
+        ThemeRepository themeRepository,
+        WaitingRepository waitingRepository
     ) {
         this.reservationRepository = reservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
+        this.waitingRepository = waitingRepository;
     }
 
     @Transactional
@@ -72,8 +76,9 @@ public class ReservationService {
 
     @Transactional
     public void deleteReservation(Long id, String name) {
-        validateReservationOwner(id, name);
+        Reservation reservation = validateReservationOwner(id, name);
         reservationRepository.deleteById(id);
+        promoteFirstWaiting(reservation);
     }
 
     @Transactional(readOnly = true)
@@ -104,10 +109,11 @@ public class ReservationService {
         }
     }
 
-    private void validateReservationOwner(Long id, String name) {
+    private Reservation validateReservationOwner(Long id, String name) {
         Reservation reservation = reservationRepository.findById(id)
             .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
         reservation.validateOwner(name);
+        return reservation;
     }
 
     private void validateDuplicateReservation(LocalDate date, Long timeId, Long themeId) {
@@ -115,6 +121,23 @@ public class ReservationService {
         if (isDuplicated) {
             throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
         }
+    }
+
+    private void promoteFirstWaiting(Reservation reservation) {
+        waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                reservation.getDate(),
+                reservation.getTime().getId(),
+                reservation.getTheme().getId()
+            )
+            .ifPresent(waiting -> {
+                reservationRepository.save(Reservation.of(
+                    waiting.getName(),
+                    waiting.getDate(),
+                    waiting.getTime(),
+                    waiting.getTheme()
+                ));
+                waitingRepository.deleteById(waiting.getId());
+            });
     }
 
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -77,9 +77,12 @@ public class ReservationService {
 
     @Transactional
     public void deleteReservation(Long id, String name) {
-        Reservation reservation = validateReservationOwner(id, name);
-        reservationRepository.deleteById(id);
-        promoteFirstWaiting(reservation);
+        reservationRepository.findById(id)
+            .ifPresent(reservation -> {
+                reservation.validateOwner(name);
+                reservationRepository.deleteById(id);
+                promoteFirstWaiting(reservation);
+            });
     }
 
     @Transactional(readOnly = true)
@@ -108,13 +111,6 @@ public class ReservationService {
         } catch (DuplicateKeyException exception) {
             throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
         }
-    }
-
-    private Reservation validateReservationOwner(Long id, String name) {
-        Reservation reservation = reservationRepository.findByIdForUpdate(id)
-            .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
-        reservation.validateOwner(name);
-        return reservation;
     }
 
     private void validateDuplicateReservation(LocalDate date, Long timeId, Long themeId) {

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -12,6 +12,7 @@ import roomescape.domain.reservation.dto.ReservationResponse;
 import roomescape.domain.reservationtime.ReservationTime;
 import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
+import roomescape.domain.reservationtime.dto.TimeSlot;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.theme.ThemeRepository;
 import roomescape.domain.waiting.WaitingRepository;
@@ -124,11 +125,9 @@ public class ReservationService {
     }
 
     private void promoteFirstWaiting(Reservation reservation) {
-        waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
-                reservation.getDate(),
-                reservation.getTime().getId(),
-                reservation.getTheme().getId()
-            )
+        TimeSlot canceledReservationSlot = TimeSlot.from(reservation);
+
+        waitingRepository.findFirstByTimeSlotForUpdate(canceledReservationSlot)
             .ifPresent(waiting -> {
                 reservationRepository.save(Reservation.of(
                     waiting.getName(),

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -77,7 +77,7 @@ public class ReservationService {
 
     @Transactional
     public void deleteReservation(Long id, String name) {
-        reservationRepository.findById(id)
+        reservationRepository.findByIdForUpdate(id)
             .ifPresent(reservation -> {
                 reservation.validateOwner(name);
                 reservationRepository.deleteById(id);

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -110,7 +110,7 @@ public class ReservationService {
     }
 
     private Reservation validateReservationOwner(Long id, String name) {
-        Reservation reservation = reservationRepository.findById(id)
+        Reservation reservation = reservationRepository.findByIdForUpdate(id)
             .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
         reservation.validateOwner(name);
         return reservation;

--- a/src/main/java/roomescape/domain/reservationtime/dto/TimeSlot.java
+++ b/src/main/java/roomescape/domain/reservationtime/dto/TimeSlot.java
@@ -1,0 +1,11 @@
+package roomescape.domain.reservationtime.dto;
+
+import java.time.LocalDate;
+
+public record TimeSlot(
+    LocalDate date,
+    Long timeId,
+    Long themeId
+) {
+
+}

--- a/src/main/java/roomescape/domain/reservationtime/dto/TimeSlot.java
+++ b/src/main/java/roomescape/domain/reservationtime/dto/TimeSlot.java
@@ -1,6 +1,7 @@
 package roomescape.domain.reservationtime.dto;
 
 import java.time.LocalDate;
+import roomescape.domain.reservation.Reservation;
 
 public record TimeSlot(
     LocalDate date,
@@ -8,4 +9,11 @@ public record TimeSlot(
     Long themeId
 ) {
 
+    public static TimeSlot from (Reservation reservation) {
+        return new TimeSlot(
+            reservation.getDate(),
+            reservation.getTime().getId(),
+            reservation.getTheme().getId()
+        );
+    }
 }

--- a/src/main/java/roomescape/domain/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingRepository.java
@@ -144,7 +144,7 @@ public class WaitingRepository {
             WHERE w.date = ? AND w.time_id = ? AND w.theme_id = ?
             ORDER BY w.id
             LIMIT 1
-            FOR UPDATE
+            FOR UPDATE OF w
             """;
 
         return jdbcTemplate.query(query, waitingRowMapper,

--- a/src/main/java/roomescape/domain/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingRepository.java
@@ -130,4 +130,23 @@ public class WaitingRepository {
         return jdbcTemplate.query(query, waitingRowMapper, id).stream()
             .findFirst();
     }
+
+    public Optional<Waiting> findFirstByDateAndTimeIdAndThemeIdForUpdate(LocalDate date, Long timeId, Long themeId) {
+        String query = """
+            SELECT w.id AS waiting_id, w.name, w.date,
+                   t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
+                   th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
+                   th.image_url AS theme_image_url
+            FROM waiting w
+            JOIN reservation_time t ON w.time_id = t.id
+            JOIN theme th ON w.theme_id = th.id
+            WHERE w.date = ? AND w.time_id = ? AND w.theme_id = ?
+            ORDER BY w.id
+            LIMIT 1
+            FOR UPDATE
+            """;
+
+        return jdbcTemplate.query(query, waitingRowMapper, date, timeId, themeId).stream()
+            .findFirst();
+    }
 }

--- a/src/main/java/roomescape/domain/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingRepository.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.reservationtime.ReservationTime;
+import roomescape.domain.reservationtime.dto.TimeSlot;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.waiting.dto.MyWaitingResult;
 
@@ -131,7 +132,7 @@ public class WaitingRepository {
             .findFirst();
     }
 
-    public Optional<Waiting> findFirstByDateAndTimeIdAndThemeIdForUpdate(LocalDate date, Long timeId, Long themeId) {
+    public Optional<Waiting> findFirstByTimeSlotForUpdate(TimeSlot timeSlot) {
         String query = """
             SELECT w.id AS waiting_id, w.name, w.date,
                    t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
@@ -146,7 +147,11 @@ public class WaitingRepository {
             FOR UPDATE
             """;
 
-        return jdbcTemplate.query(query, waitingRowMapper, date, timeId, themeId).stream()
+        return jdbcTemplate.query(query, waitingRowMapper,
+                timeSlot.date(),
+                timeSlot.timeId(),
+                timeSlot.themeId())
+            .stream()
             .findFirst();
     }
 }

--- a/src/main/java/roomescape/domain/waiting/WaitingService.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingService.java
@@ -65,12 +65,11 @@ public class WaitingService {
 
     @Transactional
     public void deleteWaiting(Long id, String name) {
-        Waiting waiting = waitingRepository.findById(id).orElse(null);
-        if (waiting == null) {
-            return;
-        }
-        waiting.validateOwner(name);
-        waitingRepository.deleteById(id);
+        waitingRepository.findById(id)
+            .ifPresent(waiting -> {
+                waiting.validateOwner(name);
+                waitingRepository.deleteById(id);
+            });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/roomescape/domain/waiting/WaitingService.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingService.java
@@ -65,7 +65,11 @@ public class WaitingService {
 
     @Transactional
     public void deleteWaiting(Long id, String name) {
-        validateWaitingOwner(id, name);
+        Waiting waiting = waitingRepository.findById(id).orElse(null);
+        if (waiting == null) {
+            return;
+        }
+        waiting.validateOwner(name);
         waitingRepository.deleteById(id);
     }
 
@@ -81,12 +85,6 @@ public class WaitingService {
         if (isDuplicated) {
             throw new RoomescapeException(ErrorCode.DUPLICATE_WAITING_NAME);
         }
-    }
-
-    private void validateWaitingOwner(Long id, String name) {
-        Waiting waiting = waitingRepository.findById(id)
-            .orElseThrow(() -> new RoomescapeException(ErrorCode.WAITING_ID_NOT_FOUND));
-        waiting.validateOwner(name);
     }
 
     private void validateWaitingIsAvailable(WaitingRequest waitingRequest) {

--- a/src/test/java/roomescape/domain/reservation/ReservationConcurrencyTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationConcurrencyTest.java
@@ -87,6 +87,35 @@ class ReservationConcurrencyTest {
         assertReservationCount(2);
     }
 
+    @Test
+    void 같은_예약을_동시에_취소해도_대기는_한_번만_예약으로_전환된다() throws Exception {
+        Long themeId = insertTheme("취소동시성테마");
+        Long timeId = insertTime("10:00", "11:00");
+        Long reservationId = insertReservation("예약자", LocalDate.of(2099, 12, 31), timeId, themeId);
+        insertWaiting("대기자1", LocalDate.of(2099, 12, 31), timeId, themeId);
+        insertWaiting("대기자2", LocalDate.of(2099, 12, 31), timeId, themeId);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        Callable<ReservationResult> firstTask = deleteReservationTask(ready, start, reservationId, "예약자");
+        Callable<ReservationResult> secondTask = deleteReservationTask(ready, start, reservationId, "예약자");
+
+        Future<ReservationResult> firstResult = executorService.submit(firstTask);
+        Future<ReservationResult> secondResult = executorService.submit(secondTask);
+        ready.await(1, TimeUnit.SECONDS);
+        start.countDown();
+
+        List<ReservationResult> results = List.of(firstResult.get(), secondResult.get());
+        executorService.shutdown();
+
+        assertThat(results).allMatch(ReservationResult::success);
+        assertReservationCount(1);
+        assertWaitingCount(1);
+        assertThat(reservationNames()).containsExactly("대기자1");
+        assertThat(waitingNames()).containsExactly("대기자2");
+    }
+
     private Callable<ReservationResult> createReservationTask(
         CountDownLatch ready, CountDownLatch start, ReservationRequest request
     ) {
@@ -95,6 +124,21 @@ class ReservationConcurrencyTest {
             start.await();
             try {
                 reservationService.createReservation(request);
+                return ReservationResult.succeeded();
+            } catch (RoomescapeException exception) {
+                return ReservationResult.failed(exception.getErrorCode());
+            }
+        };
+    }
+
+    private Callable<ReservationResult> deleteReservationTask(
+        CountDownLatch ready, CountDownLatch start, Long reservationId, String name
+    ) {
+        return () -> {
+            ready.countDown();
+            start.await();
+            try {
+                reservationService.deleteReservation(reservationId, name);
                 return ReservationResult.succeeded();
             } catch (RoomescapeException exception) {
                 return ReservationResult.failed(exception.getErrorCode());
@@ -118,9 +162,37 @@ class ReservationConcurrencyTest {
         return jdbcTemplate.queryForObject("SELECT id FROM reservation_time WHERE start_at = ?", Long.class, startAt);
     }
 
+    private Long insertReservation(String name, LocalDate date, Long timeId, Long themeId) {
+        jdbcTemplate.update(
+            "INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
+            name, date, timeId, themeId
+        );
+        return jdbcTemplate.queryForObject("SELECT id FROM reservation WHERE name = ?", Long.class, name);
+    }
+
+    private void insertWaiting(String name, LocalDate date, Long timeId, Long themeId) {
+        jdbcTemplate.update(
+            "INSERT INTO waiting (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
+            name, date, timeId, themeId
+        );
+    }
+
     private void assertReservationCount(int expected) {
         Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM reservation", Integer.class);
         assertThat(count).isEqualTo(expected);
+    }
+
+    private void assertWaitingCount(int expected) {
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM waiting", Integer.class);
+        assertThat(count).isEqualTo(expected);
+    }
+
+    private List<String> reservationNames() {
+        return jdbcTemplate.queryForList("SELECT name FROM reservation ORDER BY id", String.class);
+    }
+
+    private List<String> waitingNames() {
+        return jdbcTemplate.queryForList("SELECT name FROM waiting ORDER BY id", String.class);
     }
 
     private record ReservationResult(boolean success, ErrorCode errorCode) {

--- a/src/test/java/roomescape/domain/reservation/ReservationControllerTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationControllerTest.java
@@ -238,11 +238,11 @@ class ReservationControllerTest {
     }
 
     @Test
-    void deleteReservation_존재하지_않는_id인경우_에러_반환_테스트() {
+    void deleteReservation_존재하지_않는_id인경우_성공_반환_테스트() {
         RestAssured.given().log().all()
             .when().delete("/reservations/999?name=유저1")
             .then().log().all()
-            .statusCode(404);
+            .statusCode(204);
     }
 
     @Test

--- a/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
@@ -288,6 +288,34 @@ class ReservationRepositoryTest {
     }
 
     @Nested
+    @DisplayName("id로 예약 락 조회")
+    class FindByIdForUpdate {
+
+        @Test
+        void 존재하는_id면_예약과_시간_테마를_함께_반환한다() {
+            Reservation saved = reservationRepository.save(
+                Reservation.of("유저1", LocalDate.of(2099, 12, 31), time, theme)
+            );
+
+            Optional<Reservation> result = reservationRepository.findByIdForUpdate(saved.getId());
+
+            assertAll(
+                () -> assertThat(result).isPresent(),
+                () -> assertThat(result.get().getName()).isEqualTo("유저1"),
+                () -> assertThat(result.get().getTime().getId()).isEqualTo(time.getId()),
+                () -> assertThat(result.get().getTheme().getId()).isEqualTo(theme.getId())
+            );
+        }
+
+        @Test
+        void 존재하지_않는_id면_빈_Optional을_반환한다() {
+            Optional<Reservation> result = reservationRepository.findByIdForUpdate(999L);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     @DisplayName("예약 날짜와 시간 수정")
     class UpdateDateAndTime {
 

--- a/src/test/java/roomescape/domain/reservation/ReservationRollbackTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationRollbackTest.java
@@ -1,0 +1,117 @@
+package roomescape.domain.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import roomescape.domain.waiting.WaitingRepository;
+
+@SpringBootTest
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+class ReservationRollbackTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Test
+    void 예약_취소_중_대기_삭제가_실패하면_예약_삭제와_대기_승격을_롤백한다() {
+        Long themeId = insertTheme("롤백테마");
+        Long timeId = insertTime("10:00", "11:00");
+        Long reservationId = insertReservation("예약자", LocalDate.of(2099, 12, 31), timeId, themeId);
+        insertWaiting("대기자1", LocalDate.of(2099, 12, 31), timeId, themeId);
+        ((FailingWaitingRepository) waitingRepository).failOnDelete();
+
+        assertThatThrownBy(() -> reservationService.deleteReservation(reservationId, "예약자"))
+            .isInstanceOf(IllegalStateException.class);
+
+        assertThat(reservationNames()).containsExactly("예약자");
+        assertThat(waitingNames()).containsExactly("대기자1");
+    }
+
+    private Long insertTheme(String name) {
+        jdbcTemplate.update(
+            "INSERT INTO theme (name, description, image_url) VALUES (?, '설명', 'https://example.com/image.jpg')",
+            name
+        );
+        return jdbcTemplate.queryForObject("SELECT id FROM theme WHERE name = ?", Long.class, name);
+    }
+
+    private Long insertTime(String startAt, String finishAt) {
+        jdbcTemplate.update(
+            "INSERT INTO reservation_time (start_at, finish_at) VALUES (?, ?)",
+            startAt, finishAt
+        );
+        return jdbcTemplate.queryForObject("SELECT id FROM reservation_time WHERE start_at = ?", Long.class, startAt);
+    }
+
+    private Long insertReservation(String name, LocalDate date, Long timeId, Long themeId) {
+        jdbcTemplate.update(
+            "INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
+            name, date, timeId, themeId
+        );
+        return jdbcTemplate.queryForObject("SELECT id FROM reservation WHERE name = ?", Long.class, name);
+    }
+
+    private void insertWaiting(String name, LocalDate date, Long timeId, Long themeId) {
+        jdbcTemplate.update(
+            "INSERT INTO waiting (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)",
+            name, date, timeId, themeId
+        );
+    }
+
+    private List<String> reservationNames() {
+        return jdbcTemplate.queryForList("SELECT name FROM reservation ORDER BY id", String.class);
+    }
+
+    private List<String> waitingNames() {
+        return jdbcTemplate.queryForList("SELECT name FROM waiting ORDER BY id", String.class);
+    }
+
+    @TestConfiguration
+    static class FailingWaitingRepositoryConfig {
+
+        @Bean
+        @Primary
+        WaitingRepository failingWaitingRepository(JdbcTemplate jdbcTemplate) {
+            return new FailingWaitingRepository(jdbcTemplate);
+        }
+    }
+
+    static class FailingWaitingRepository extends WaitingRepository {
+
+        private final AtomicBoolean failOnDelete = new AtomicBoolean(false);
+
+        FailingWaitingRepository(JdbcTemplate jdbcTemplate) {
+            super(jdbcTemplate);
+        }
+
+        void failOnDelete() {
+            failOnDelete.set(true);
+        }
+
+        @Override
+        public void deleteById(Long id) {
+            if (failOnDelete.get()) {
+                throw new IllegalStateException("대기 삭제 실패");
+            }
+            super.deleteById(id);
+        }
+    }
+}

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -181,7 +181,7 @@ class ReservationServiceTest {
         @Test
         void 정상_삭제() {
             Reservation reservation = Reservation.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
-            when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
             when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
                 reservation.getDate(), time.getId(), theme.getId()
             )).thenReturn(Optional.empty());
@@ -195,7 +195,7 @@ class ReservationServiceTest {
         void 예약_취소_시_1순위_대기를_예약으로_전환한다() {
             Reservation reservation = Reservation.of(1L, "예약자", LocalDate.of(2099, 12, 31), time, theme);
             Waiting waiting = Waiting.of(2L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
-            when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
             when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
                 reservation.getDate(), time.getId(), theme.getId()
             )).thenReturn(Optional.of(waiting));
@@ -203,6 +203,7 @@ class ReservationServiceTest {
             reservationService.deleteReservation(1L, "예약자");
 
             InOrder inOrder = inOrder(reservationRepository, waitingRepository);
+            inOrder.verify(reservationRepository).findByIdForUpdate(1L);
             inOrder.verify(reservationRepository).deleteById(1L);
             inOrder.verify(waitingRepository).findFirstByDateAndTimeIdAndThemeIdForUpdate(
                 reservation.getDate(), time.getId(), theme.getId()
@@ -213,7 +214,7 @@ class ReservationServiceTest {
 
         @Test
         void 존재하지_않는_id면_예외() {
-            when(reservationRepository.findById(99L)).thenReturn(Optional.empty());
+            when(reservationRepository.findByIdForUpdate(99L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> reservationService.deleteReservation(99L, "유저1"))
                 .isInstanceOf(RoomescapeException.class)

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -30,6 +30,7 @@ import roomescape.domain.reservation.dto.ReservationRequest;
 import roomescape.domain.reservationtime.ReservationTime;
 import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
+import roomescape.domain.reservationtime.dto.TimeSlot;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.theme.ThemeRepository;
 import roomescape.domain.waiting.Waiting;
@@ -181,10 +182,9 @@ class ReservationServiceTest {
         @Test
         void 정상_삭제() {
             Reservation reservation = Reservation.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
+            TimeSlot canceledReservationSlot = TimeSlot.from(reservation);
             when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
-            when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
-                reservation.getDate(), time.getId(), theme.getId()
-            )).thenReturn(Optional.empty());
+            when(waitingRepository.findFirstByTimeSlotForUpdate(canceledReservationSlot)).thenReturn(Optional.empty());
 
             reservationService.deleteReservation(1L, "유저1");
 
@@ -195,19 +195,16 @@ class ReservationServiceTest {
         void 예약_취소_시_1순위_대기를_예약으로_전환한다() {
             Reservation reservation = Reservation.of(1L, "예약자", LocalDate.of(2099, 12, 31), time, theme);
             Waiting waiting = Waiting.of(2L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
+            TimeSlot canceledReservationSlot = TimeSlot.from(reservation);
             when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
-            when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
-                reservation.getDate(), time.getId(), theme.getId()
-            )).thenReturn(Optional.of(waiting));
+            when(waitingRepository.findFirstByTimeSlotForUpdate(canceledReservationSlot)).thenReturn(Optional.of(waiting));
 
             reservationService.deleteReservation(1L, "예약자");
 
             InOrder inOrder = inOrder(reservationRepository, waitingRepository);
             inOrder.verify(reservationRepository).findByIdForUpdate(1L);
             inOrder.verify(reservationRepository).deleteById(1L);
-            inOrder.verify(waitingRepository).findFirstByDateAndTimeIdAndThemeIdForUpdate(
-                reservation.getDate(), time.getId(), theme.getId()
-            );
+            inOrder.verify(waitingRepository).findFirstByTimeSlotForUpdate(canceledReservationSlot);
             inOrder.verify(reservationRepository).save(any(Reservation.class));
             inOrder.verify(waitingRepository).deleteById(waiting.getId());
         }

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -32,6 +32,8 @@ import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.theme.ThemeRepository;
+import roomescape.domain.waiting.Waiting;
+import roomescape.domain.waiting.WaitingRepository;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
 
@@ -46,6 +48,9 @@ class ReservationServiceTest {
 
     @Mock
     private ThemeRepository themeRepository;
+
+    @Mock
+    private WaitingRepository waitingRepository;
 
     @InjectMocks
     private ReservationService reservationService;
@@ -177,10 +182,33 @@ class ReservationServiceTest {
         void 정상_삭제() {
             Reservation reservation = Reservation.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
             when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+            when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                reservation.getDate(), time.getId(), theme.getId()
+            )).thenReturn(Optional.empty());
 
             reservationService.deleteReservation(1L, "유저1");
 
             verify(reservationRepository, times(1)).deleteById(1L);
+        }
+
+        @Test
+        void 예약_취소_시_1순위_대기를_예약으로_전환한다() {
+            Reservation reservation = Reservation.of(1L, "예약자", LocalDate.of(2099, 12, 31), time, theme);
+            Waiting waiting = Waiting.of(2L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
+            when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+            when(waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                reservation.getDate(), time.getId(), theme.getId()
+            )).thenReturn(Optional.of(waiting));
+
+            reservationService.deleteReservation(1L, "예약자");
+
+            InOrder inOrder = inOrder(reservationRepository, waitingRepository);
+            inOrder.verify(reservationRepository).deleteById(1L);
+            inOrder.verify(waitingRepository).findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                reservation.getDate(), time.getId(), theme.getId()
+            );
+            inOrder.verify(reservationRepository).save(any(Reservation.class));
+            inOrder.verify(waitingRepository).deleteById(waiting.getId());
         }
 
         @Test

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -210,12 +210,12 @@ class ReservationServiceTest {
         }
 
         @Test
-        void 존재하지_않는_id면_예외() {
+        void 존재하지_않는_id면_삭제하지_않음() {
             when(reservationRepository.findByIdForUpdate(99L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> reservationService.deleteReservation(99L, "유저1"))
-                .isInstanceOf(RoomescapeException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.RESERVATION_ID_NOT_FOUND);
+            reservationService.deleteReservation(99L, "유저1");
+
+            verify(reservationRepository, times(0)).deleteById(99L);
         }
     }
 

--- a/src/test/java/roomescape/domain/waiting/WaitingControllerTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingControllerTest.java
@@ -171,11 +171,11 @@ class WaitingControllerTest {
     }
 
     @Test
-    void deleteWaiting_존재하지_않는_id인경우_에러_반환_테스트() {
+    void deleteWaiting_존재하지_않는_id인경우_성공_반환_테스트() {
         RestAssured.given().log().all()
             .when().delete("/reservations/waiting/999?name=유저1")
             .then().log().all()
-            .statusCode(404);
+            .statusCode(204);
     }
 
     private Long insertTheme(String name) {

--- a/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.domain.reservationtime.ReservationTime;
+import roomescape.domain.reservationtime.dto.TimeSlot;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.waiting.dto.MyWaitingResult;
 
@@ -216,7 +217,7 @@ class WaitingRepositoryTest {
 
     @Nested
     @DisplayName("슬롯의 첫 번째 대기 조회")
-    class FindFirstByDateAndTimeIdAndThemeIdForUpdate {
+    class FindFirstByTimeSlotForUpdate {
 
         @Test
         void 같은_날짜_시간_테마의_가장_먼저_등록된_대기를_반환한다() {
@@ -224,9 +225,11 @@ class WaitingRepositoryTest {
             waitingRepository.save(Waiting.of("유저2", LocalDate.of(2099, 12, 31), time, theme));
             waitingRepository.save(Waiting.of("다른날짜", LocalDate.of(2099, 12, 30), time, theme));
 
-            Optional<Waiting> result = waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+            TimeSlot timeSlot = new TimeSlot(
                 LocalDate.of(2099, 12, 31), time.getId(), theme.getId()
             );
+
+            Optional<Waiting> result = waitingRepository.findFirstByTimeSlotForUpdate(timeSlot);
 
             assertAll(
                 () -> assertThat(result).isPresent(),
@@ -239,9 +242,11 @@ class WaitingRepositoryTest {
         void 해당_슬롯의_대기가_없으면_빈_Optional을_반환한다() {
             waitingRepository.save(Waiting.of("유저1", LocalDate.of(2099, 12, 31), time, theme));
 
-            Optional<Waiting> result = waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+            TimeSlot timeSlot = new TimeSlot(
                 LocalDate.of(2099, 12, 30), time.getId(), theme.getId()
             );
+
+            Optional<Waiting> result = waitingRepository.findFirstByTimeSlotForUpdate(timeSlot);
 
             assertThat(result).isEmpty();
         }

--- a/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
@@ -213,4 +213,37 @@ class WaitingRepositoryTest {
             assertThat(result).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("슬롯의 첫 번째 대기 조회")
+    class FindFirstByDateAndTimeIdAndThemeIdForUpdate {
+
+        @Test
+        void 같은_날짜_시간_테마의_가장_먼저_등록된_대기를_반환한다() {
+            Waiting first = waitingRepository.save(Waiting.of("유저1", LocalDate.of(2099, 12, 31), time, theme));
+            waitingRepository.save(Waiting.of("유저2", LocalDate.of(2099, 12, 31), time, theme));
+            waitingRepository.save(Waiting.of("다른날짜", LocalDate.of(2099, 12, 30), time, theme));
+
+            Optional<Waiting> result = waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                LocalDate.of(2099, 12, 31), time.getId(), theme.getId()
+            );
+
+            assertAll(
+                () -> assertThat(result).isPresent(),
+                () -> assertThat(result.get().getId()).isEqualTo(first.getId()),
+                () -> assertThat(result.get().getName()).isEqualTo("유저1")
+            );
+        }
+
+        @Test
+        void 해당_슬롯의_대기가_없으면_빈_Optional을_반환한다() {
+            waitingRepository.save(Waiting.of("유저1", LocalDate.of(2099, 12, 31), time, theme));
+
+            Optional<Waiting> result = waitingRepository.findFirstByDateAndTimeIdAndThemeIdForUpdate(
+                LocalDate.of(2099, 12, 30), time.getId(), theme.getId()
+            );
+
+            assertThat(result).isEmpty();
+        }
+    }
 }

--- a/src/test/java/roomescape/domain/waiting/WaitingServiceTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -188,12 +189,12 @@ class WaitingServiceTest {
         }
 
         @Test
-        void 존재하지_않는_id면_예외() {
+        void 존재하지_않는_id면_삭제하지_않음() {
             when(waitingRepository.findById(99L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> waitingService.deleteWaiting(99L, "유저1"))
-                .isInstanceOf(RoomescapeException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.WAITING_ID_NOT_FOUND);
+            waitingService.deleteWaiting(99L, "유저1");
+
+            verify(waitingRepository, never()).deleteById(99L);
         }
     }
 


### PR DESCRIPTION
안녕하세요 에코! 미션 제출이 늦어지게 되었네요 🥲
마지막 미션 리뷰도 잘 부탁드립니다!🙇‍♀️🙇‍♀️🙇‍♀️

먼저 이번 미션에서의 요구사항이 대기 승격밖에 없고, 지난 미션에서 트랜잭션 관련 처리를 해둔 상황이라 코드의 변경사항이 거의 없습니다...
따라서 이번 미션에서의 부족한 점 뿐 만 아니라, 지난 리뷰에서 말씀해주신 성능 측정 등 다양한 부분에서의 리뷰 또한 남겨주시면 학습 후 반영해보겠습니다!

## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 설계 고려사항

저는 예약 대기를 예약으로 자동 승격시키도록 로직을 구현했습니다.
1. 같은 슬롯(예약 날짜 + 시간 + 테마)의 대기 중 id가 가장 작은 한 칼럼을 가져옵니다
2. 존재하면 해당 데이터를 Reservation 테이블에 저장해 예약을 생성합니다
3. 해당 데이터를 waiting 테이블에서는 삭제합니다

이 과정에서 고려한 동시성 측면은 다음과 같습니다.

예약 취소와 대기 승격은 하나의 트랜잭션 안에서 처리되도록 했습니다. 예약을 삭제한 뒤 대기자를 예약으로 승격하는 사이에 다른 요청이 끼어들면 같은 슬롯에 대해 중복 승격이 발생할 수 있기 때문입니다.

1. 먼저 취소 대상 예약을 조회할 때 FOR UPDATE를 사용해 해당 예약 row에 락을 걸었습니다.
같은 예약 취소 요청이 동시에 들어오더라도 하나의 요청만 먼저 처리되고, 나머지 요청은 앞선 트랜잭션이 끝날 때까지 대기하게 됩니다. 이를 통해 같은 예약이 중복으로 취소되고 대기 승격 로직이 여러 번 실행되는 상황을 방지하려 했습니다.

2. 승격 대상이 되는 1순위 대기 row를 조회할 때도 FOR UPDATE를 사용했습니다.
같은 슬롯의 1순위 대기자를 여러 트랜잭션이 동시에 승격 대상으로 선택하지 못하도록 하기 위함입니다. 예약 row 락이 취소 요청의 중복 처리를 1차로 막고, 대기 row 락은 승격 대상 중복 선택을 한 번 더 방지하는 역할을 합니다.

3. 마지막으로 예약 테이블에는 (date, time_id, theme_id) 유니크 제약이 있기 때문에, 애플리케이션 레벨에서 놓친 중복 예약 시도도 DB 레벨에서 한 번 더 막을 수 있습니다.
이때 대기 순번은 별도 컬럼으로 저장하지 않고 조회 시 계산되므로, 승격된 대기 데이터를 삭제하면 나머지 대기 순번은 자연스럽게 재정렬됩니다.

## 리뷰 포인트

일단 동시성 문제를 락을 거는 방법으로 해결하도록 구현했는데, 이 때 발생하는 성능적인 측면은 고려해보지 못했습니다. 혹시 로직에서 치명적인 성능 문제가 발생하는 부분이 있다면 리뷰 남겨주시면 감사하겠습니다!

또한 이번 미션을 통해 락과 트랜잭션에 대해 공부해보았는데 개념이 어려워 완벽하게 이해했다는 생각이 들지 않는데, 학습하면 좋을 개념들이 있을까요?