### PR TITLE
[🚀 사이클2 - 미션 (예약 대기 승인)] 피노(문해찬) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/reservation/application/service/ReservationCommandService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationCommandService.java
@@ -76,7 +76,7 @@ public class ReservationCommandService {
         );
     }
 
-    public void delete(Long reservationId, LocalDateTime now) {
+    public void cancel(Long reservationId, LocalDateTime now) {
         ReservationSlot slot = reservationRepository.findSlotById(reservationId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 예약입니다."));
 

--- a/src/main/java/roomescape/reservation/application/service/ReservationCommandService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationCommandService.java
@@ -96,11 +96,15 @@ public class ReservationCommandService {
         );
 
         validateNoDuplicateReservationSlot(updatedReservation);
-        if (reservationRepository.update(updatedReservation.getId(), updatedReservation.getSlot()) == 0) {
+        if (isUpdateFailed(updatedReservation)) {
             throw new NotFoundException("존재하지 않는 예약입니다.");
         }
 
         return updatedReservation;
+    }
+
+    private boolean isUpdateFailed(Reservation updatedReservation) {
+        return reservationRepository.update(updatedReservation.getId(), updatedReservation.getSlot()) == 0;
     }
 
     private void promoteFirstWaitingToReservation(ReservationSlot slot) {

--- a/src/main/java/roomescape/reservation/application/service/WaitingCommandService.java
+++ b/src/main/java/roomescape/reservation/application/service/WaitingCommandService.java
@@ -59,7 +59,7 @@ public class WaitingCommandService {
         );
     }
 
-    public void delete(Long id, LocalDateTime now) {
+    public void cancel(Long id, LocalDateTime now) {
         ReservationSlot slot = waitingRepository.findSlotById(id)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 대기입니다."));
 

--- a/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
@@ -69,10 +69,10 @@ public class ReservationController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteReservation(
+    public ResponseEntity<Void> cancelReservation(
             @PathVariable Long id
     ) {
-        reservationCommandService.delete(id, LocalDateTime.now());
+        reservationCommandService.cancel(id, LocalDateTime.now());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/reservation/presentation/controller/WaitingController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/WaitingController.java
@@ -55,10 +55,10 @@ public class WaitingController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteWaiting(
+    public ResponseEntity<Void> cancelWaiting(
             @PathVariable Long id
     ) {
-        waitingCommandService.delete(id, LocalDateTime.now());
+        waitingCommandService.cancel(id, LocalDateTime.now());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
@@ -350,4 +350,20 @@ class ReservationCommandServiceTest {
         assertThat(survivedReservation).isNotNull();
         assertThat(survivedReservation.getMemberName().name()).isEqualTo("피노");
     }
+
+    @DisplayName("예약을 취소할 때, 해당 슬롯에 대기자가 아무도 없어도 정상적으로 취소되어야 한다.")
+    @Test
+    void cancel_reservation_when_no_waiting_exists_successfully() {
+        Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+
+        Long reservationId = testHelper.insertReservation("피노", ReservationFixture.futureReservationDate(), themeId,
+                timeId);
+
+        assertThatNoException().isThrownBy(() -> reservationCommandService.cancel(reservationId, NOW));
+
+        assertThatThrownBy(() -> reservationCommandService.cancel(reservationId, NOW))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("존재하지 않는 예약");
+    }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
@@ -70,7 +70,7 @@ class ReservationCommandServiceTest {
 
     @DisplayName("예약 삭제를 테스트합니다.")
     @Test
-    void delete_reservation() {
+    void cancel_reservation() {
         Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
         Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
         Long reservationId = testHelper.insertReservation(
@@ -80,20 +80,20 @@ class ReservationCommandServiceTest {
                 timeId
         );
 
-        assertThatNoException().isThrownBy(() -> reservationCommandService.delete(reservationId, NOW));
+        assertThatNoException().isThrownBy(() -> reservationCommandService.cancel(reservationId, NOW));
     }
 
     @DisplayName("삭제할 예약이 없을 시 예외 발생을 테스트합니다.")
     @Test
-    void delete_not_found_reservation_exception() {
-        assertThatThrownBy(() -> reservationCommandService.delete(1L, NOW))
+    void cancel_not_found_reservation_exception() {
+        assertThatThrownBy(() -> reservationCommandService.cancel(1L, NOW))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 예약입니다.");
     }
 
     @DisplayName("삭제할 예약이 현재 시간보다 이전 시간일 경우 예외 발생을 테스트합니다.")
     @Test
-    void delete_past_reservation_exception() {
+    void cancel_past_reservation_exception() {
         Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
         Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
         Long reservationId = testHelper.insertReservation(
@@ -103,7 +103,7 @@ class ReservationCommandServiceTest {
                 timeId
         );
 
-        assertThatThrownBy(() -> reservationCommandService.delete(reservationId, NOW))
+        assertThatThrownBy(() -> reservationCommandService.cancel(reservationId, NOW))
                 .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("이미 지나간 예약은 삭제할 수 없습니다.");
     }
@@ -233,7 +233,7 @@ class ReservationCommandServiceTest {
 
     @DisplayName("확정 예약 삭제 시 예약 대기의 확정 예약으로의 승격을 테스트합니다.")
     @Test
-    void delete_confirmed_reservation_and_waiting_to_reservation() {
+    void cancel_confirmed_reservation_and_waiting_to_reservation() {
         Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
         Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
         Long reservationId = testHelper.insertReservation(
@@ -249,7 +249,7 @@ class ReservationCommandServiceTest {
                 timeId
         );
 
-        reservationCommandService.delete(reservationId, NOW);
+        reservationCommandService.cancel(reservationId, NOW);
 
         ReservationSlot slot = ReservationSlot.builder()
                 .date(ReservationFixture.futureReservationDate())
@@ -261,7 +261,7 @@ class ReservationCommandServiceTest {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(promoteReservation.getMemberName().name()).isEqualTo("스타크");
-            softly.assertThatThrownBy(() -> reservationCommandService.delete(reservationId, NOW))
+            softly.assertThatThrownBy(() -> reservationCommandService.cancel(reservationId, NOW))
                     .isInstanceOf(NotFoundException.class);
         });
     }

--- a/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationCommandServiceTest.java
@@ -1,7 +1,10 @@
 package roomescape.reservation.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -9,6 +12,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import roomescape.fixture.ReservationFixture;
 import roomescape.fixture.ThemeFixture;
 import roomescape.global.exception.ConflictException;
@@ -21,6 +25,7 @@ import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.service.ReservationCommandService;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.ReservationSlot;
+import roomescape.reservation.domain.repository.WaitingRepository;
 import roomescape.reservationtime.application.dto.ReservationTimeResult;
 import roomescape.support.ServiceTest;
 import roomescape.support.TestDataHelper;
@@ -35,6 +40,9 @@ class ReservationCommandServiceTest {
 
     @Autowired
     private TestDataHelper testHelper;
+
+    @MockitoSpyBean
+    private WaitingRepository waitingRepository;
 
     @DisplayName("사용자의 방탈출 예약 생성을 테스트합니다.")
     @Test
@@ -310,5 +318,36 @@ class ReservationCommandServiceTest {
             softly.assertThat(changeReservation.getMemberName().name()).isEqualTo("피노");
             softly.assertThat(promoteReservation.getMemberName().name()).isEqualTo("스타크");
         });
+    }
+
+    @DisplayName("예약 취소 중 대기 승격이 실패하면, 기존 예약 취소도 롤백되어 DB에 남아있어야 한다.")
+    @Test
+    void delete_rollback_when_waiting_promotion_fails() {
+        Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+
+        Long reservationId = testHelper.insertReservation("피노", ReservationFixture.futureReservationDate(), themeId,
+                timeId);
+        testHelper.insertWaiting("스타크", ReservationFixture.futureReservationDate(), themeId, timeId);
+
+        doThrow(new RuntimeException("대기 승격 중 에러 발생!"))
+                .when(waitingRepository)
+                .delete(anyLong());
+
+        assertThatThrownBy(() -> reservationCommandService.cancel(reservationId, NOW))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("에러 발생!");
+
+        ReservationSlot slot = ReservationSlot.builder()
+                .date(ReservationFixture.futureReservationDate())
+                .themeId(themeId)
+                .timeId(timeId)
+                .startAt(LocalTime.of(10, 0))
+                .build();
+
+        Reservation survivedReservation = testHelper.findReservationBySlot(slot);
+
+        assertThat(survivedReservation).isNotNull();
+        assertThat(survivedReservation.getMemberName().name()).isEqualTo("피노");
     }
 }

--- a/src/test/java/roomescape/reservation/service/WaitingCommandServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/WaitingCommandServiceTest.java
@@ -130,7 +130,7 @@ class WaitingCommandServiceTest {
 
     @DisplayName("예약 대기 삭제를 테스트합니다.")
     @Test
-    void delete_waiting_reservation() {
+    void cancel_waiting_reservation() {
         Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
         Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
         Long waitingId = testHelper.insertWaiting(
@@ -140,20 +140,20 @@ class WaitingCommandServiceTest {
                 timeId
         );
 
-        assertThatNoException().isThrownBy(() -> waitingCommandService.delete(waitingId, NOW));
+        assertThatNoException().isThrownBy(() -> waitingCommandService.cancel(waitingId, NOW));
     }
 
     @DisplayName("삭제할 예약 대기가 없을 시 예외 발생을 테스트합니다.")
     @Test
-    void delete_not_found_waiting_exception() {
-        assertThatThrownBy(() -> waitingCommandService.delete(1L, NOW))
+    void cancel_not_found_waiting_exception() {
+        assertThatThrownBy(() -> waitingCommandService.cancel(1L, NOW))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 대기입니다.");
     }
 
     @DisplayName("삭제할 예약 대기가 현재 시간보다 이전 시간일 경우 예외 발생을 테스트합니다.")
     @Test
-    void delete_past_waiting_exception() {
+    void cancel_past_waiting_exception() {
         Long themeId = testHelper.insertTheme(ThemeFixture.horrorThemeCreateCommand());
         Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
         Long waitingId = testHelper.insertWaiting(
@@ -163,7 +163,7 @@ class WaitingCommandServiceTest {
                 timeId
         );
 
-        assertThatThrownBy(() -> waitingCommandService.delete(waitingId, NOW))
+        assertThatThrownBy(() -> waitingCommandService.cancel(waitingId, NOW))
                 .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("이미 지나간 예약은 삭제할 수 없습니다.");
     }


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [x] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

안녕하세요 찰리! 피노입니다 😄

이전 미션에서 어느정도 구현을 했어서 코드가 많이 추가되진 않았습니다

질문 2개가 있습니다!

#### Q1. 트랜잭션 경계와 사용자 경험 간의 고민

이번 미션에서 데이터 일관성을 위해 '사용자의 예약 취소'와 '대기자의 예약 승격'을 하나의 트랜잭션으로 묶었습니다. 그런데 만약 대기 승격 로직에 서버 장애가 발생하면 멀쩡한 사용자의 예약 취소 요청까지 실패되어 좋지 않을 것 같다는 생각이 들었습니다. 일단 '예약 취소'는 성공시키고, 대기 승격은 나중에 처리하는 방식이 더 사용자 입장을 더 고려한 것 같습니다. 이런 트랜잭션의 일관성과 사용자 경험을 위한 설계. 찰리는 어떤 방식을 선택할 것 같은지 궁금합니다!

#### Q2. 롤백 테스트에 대한 고민

대기 승격 중간에 실패할 경우 예약 취소도 롤백되는지 검증하는 테스트 @SpyBean 을 작성했습니다. 그런데 처음에는 '스프링의 @Transactional이 잘 동작하는지 검증하는 불필요한 프레임워크 테스트가 아닌가?' 하는 의문이 들었습니다. 스스로 고민해 본 결과, 예외를 삼키는등 개발자의 에러로 인해 트랜잭션 경계가 깨지는 것을 방지하기 위한 안전망이라고 결론을 내렸습니다. 찰리는 이런 트랜잭션을 사용할 때  롤백 상황에 대한 예외 테스트를 모두 꼼꼼하게 작성하는 편인지 궁금합니다!

감사합니다!