### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 카야(최서영) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/reservation/application/event/ReservationScheduleVacatedEvent.java
+++ b/src/main/java/roomescape/reservation/application/event/ReservationScheduleVacatedEvent.java
@@ -1,0 +1,10 @@
+package roomescape.reservation.application.event;
+
+import java.time.LocalDate;
+
+public record ReservationScheduleVacatedEvent(
+        LocalDate date,
+        Long themeId,
+        Long timeId
+) {
+}

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -5,12 +5,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.ReservationQueryResult;
 import roomescape.reservation.application.dto.ReservationUpdateCommand;
+import roomescape.reservation.application.event.ReservationScheduleVacatedEvent;
 import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Waiting;
@@ -30,6 +32,7 @@ public class ReservationService {
     private final WaitingService waitingService;
     private final ThemeService themeService;
     private final ReservationTimeService timeService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<ReservationQueryResult> findAll() {
@@ -69,6 +72,49 @@ public class ReservationService {
         return ReservationQueryResult.from(reservationRepository.save(reservation), themeQueryResult, timeQueryResult);
     }
 
+    public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
+        ReservationDetail reservationDetail = getReservationDetail(request.id());
+        Reservation reservation = toReservation(reservationDetail);
+        validateOwner(request.name(), reservation);
+        validateReservationNotPast(reservationDetail, currentDateTime);
+
+        ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
+        validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
+        validateDuplicateReservation(request, reservation);
+
+        if (isSameSchedule(request, reservation)) {
+            return toQueryResult(reservation);
+        }
+
+        ReservationQueryResult updatedReservation = updateReservation(request, reservation);
+        eventPublisher.publishEvent(new ReservationScheduleVacatedEvent(
+                reservation.getDate(),
+                reservation.getThemeId(),
+                reservation.getTimeId()
+        ));
+
+        return updatedReservation;
+    }
+
+    public int delete(Long id, String name, LocalDateTime currentDateTime) {
+        ReservationDetail reservationDetail = getReservationDetail(id);
+        Reservation reservation = toReservation(reservationDetail);
+        validateOwner(name, reservation);
+        validateReservationNotPast(reservationDetail, currentDateTime);
+
+        int deletedCount = reservationRepository.delete(id);
+
+        if (deletedCount > 0) {
+            eventPublisher.publishEvent(new ReservationScheduleVacatedEvent(
+                    reservation.getDate(),
+                    reservation.getThemeId(),
+                    reservation.getTimeId()
+            ));
+        }
+
+        return deletedCount;
+    }
+
     private void validateDuplicateReservationWaiting(ReservationCreateCommand request) {
         boolean alreadyReservedBySameName = reservationRepository.existsByNameAndDateAndThemeAndTime(
                 request.name(),
@@ -82,34 +128,6 @@ public class ReservationService {
         }
     }
 
-    public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
-        ReservationDetail reservationDetail = getReservationDetail(request.id());
-        Reservation reservation = toReservation(reservationDetail);
-        validateOwner(request.name(), reservation);
-        validateReservationNotPast(reservationDetail, currentDateTime);
-
-        ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
-        validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
-        validateDuplicateReservation(request, reservation);
-
-        if (isSameSchedule(request, reservation)) {
-            return updateReservation(request, reservation);
-        }
-
-        return waitingService.findOldestByReservation(reservation)
-                .map(waiting -> updateWithWaiting(request, reservation, waiting))
-                .orElseGet(() -> updateReservation(request, reservation));
-    }
-
-    private ReservationQueryResult updateWithWaiting(ReservationUpdateCommand request, Reservation reservation, Waiting waiting) {
-        reservationRepository.updateWaitingOwner(reservation.getId(), waiting.getName());
-        waitingService.delete(waiting.getId());
-
-        Reservation movedReservation = reservation.update(request.date(), request.timeId());
-        Reservation savedReservation = reservationRepository.save(movedReservation);
-        return toQueryResult(savedReservation);
-    }
-
     private ReservationQueryResult updateReservation(ReservationUpdateCommand request, Reservation reservation) {
         Reservation updatedReservation = reservation.update(request.date(), request.timeId());
         Reservation savedReservation = reservationRepository.update(updatedReservation);
@@ -119,20 +137,6 @@ public class ReservationService {
     private boolean isSameSchedule(ReservationUpdateCommand request, Reservation reservation) {
         return reservation.getDate().equals(request.date())
                 && reservation.getTimeId().equals(request.timeId());
-    }
-
-    public int delete(Long id, String name, LocalDateTime currentDateTime) {
-        ReservationDetail reservationDetail = getReservationDetail(id);
-        Reservation reservation = toReservation(reservationDetail);
-        validateOwner(name, reservation);
-        validateReservationNotPast(reservationDetail, currentDateTime);
-
-        return waitingService.findOldestByReservation(reservation)
-                .map(waiting -> {
-                    reservationRepository.updateWaitingOwner(reservation.getId(), waiting.getName());
-                    return waitingService.delete(waiting.getId());
-                })
-                .orElseGet(() -> reservationRepository.delete(id));
     }
 
     private ReservationDetail getReservationDetail(Long id) {

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import roomescape.reservationtime.application.service.ReservationTimeService;
 import roomescape.theme.application.dto.ThemeQueryResult;
 import roomescape.theme.application.service.ThemeService;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -59,6 +61,8 @@ public class ReservationService {
 
         if (reservationRepository.existsByDateAndThemeAndTime(request.date(), request.themeId(), request.timeId())) {
             validateDuplicateReservationWaiting(request);
+            log.info("이미 예약된 일정이므로 대기로 저장합니다. date={}, themeId={}, timeId={}",
+                    request.date(), request.themeId(), request.timeId());
 
             Waiting savedWaitingResult = waitingService.save(Waiting.of(
                     null,
@@ -87,11 +91,7 @@ public class ReservationService {
         }
 
         ReservationQueryResult updatedReservation = updateReservation(request, reservation);
-        eventPublisher.publishEvent(new ReservationScheduleVacatedEvent(
-                reservation.getDate(),
-                reservation.getThemeId(),
-                reservation.getTimeId()
-        ));
+        publishScheduleVacated(reservation, "update");
 
         return updatedReservation;
     }
@@ -105,11 +105,7 @@ public class ReservationService {
         int deletedCount = reservationRepository.delete(id);
 
         if (deletedCount > 0) {
-            eventPublisher.publishEvent(new ReservationScheduleVacatedEvent(
-                    reservation.getDate(),
-                    reservation.getThemeId(),
-                    reservation.getTimeId()
-            ));
+            publishScheduleVacated(reservation, "delete");
         }
 
         return deletedCount;
@@ -132,6 +128,21 @@ public class ReservationService {
         Reservation updatedReservation = reservation.update(request.date(), request.timeId());
         Reservation savedReservation = reservationRepository.update(updatedReservation);
         return toQueryResult(savedReservation);
+    }
+
+    private void publishScheduleVacated(Reservation reservation, String reason) {
+        log.info("예약 일정이 비어 대기 승격 이벤트를 발행합니다. reason={}, reservationId={}, date={}, themeId={}, timeId={}",
+                reason,
+                reservation.getId(),
+                reservation.getDate(),
+                reservation.getThemeId(),
+                reservation.getTimeId());
+
+        eventPublisher.publishEvent(new ReservationScheduleVacatedEvent(
+                reservation.getDate(),
+                reservation.getThemeId(),
+                reservation.getTimeId()
+        ));
     }
 
     private boolean isSameSchedule(ReservationUpdateCommand request, Reservation reservation) {

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -70,10 +70,12 @@ public class ReservationService {
     }
 
     private void validateDuplicateReservationWaiting(ReservationCreateCommand request) {
-        boolean alreadyReservedBySameName = reservationRepository.findByName(request.name()).stream()
-                .anyMatch(reservation -> reservation.getDate().equals(request.date())
-                        && reservation.getThemeId().equals(request.themeId())
-                        && reservation.getTimeId().equals(request.timeId()));
+        boolean alreadyReservedBySameName = reservationRepository.existsByNameAndDateAndThemeAndTime(
+                request.name(),
+                request.date(),
+                request.themeId(),
+                request.timeId()
+        );
 
         if (alreadyReservedBySameName) {
             throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -1,8 +1,6 @@
 package roomescape.reservation.application.service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +13,7 @@ import roomescape.reservation.application.dto.ReservationQueryResult;
 import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.event.ReservationScheduleVacatedEvent;
 import roomescape.reservation.application.exception.ReservationErrorCode;
+import roomescape.reservation.application.validator.ReservationValidator;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Waiting;
 import roomescape.reservation.domain.repository.ReservationRepository;
@@ -35,6 +34,7 @@ public class ReservationService {
     private final ThemeService themeService;
     private final ReservationTimeService timeService;
     private final ApplicationEventPublisher eventPublisher;
+    private final ReservationValidator reservationValidator;
 
     @Transactional(readOnly = true)
     public List<ReservationQueryResult> findAll() {
@@ -53,14 +53,14 @@ public class ReservationService {
 
     public ReservationQueryResult save(ReservationCreateCommand request, LocalDateTime currentDateTime) {
         ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
-        validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
+        reservationValidator.validateCreateDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
 
         ThemeQueryResult themeQueryResult = themeService.findById(request.themeId());
 
         Reservation reservation = request.toEntity(themeQueryResult.id(), timeQueryResult.id());
 
         if (reservationRepository.existsByDateAndThemeAndTime(request.date(), request.themeId(), request.timeId())) {
-            validateDuplicateReservationWaiting(request);
+            reservationValidator.validateWaitingRequest(request);
             log.info("이미 예약된 일정이므로 대기로 저장합니다. date={}, themeId={}, timeId={}",
                     request.date(), request.themeId(), request.timeId());
 
@@ -79,12 +79,20 @@ public class ReservationService {
     public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
         ReservationDetail reservationDetail = getReservationDetail(request.id());
         Reservation reservation = toReservation(reservationDetail);
-        validateOwner(request.name(), reservation);
-        validateReservationNotPast(reservationDetail, currentDateTime);
+        reservationValidator.validateModification(
+                request.name(),
+                reservation,
+                reservationDetail,
+                currentDateTime
+        );
 
         ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
-        validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
-        validateDuplicateReservation(request, reservation);
+        reservationValidator.validateUpdateSchedule(
+                request,
+                reservation,
+                timeQueryResult.startAt(),
+                currentDateTime
+        );
 
         if (isSameSchedule(request, reservation)) {
             return toQueryResult(reservation);
@@ -99,8 +107,7 @@ public class ReservationService {
     public int delete(Long id, String name, LocalDateTime currentDateTime) {
         ReservationDetail reservationDetail = getReservationDetail(id);
         Reservation reservation = toReservation(reservationDetail);
-        validateOwner(name, reservation);
-        validateReservationNotPast(reservationDetail, currentDateTime);
+        reservationValidator.validateModification(name, reservation, reservationDetail, currentDateTime);
 
         int deletedCount = reservationRepository.delete(id);
 
@@ -109,19 +116,6 @@ public class ReservationService {
         }
 
         return deletedCount;
-    }
-
-    private void validateDuplicateReservationWaiting(ReservationCreateCommand request) {
-        boolean alreadyReservedBySameName = reservationRepository.existsByNameAndDateAndThemeAndTime(
-                request.name(),
-                request.date(),
-                request.themeId(),
-                request.timeId()
-        );
-
-        if (alreadyReservedBySameName) {
-            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
-        }
     }
 
     private ReservationQueryResult updateReservation(ReservationUpdateCommand request, Reservation reservation) {
@@ -153,40 +147,6 @@ public class ReservationService {
     private ReservationDetail getReservationDetail(Long id) {
         return reservationRepository.findDetailById(id)
                 .orElseThrow(() -> new RoomEscapeException(ReservationErrorCode.RESERVATION_NOT_FOUND));
-    }
-
-    private void validateDuplicateReservation(ReservationUpdateCommand request, Reservation reservation) {
-        Boolean existsByDateAndTime = reservationRepository.existsByDateAndThemeAndTimeExcludingId(
-                request.date(),
-                reservation.getThemeId(),
-                request.timeId(),
-                reservation.getId()
-        );
-        if (existsByDateAndTime) {
-            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
-        }
-    }
-
-    private void validateOwner(String name, Reservation reservation) {
-        if (!reservation.isOwner(name)) {
-            throw new RoomEscapeException(ReservationErrorCode.FORBIDDEN_RESERVATION_ACCESS);
-        }
-    }
-
-    private void validateReservationDateTime(LocalDate date, LocalTime startAt, LocalDateTime currentDateTime) {
-        LocalDateTime triedDateTime = LocalDateTime.of(date, startAt);
-
-        if (triedDateTime.isBefore(currentDateTime)) {
-            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_TIME);
-        }
-    }
-
-    private void validateReservationNotPast(ReservationDetail reservationDetail, LocalDateTime currentDateTime) {
-        LocalDateTime reservationDateTime = LocalDateTime.of(reservationDetail.date(), reservationDetail.startAt());
-
-        if (reservationDateTime.isBefore(currentDateTime)) {
-            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_MODIFICATION);
-        }
     }
 
     private ReservationQueryResult toQueryResult(Reservation reservation) {

--- a/src/main/java/roomescape/reservation/application/service/WaitingService.java
+++ b/src/main/java/roomescape/reservation/application/service/WaitingService.java
@@ -1,16 +1,15 @@
 package roomescape.reservation.application.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import roomescape.global.RoomEscapeException;
-import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.WaitingQueryResult;
 import roomescape.reservation.application.event.ReservationScheduleVacatedEvent;
 import roomescape.reservation.application.exception.ReservationErrorCode;
@@ -20,6 +19,7 @@ import roomescape.reservation.domain.repository.ReservationRepository;
 import roomescape.reservation.domain.repository.WaitingRepository;
 import roomescape.reservation.domain.repository.dto.WaitingDetail;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -51,15 +51,25 @@ public class WaitingService {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void promoteOldestWaiting(ReservationScheduleVacatedEvent event) {
+        log.info("대기 승격 이벤트를 수신했습니다. date={}, themeId={}, timeId={}",
+                event.date(), event.themeId(), event.timeId());
+
         waitingRepository.findOldestByDateAndThemeIdAndTimeId(
                         event.date(),
                         event.themeId(),
                         event.timeId()
                 )
-                .ifPresent(this::promote);
+                .ifPresentOrElse(
+                        this::promote,
+                        () -> log.info("대기가 존재하지 않아 승격을 진행하지 않습니다. date={}, themeId={}, timeId={}",
+                                event.date(), event.themeId(), event.timeId())
+                );
     }
 
     private void promote(Waiting waiting) {
+        log.info("대기를 예약으로 전환합니다. waitingId={}, date={}, themeId={}, timeId={}",
+                waiting.getId(), waiting.getDate(), waiting.getThemeId(), waiting.getTimeId());
+
         Reservation reservation = Reservation.builder()
                 .name(waiting.getName())
                 .date(waiting.getDate())

--- a/src/main/java/roomescape/reservation/application/service/WaitingService.java
+++ b/src/main/java/roomescape/reservation/application/service/WaitingService.java
@@ -1,15 +1,22 @@
 package roomescape.reservation.application.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import roomescape.global.RoomEscapeException;
+import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.WaitingQueryResult;
+import roomescape.reservation.application.event.ReservationScheduleVacatedEvent;
 import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.Waiting;
+import roomescape.reservation.domain.repository.ReservationRepository;
 import roomescape.reservation.domain.repository.WaitingRepository;
 import roomescape.reservation.domain.repository.dto.WaitingDetail;
 
@@ -19,6 +26,7 @@ import roomescape.reservation.domain.repository.dto.WaitingDetail;
 public class WaitingService {
 
     private final WaitingRepository waitingRepository;
+    private final ReservationRepository reservationRepository;
 
     @Transactional(readOnly = true)
     public List<WaitingQueryResult> findAllByName(String name) {
@@ -40,16 +48,27 @@ public class WaitingService {
         return waitingRepository.delete(id);
     }
 
-    public Optional<Waiting> findOldestByReservation(Reservation reservation) {
-        return waitingRepository.findOldestByDateAndThemeIdAndTimeId(
-                reservation.getDate(),
-                reservation.getThemeId(),
-                reservation.getTimeId()
-        );
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void promoteOldestWaiting(ReservationScheduleVacatedEvent event) {
+        waitingRepository.findOldestByDateAndThemeIdAndTimeId(
+                        event.date(),
+                        event.themeId(),
+                        event.timeId()
+                )
+                .ifPresent(this::promote);
     }
 
-    public int delete(Long id) {
-        return waitingRepository.delete(id);
+    private void promote(Waiting waiting) {
+        Reservation reservation = Reservation.builder()
+                .name(waiting.getName())
+                .date(waiting.getDate())
+                .themeId(waiting.getThemeId())
+                .timeId(waiting.getTimeId())
+                .build();
+
+        reservationRepository.save(reservation);
+        waitingRepository.delete(waiting.getId());
     }
 
     private WaitingDetail getWaitingDetail(Long id) {

--- a/src/main/java/roomescape/reservation/application/validator/ReservationValidator.java
+++ b/src/main/java/roomescape/reservation/application/validator/ReservationValidator.java
@@ -1,0 +1,93 @@
+package roomescape.reservation.application.validator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import roomescape.global.RoomEscapeException;
+import roomescape.reservation.application.dto.ReservationCreateCommand;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
+import roomescape.reservation.application.exception.ReservationErrorCode;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.repository.ReservationRepository;
+import roomescape.reservation.domain.repository.dto.ReservationDetail;
+
+@RequiredArgsConstructor
+@Component
+public class ReservationValidator {
+
+    private final ReservationRepository reservationRepository;
+
+    public void validateCreateDateTime(LocalDate date, LocalTime startAt, LocalDateTime currentDateTime) {
+        if (LocalDateTime.of(date, startAt).isBefore(currentDateTime)) {
+            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_TIME);
+        }
+    }
+
+    public void validateModification(
+            String name,
+            Reservation reservation,
+            ReservationDetail reservationDetail,
+            LocalDateTime currentDateTime
+    ) {
+        validateOwner(name, reservation);
+        validateReservationNotPast(reservationDetail, currentDateTime);
+    }
+
+    public void validateUpdateSchedule(
+            ReservationUpdateCommand request,
+            Reservation reservation,
+            LocalTime updatedStartAt,
+            LocalDateTime currentDateTime
+    ) {
+        validateCreateDateTime(request.date(), updatedStartAt, currentDateTime);
+        validateDuplicateReservation(request, reservation);
+    }
+
+    public void validateWaitingRequest(ReservationCreateCommand request) {
+        boolean alreadyReservedBySameName = reservationRepository.existsByNameAndDateAndThemeAndTime(
+                request.name(),
+                request.date(),
+                request.themeId(),
+                request.timeId()
+        );
+
+        if (alreadyReservedBySameName) {
+            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    private void validateDuplicateReservation(ReservationUpdateCommand request, Reservation reservation) {
+        boolean duplicated = reservationRepository.existsByDateAndThemeAndTimeExcludingId(
+                request.date(),
+                reservation.getThemeId(),
+                request.timeId(),
+                reservation.getId()
+        );
+
+        if (duplicated) {
+            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    private void validateOwner(String name, Reservation reservation) {
+        if (!reservation.isOwner(name)) {
+            throw new RoomEscapeException(ReservationErrorCode.FORBIDDEN_RESERVATION_ACCESS);
+        }
+    }
+
+    private void validateReservationNotPast(
+            ReservationDetail reservationDetail,
+            LocalDateTime currentDateTime
+    ) {
+        LocalDateTime reservationDateTime = LocalDateTime.of(
+                reservationDetail.date(),
+                reservationDetail.startAt()
+        );
+
+        if (reservationDateTime.isBefore(currentDateTime)) {
+            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_MODIFICATION);
+        }
+    }
+}

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -23,6 +23,8 @@ public interface ReservationRepository {
 
     Boolean existsByDateAndThemeAndTime(LocalDate date, Long themeId, Long timeId);
 
+    Boolean existsByNameAndDateAndThemeAndTime(String name, LocalDate date, Long themeId, Long timeId);
+
     Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id);
 
     void updateWaitingOwner(Long id, String name);

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
@@ -149,6 +149,29 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public Boolean existsByNameAndDateAndThemeAndTime(
+            String name,
+            LocalDate date,
+            Long themeId,
+            Long timeId
+    ) {
+        return jdbcTemplate.queryForObject(
+                """
+                        SELECT EXISTS(
+                            SELECT 1
+                            FROM reservation
+                            WHERE name = ? AND date = ? AND theme_id = ? AND time_id = ?
+                        )
+                        """,
+                Boolean.class,
+                name,
+                date,
+                themeId,
+                timeId
+        );
+    }
+
+    @Override
     public Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id) {
         return jdbcTemplate.queryForObject(
                 """

--- a/src/test/java/roomescape/fake/FakeReservationRepository.java
+++ b/src/test/java/roomescape/fake/FakeReservationRepository.java
@@ -101,6 +101,20 @@ public class FakeReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public Boolean existsByNameAndDateAndThemeAndTime(
+            String name,
+            LocalDate date,
+            Long themeId,
+            Long timeId
+    ) {
+        return reservations.values().stream()
+                .anyMatch(savedReservation -> savedReservation.getName().equals(name)
+                        && savedReservation.getDate().equals(date)
+                        && savedReservation.getThemeId().equals(themeId)
+                        && savedReservation.getTimeId().equals(timeId));
+    }
+
+    @Override
     public Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id) {
         return reservations.values().stream()
                 .filter(savedReservation -> !savedReservation.getId().equals(id))

--- a/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
+++ b/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
@@ -166,10 +166,16 @@ class ReservationApiIntegrationTest {
                 .body("date", equalTo("2028-05-07"))
                 .body("time.id", equalTo(secondTimeId.intValue()));
 
-        String oldReservationOwner = jdbcTemplate.queryForObject(
-                "SELECT name FROM reservation WHERE id = ?",
+        String promotedReservationOwner = jdbcTemplate.queryForObject(
+                """
+                        SELECT name
+                        FROM reservation
+                        WHERE date = ? AND theme_id = ? AND time_id = ?
+                        """,
                 String.class,
-                reservationId
+                LocalDate.of(2028, 5, 6),
+                themeId,
+                firstTimeId
         );
         Integer waitingCount = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM waiting WHERE id = ?",
@@ -177,7 +183,7 @@ class ReservationApiIntegrationTest {
                 waitingId
         );
 
-        assertThat(oldReservationOwner).isEqualTo("카야");
+        assertThat(promotedReservationOwner).isEqualTo("카야");
         assertThat(waitingCount).isZero();
     }
 
@@ -211,10 +217,21 @@ class ReservationApiIntegrationTest {
                 .then().log().all()
                 .statusCode(204);
 
-        String reservationOwner = jdbcTemplate.queryForObject(
-                "SELECT name FROM reservation WHERE id = ?",
-                String.class,
+        Integer deletedReservationCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation WHERE id = ?",
+                Integer.class,
                 reservationId
+        );
+        String promotedReservationOwner = jdbcTemplate.queryForObject(
+                """
+                        SELECT name
+                        FROM reservation
+                        WHERE date = ? AND theme_id = ? AND time_id = ?
+                        """,
+                String.class,
+                date,
+                themeId,
+                timeId
         );
         Integer firstWaitingCount = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM waiting WHERE id = ?",
@@ -227,7 +244,8 @@ class ReservationApiIntegrationTest {
                 secondWaitingId
         );
 
-        assertThat(reservationOwner).isEqualTo("카야");
+        assertThat(deletedReservationCount).isZero();
+        assertThat(promotedReservationOwner).isEqualTo("카야");
         assertThat(firstWaitingCount).isZero();
         assertThat(secondWaitingCount).isEqualTo(1);
     }

--- a/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
+++ b/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
@@ -195,6 +195,69 @@ class ReservationApiIntegrationTest {
                 .statusCode(204);
     }
 
+    @DisplayName("예약 취소 시 첫 번째 대기자가 예약자로 전환됩니다.")
+    @Test
+    void cancel_reservation_promotes_first_waiting() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        LocalDate date = LocalDate.of(2028, 5, 6);
+        Long reservationId = testHelper.insertReservation("스타크", date, themeId, timeId);
+        Long firstWaitingId = testHelper.insertWaiting("카야", date, themeId, timeId);
+        Long secondWaitingId = testHelper.insertWaiting("타스", date, themeId, timeId);
+
+        RestAssured.given()
+                .queryParam("name", "스타크")
+                .when().delete("/reservations/{id}", reservationId)
+                .then().log().all()
+                .statusCode(204);
+
+        String reservationOwner = jdbcTemplate.queryForObject(
+                "SELECT name FROM reservation WHERE id = ?",
+                String.class,
+                reservationId
+        );
+        Integer firstWaitingCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM waiting WHERE id = ?",
+                Integer.class,
+                firstWaitingId
+        );
+        Integer secondWaitingCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM waiting WHERE id = ?",
+                Integer.class,
+                secondWaitingId
+        );
+
+        assertThat(reservationOwner).isEqualTo("카야");
+        assertThat(firstWaitingCount).isZero();
+        assertThat(secondWaitingCount).isEqualTo(1);
+    }
+
+    @DisplayName("첫 번째 대기자가 예약으로 전환되면 다음 대기자의 순번이 1번이 됩니다.")
+    @Test
+    void promotion_reorders_remaining_waitings() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        LocalDate date = LocalDate.of(2028, 5, 6);
+        Long reservationId = testHelper.insertReservation("스타크", date, themeId, timeId);
+        testHelper.insertWaiting("카야", date, themeId, timeId);
+        testHelper.insertWaiting("타스", date, themeId, timeId);
+
+        RestAssured.given()
+                .queryParam("name", "스타크")
+                .when().delete("/reservations/{id}", reservationId)
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given()
+                .queryParam("name", "타스")
+                .when().get("/waitings")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(1))
+                .body("[0].name", equalTo("타스"))
+                .body("[0].order", equalTo(1));
+    }
+
     @DisplayName("동일한 예약 요청이 동시에 들어오면 1건만 성공하고 나머지는 409를 반환한다.")
     @Test
     void save_reservation_concurrently() throws Exception {

--- a/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
+++ b/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
@@ -187,6 +187,39 @@ class ReservationApiIntegrationTest {
         assertThat(waitingCount).isZero();
     }
 
+    @DisplayName("예약 변경 시 첫 번째 대기자가 예약으로 전환되면 다음 대기자의 순번이 1번이 됩니다.")
+    @Test
+    void update_reservation_with_waiting_reorders_remaining_waitings() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long firstTimeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        Long secondTimeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+        LocalDate date = LocalDate.of(2028, 5, 6);
+        Long reservationId = testHelper.insertReservation("스타크", date, themeId, firstTimeId);
+        testHelper.insertWaiting("카야", date, themeId, firstTimeId);
+        testHelper.insertWaiting("타스", date, themeId, firstTimeId);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "스타크");
+        params.put("date", "2028-05-07");
+        params.put("timeId", String.valueOf(secondTimeId));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().patch("/reservations/{id}", reservationId)
+                .then().log().all()
+                .statusCode(200);
+
+        RestAssured.given()
+                .queryParam("name", "타스")
+                .when().get("/waitings")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(1))
+                .body("[0].name", equalTo("타스"))
+                .body("[0].order", equalTo(1));
+    }
+
     @DisplayName("본인 예약 취소 API를 테스트합니다.")
     @Test
     void cancel_my_reservation() {

--- a/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/repository/JdbcReservationRepositoryTest.java
@@ -1,5 +1,7 @@
 package roomescape.reservation.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import org.assertj.core.api.SoftAssertions;
@@ -49,5 +51,35 @@ class JdbcReservationRepositoryTest {
             assertSoftly.assertThat(savedReservation.getThemeId()).isEqualTo(themeId);
             assertSoftly.assertThat(savedReservation.getTimeId()).isEqualTo(timeId);
         });
+    }
+
+    @DisplayName("이름과 예약 슬롯이 모두 일치하는 예약의 존재 여부를 조회합니다.")
+    @Test
+    void exists_by_name_and_schedule() {
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        LocalDate date = LocalDate.of(2026, 5, 4);
+        reservationRepository.save(Reservation.builder()
+                .name("카야")
+                .date(date)
+                .themeId(themeId)
+                .timeId(timeId)
+                .build());
+
+        Boolean exists = reservationRepository.existsByNameAndDateAndThemeAndTime(
+                "카야",
+                date,
+                themeId,
+                timeId
+        );
+        Boolean existsWithOtherName = reservationRepository.existsByNameAndDateAndThemeAndTime(
+                "스타크",
+                date,
+                themeId,
+                timeId
+        );
+
+        assertThat(exists).isTrue();
+        assertThat(existsWithOtherName).isFalse();
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -21,6 +21,7 @@ import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservation.application.service.WaitingService;
+import roomescape.reservation.application.validator.ReservationValidator;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
 import roomescape.reservationtime.application.dto.ReservationTimeQueryResult;
 import roomescape.reservationtime.application.service.ReservationTimeService;
@@ -54,13 +55,15 @@ class ReservationServiceTest {
         timeService = new ReservationTimeService(timeRepository, availableReservationTimeRepository,
                 reservationQueryService);
         waitingService = new WaitingService(fakeWaitingRepository, reservationRepository);
+        ReservationValidator reservationValidator = new ReservationValidator(reservationRepository);
         reservationService = new ReservationService(
                 reservationRepository,
                 waitingService,
                 themeService,
                 timeService,
                 event -> {
-                });
+                },
+                reservationValidator);
     }
 
     @DisplayName("사용자의 방탈출 예약 시간 추가를 테스트합니다.")

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -53,9 +53,14 @@ class ReservationServiceTest {
                 new FakeAvailableReservationTimeRepository(timeRepository, reservationRepository);
         timeService = new ReservationTimeService(timeRepository, availableReservationTimeRepository,
                 reservationQueryService);
-        waitingService = new WaitingService(fakeWaitingRepository);
-        reservationService = new ReservationService(reservationRepository, waitingService, themeService,
-                timeService);
+        waitingService = new WaitingService(fakeWaitingRepository, reservationRepository);
+        reservationService = new ReservationService(
+                reservationRepository,
+                waitingService,
+                themeService,
+                timeService,
+                event -> {
+                });
     }
 
     @DisplayName("사용자의 방탈출 예약 시간 추가를 테스트합니다.")

--- a/src/test/java/roomescape/reservation/service/WaitingServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/WaitingServiceTest.java
@@ -8,11 +8,15 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import roomescape.fake.FakeReservationRepository;
+import roomescape.fake.FakeReservationTimeRepository;
+import roomescape.fake.FakeThemeRepository;
 import roomescape.fake.FakeWaitingRepository;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.application.service.WaitingService;
 import roomescape.reservation.domain.Waiting;
+import roomescape.reservation.domain.repository.ReservationRepository;
 import roomescape.reservation.domain.repository.WaitingRepository;
 import roomescape.reservation.domain.repository.dto.WaitingDetail;
 
@@ -20,11 +24,13 @@ class WaitingServiceTest {
 
     private WaitingRepository waitingRepository;
     private WaitingService waitingService;
+    private ReservationRepository reservationRepository;
 
     @BeforeEach
     void setUp() {
         waitingRepository = new FakeWaitingRepository();
-        waitingService = new WaitingService(waitingRepository);
+        reservationRepository = new FakeReservationRepository(new FakeThemeRepository(), new FakeReservationTimeRepository());
+        waitingService = new WaitingService(waitingRepository, reservationRepository);
     }
 
     @DisplayName("대기 취소를 할 수 있어야 한다.")

--- a/src/test/java/roomescape/reservation/validator/ReservationValidatorTest.java
+++ b/src/test/java/roomescape/reservation/validator/ReservationValidatorTest.java
@@ -1,0 +1,142 @@
+package roomescape.reservation.validator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import roomescape.global.RoomEscapeException;
+import roomescape.reservation.application.dto.ReservationCreateCommand;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
+import roomescape.reservation.application.validator.ReservationValidator;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.repository.ReservationRepository;
+import roomescape.reservation.domain.repository.dto.ReservationDetail;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationValidatorTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private ReservationValidator reservationValidator;
+
+    @BeforeEach
+    void setUp() {
+        reservationValidator = new ReservationValidator(reservationRepository);
+    }
+
+    @DisplayName("현재보다 이전 일정으로 예약할 수 없습니다.")
+    @Test
+    void validate_create_date_time() {
+        assertThatThrownBy(() -> reservationValidator.validateCreateDateTime(
+                LocalDate.of(2026, 5, 6),
+                LocalTime.of(10, 0),
+                LocalDateTime.of(2026, 5, 6, 11, 0)
+        ))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
+    }
+
+    @DisplayName("예약자가 아닌 사용자는 예약을 변경할 수 없습니다.")
+    @Test
+    void validate_update_owner() {
+        Reservation reservation = createReservation();
+        ReservationDetail reservationDetail = createReservationDetail();
+        ReservationUpdateCommand request = new ReservationUpdateCommand(
+                reservation.getId(),
+                "카야",
+                LocalDate.of(2026, 5, 7),
+                2L
+        );
+
+        assertThatThrownBy(() -> reservationValidator.validateModification(
+                request.name(),
+                reservation,
+                reservationDetail,
+                LocalDateTime.of(2026, 5, 1, 0, 0)
+        ))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("본인의 예약만 변경하거나 취소할 수 있습니다.");
+    }
+
+    @DisplayName("이미 예약이 존재하는 일정으로 변경할 수 없습니다.")
+    @Test
+    void validate_duplicate_update() {
+        Reservation reservation = createReservation();
+        ReservationDetail reservationDetail = createReservationDetail();
+        ReservationUpdateCommand request = new ReservationUpdateCommand(
+                reservation.getId(),
+                reservation.getName(),
+                LocalDate.of(2026, 5, 7),
+                2L
+        );
+        given(reservationRepository.existsByDateAndThemeAndTimeExcludingId(
+                request.date(),
+                reservation.getThemeId(),
+                request.timeId(),
+                reservation.getId()
+        )).willReturn(true);
+
+        assertThatThrownBy(() -> reservationValidator.validateUpdateSchedule(
+                request,
+                reservation,
+                LocalTime.of(11, 0),
+                LocalDateTime.of(2026, 5, 1, 0, 0)
+        ))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("이미 해당 날짜와 시간에 예약이 존재합니다.");
+    }
+
+    @DisplayName("이미 같은 일정에 예약한 사용자는 대기를 신청할 수 없습니다.")
+    @Test
+    void validate_duplicate_waiting_request() {
+        ReservationCreateCommand request = new ReservationCreateCommand(
+                "스타크",
+                LocalDate.of(2026, 5, 6),
+                1L,
+                1L
+        );
+        given(reservationRepository.existsByNameAndDateAndThemeAndTime(
+                request.name(),
+                request.date(),
+                request.themeId(),
+                request.timeId()
+        )).willReturn(true);
+
+        assertThatThrownBy(() -> reservationValidator.validateWaitingRequest(request))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("이미 해당 날짜와 시간에 예약이 존재합니다.");
+    }
+
+    private Reservation createReservation() {
+        return Reservation.builder()
+                .id(1L)
+                .name("스타크")
+                .date(LocalDate.of(2026, 5, 6))
+                .themeId(1L)
+                .timeId(1L)
+                .build();
+    }
+
+    private ReservationDetail createReservationDetail() {
+        return new ReservationDetail(
+                1L,
+                "스타크",
+                LocalDate.of(2026, 5, 6),
+                1L,
+                "theme",
+                "description",
+                "thumbnail",
+                1L,
+                LocalTime.of(10, 0)
+        );
+    }
+}


### PR DESCRIPTION
안녕하세요, 카프카
이번 미션도 잘 부탁드립니다🙇‍♂️

이번 단계의 요구사항인 예약 취소 시 대기 자동 승인과 순번 재정렬은 이전 사이클에서 대부분 구현해 두어 변경 코드가 많지 않습니다!
이번에는 기존 동작을 테스트로 보완하고, 중복 검증 과정에서 불필요하게 전체 예약을 조회하던 부분을 EXISTS 쿼리로 개선했습니다!

그리고 이번 미션의 부족한 점뿐만 아니라, 지난 리뷰에서 말씀해 주신 로그 등 추가로 학습하면 좋을 부분도 함께 피드백해 주시면 학습한 뒤 반영해 보겠습니다 😊

<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

## 1. 외래 키를 가진 도메인 객체의 책임을 어떻게 나누면 좋을까요?
처음에는 사이클 1에서 말씀해 주신 로그 기능을 먼저 추가해 보려 했지만, 그전에 현재 코드 구조가 충분히 객체지향적이지 않다는 생각이 들어 구조부터 개선해 보고자 했습니다!

현재 Reservation은 Theme, ReservationTime 객체가 아니라 themeId, timeId만 가지고 있습니다. 
이 때문에 예약 시간이 과거인지 확인하는 것처럼 실제 연관 데이터가 필요한 검증은 서비스에서 DB 조회 후 처리하고 있습니다.

처음에는 이런 검증을 도메인 객체가 담당하려면 Reservation이 ID가 아닌 Theme, ReservationTime 객체를 직접 가져야 하는 것 아닐까 생각했습니다.  그래서 실제로 연관 엔티티를 포함하는 구조로 변경하는 작업도 진행했었습니다!

그러던 중 코치님들과 대화하면서, 좋지 않은 방식이라고 생각되더라도 직접 끝까지 구현해 보고 문제를 경험하는 과정도 필요하다는 이야기를 들었습니다. 그래서 이번 미션까지는 기존처럼 도메인이 외래 키를 가지는 구조를 유지한 채 개선해 보기로 결정했고, 진행하던 변경과 커밋을 모두 되돌린 뒤 다시 시작했습니다.

하지만 ID 중심의 구조를 유지하니 조회와 검증, 대기 전환 등의 로직이 계속 ReservationService에 모였습니다. 
서비스 코드가 길어지고 흐름도 읽기 어려워졌는데, 이것이 ID를 가지는 모델 자체의 문제인지 
아니면 제가 책임을 제대로 나누지 못한 문제인지 판단하기 어려웠습니다.

실무에서도 연관 엔티티 전체가 아니라 외래 키만 도메인 객체에 저장하는 경우가 많은 것으로 알고 있습니다. 
그렇다고 모든 코드가 지금의 제 서비스처럼 비대하고 복잡하지는 않을 것 같습니다..

외래 키 중심의 도메인 모델을 유지하면서도 서비스가 비대해지지 않게 하려면 보통 조회, 검증, 유스케이스 흐름을 어떻게 나누는지 궁금합니다! 또한 현재 구조에서 가장 먼저 책임을 분리하거나 개선해 볼 부분이 어디인지 의견을 듣고 싶습니다!

## 2. 단일 쿼리에도 트랜잭션을 선언해야 할까요?
이번 사이클에서는 트랜잭션을 중점적으로 공부하고 있습니다.

하나의 서비스 메서드가 단순한 INSERT 또는 DELETE 쿼리 하나만 실행한다면, 명시적인 @Transactional이 반드시 필요한지 궁금합니다. 
단일 SQL은 DB가 원자성을 보장하므로 기능적으로는 없어도 될 것 같지만, 애플리케이션의 트랜잭션 경계를 서비스 계층에 명확히 표현한다는 관점에서는 선언하는 것이 자연스러워 보입니다.

실무에서는 단일 쿼리인 경우에도 서비스의 변경 메서드에 일관되게 @Transactional을 선언하는지,
아니면 여러 쿼리의 원자성이 필요한 경우에만 선언하는지 궁금합니다!

## 3. 예약 취소와 대기 승격을 하나의 트랜잭션으로 묶는 것이 적절할까요?
현재 예약 취소 시 대기자가 존재하면 다음 작업을 하나의 트랜잭션으로 처리하고 있습니다.

- 예약 취소
- 첫 번째 대기자 조회
- 해당 대기자를 예약자로 승격
- 승격된 대기 정보 삭제

처음에는 중간에 일부 작업만 반영되면 데이터 정합성이 깨진다고 생각해 모든 작업을 하나의 트랜잭션으로 묶었습니다. 
예를 들어 예약만 취소되고 대기 승격이 실패하면, 예약 가능한 슬롯인데도 대기자만 남는 상태가 될 수 있기 때문입니다!

그런데 다시 생각해 보니 예약 취소와 대기 승격을 반드시 하나의 원자적인 작업으로 봐야 하는지 의문이 생겼습니다. 
예약 취소는 사용자가 요청한 핵심 작업이므로 먼저 확정하고, 대기 승격에 실패하면 재시도하거나 별도의 후속 작업으로 처리하는 방법도 있을 것 같습니다.

이 경우 예약 취소 요청은 대기 승격 실패의 영향을 받지 않는다는 장점이 있지만, 승격이 완료될 때까지 일시적으로 데이터가 불완전한 상태가 됩니다. 반대로 하나의 트랜잭션으로 묶으면 강한 정합성은 보장되지만, 대기 승격 실패 때문에 사용자의 예약 취소까지 실패하게 됩니다.

이전에는 정합성이 깨질 수 있는 작업은 당연히 하나의 트랜잭션으로 묶어야 한다고 생각했습니다. 
지금은 비즈니스적으로 어느 수준의 정합성이 필요한지와 실패 시 어떤 동작을 보장해야 하는지를 먼저 결정해야 한다고 생각합니다!

현재 요구사항에서는 예약 취소와 대기 승격을 하나의 트랜잭션으로 처리하는 것이 적절할까요? 실무에서는 이러한 작업을 하나의 트랜잭션으로 묶을지, 예약 취소 후 승격을 재시도 가능한 별도 작업으로 분리할지 어떤 기준으로 판단하는지 궁금합니다!
