### PR TITLE
[🚀 방탈출 (예약 대기 승인)] 사이클2 - 밍구(구민서) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/roomescape/config/RetryConfig.java
+++ b/src/main/java/roomescape/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/roomescape/domain/Waiting.java
+++ b/src/main/java/roomescape/domain/Waiting.java
@@ -51,6 +51,10 @@ public class Waiting {
         }
     }
 
+    public Reservation promote(LocalDateTime now) {
+        return Reservation.create(this.name, this.date, this.time, this.theme, now);
+    }
+
     public boolean isSameName(String name) {
         return this.name.equals(name);
     }

--- a/src/main/java/roomescape/repository/UserReservationRepository.java
+++ b/src/main/java/roomescape/repository/UserReservationRepository.java
@@ -6,10 +6,9 @@ import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
-import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
-import roomescape.domain.Waiting;
 import roomescape.service.dto.UserReservation;
 
 @Repository
@@ -69,17 +68,19 @@ public class UserReservationRepository {
                     rs.getString("thumbnail")
             );
 
-            String status = rs.getString("status");
+            ReservationStatus status = ReservationStatus.valueOf(rs.getString("status"));
+            Long rank = rs.getObject("rank", Long.class);
 
-            if (status.equals("RESERVED")) {
-                return UserReservation.reserved(new Reservation(rs.getLong("id"), rs.getString("name"),
-                        LocalDate.parse(rs.getString("date")), time, theme));
-            }
+            UserReservation userReservation = new UserReservation(
+                    rs.getLong("id"),
+                    rs.getString("name"),
+                    LocalDate.parse(rs.getString("date")),
+                    time,
+                    theme,
+                    status,
+                    rank);
 
-            long rank = rs.getLong("rank");
-
-            return UserReservation.waiting(new Waiting(rs.getLong("id"), rs.getString("name"),
-                    LocalDate.parse(rs.getString("date")), time, theme), rank);
+            return userReservation;
         };
     }
 }

--- a/src/main/java/roomescape/repository/UserReservationRepository.java
+++ b/src/main/java/roomescape/repository/UserReservationRepository.java
@@ -6,8 +6,10 @@ import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
+import roomescape.domain.Waiting;
 import roomescape.service.dto.UserReservation;
 
 @Repository
@@ -70,14 +72,14 @@ public class UserReservationRepository {
             String status = rs.getString("status");
 
             if (status.equals("RESERVED")) {
-                return UserReservation.reserved(rs.getLong("id"), rs.getString("name"),
-                        LocalDate.parse(rs.getString("date")), time, theme);
+                return UserReservation.reserved(new Reservation(rs.getLong("id"), rs.getString("name"),
+                        LocalDate.parse(rs.getString("date")), time, theme));
             }
 
             long rank = rs.getLong("rank");
 
-            return UserReservation.waiting(rs.getLong("id"), rs.getString("name"),
-                    LocalDate.parse(rs.getString("date")), time, theme, rank);
+            return UserReservation.waiting(new Waiting(rs.getLong("id"), rs.getString("name"),
+                    LocalDate.parse(rs.getString("date")), time, theme), rank);
         };
     }
 }

--- a/src/main/java/roomescape/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/repository/WaitingRepository.java
@@ -147,7 +147,7 @@ public class WaitingRepository {
         };
     }
 
-    public Optional<Waiting> findFirstBySchedule(LocalDate date, Long timeId, Long themeId) {
+    public Optional<Waiting> findFirstBySchedule(LocalDate date, long timeId, long themeId) {
         String sql = """
                 SELECT w.id          AS waiting_id,
                        w.name        AS waiting_name,

--- a/src/main/java/roomescape/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/repository/WaitingRepository.java
@@ -146,4 +146,30 @@ public class WaitingRepository {
             );
         };
     }
+
+    public Optional<Waiting> findFirstBySchedule(LocalDate date, Long timeId, Long themeId) {
+        String sql = """
+                SELECT w.id          AS waiting_id,
+                       w.name        AS waiting_name,
+                       w.date        AS waiting_date,
+                       t.id          AS time_id,
+                       t.start_at    AS time_start_at,
+                       th.id         AS theme_id,
+                       th.name       AS theme_name,
+                       th.description AS theme_description,
+                       th.thumbnail  AS theme_thumbnail
+                FROM waiting w
+                JOIN reservation_time t ON w.time_id = t.id
+                JOIN theme th ON w.theme_id = th.id
+                WHERE w.date = ? AND w.time_id = ? AND w.theme_id = ?
+                ORDER BY w.id
+                LIMIT 1
+                """;
+        try {
+            Waiting waiting = jdbcTemplate.queryForObject(sql, reservationRowsMapper(), date, timeId, themeId);
+            return Optional.ofNullable(waiting);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -10,6 +10,7 @@ import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
+import roomescape.repository.WaitingRepository;
 import roomescape.service.dto.UserReservation;
 import roomescape.service.event.ReservationSlotReleasedEvent;
 import roomescape.service.exception.BusinessConflictException;
@@ -26,6 +27,7 @@ import java.util.List;
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final WaitingRepository waitingRepository;
     private final UserReservationRepository userReservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
     private final ThemeRepository themeRepository;
@@ -34,6 +36,7 @@ public class ReservationService {
 
     public ReservationService(
             ReservationRepository reservationRepository,
+            WaitingRepository waitingRepository,
             UserReservationRepository userReservationRepository,
             ReservationTimeRepository reservationTimeRepository,
             ThemeRepository themeRepository,
@@ -41,6 +44,7 @@ public class ReservationService {
             ApplicationEventPublisher eventPublisher
     ) {
         this.reservationRepository = reservationRepository;
+        this.waitingRepository = waitingRepository;
         this.userReservationRepository = userReservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
@@ -58,6 +62,8 @@ public class ReservationService {
 
     @Transactional
     public Reservation createReservation(String name, LocalDate date, long timeId, long themeId) {
+        checkWaitingExists(date, timeId, themeId);
+
         ReservationTime time = reservationTimeRepository.findById(timeId)
                 .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.RESERVATION_TIME_NOT_FOUND));
 
@@ -112,6 +118,14 @@ public class ReservationService {
 
         if (duplicated) {
             throw new BusinessConflictException(ErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    private void checkWaitingExists(LocalDate date, long timeId, long themeId) {
+        boolean waitingExists = waitingRepository.findFirstBySchedule(date, timeId, themeId).isPresent();
+
+        if (waitingExists) {
+            throw new BusinessConflictException(ErrorCode.RESERVATION_NOT_ALLOWED_WITH_WAITING);
         }
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,5 +1,6 @@
 package roomescape.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.Reservation;
@@ -10,6 +11,7 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
 import roomescape.service.dto.UserReservation;
+import roomescape.service.event.ReservationCancelledEvent;
 import roomescape.service.exception.BusinessConflictException;
 import roomescape.service.exception.ErrorCode;
 import roomescape.service.exception.ResourceNotFoundException;
@@ -23,27 +25,27 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ReservationService {
 
-    private final WaitingService waitingService;
     private final ReservationRepository reservationRepository;
     private final UserReservationRepository userReservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
     private final ThemeRepository themeRepository;
     private final Clock clock;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ReservationService(
-            WaitingService waitingService,
             ReservationRepository reservationRepository,
             UserReservationRepository userReservationRepository,
             ReservationTimeRepository reservationTimeRepository,
             ThemeRepository themeRepository,
-            Clock clock
+            Clock clock,
+            ApplicationEventPublisher eventPublisher
     ) {
-        this.waitingService = waitingService;
         this.reservationRepository = reservationRepository;
         this.userReservationRepository = userReservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
         this.clock = clock;
+        this.eventPublisher = eventPublisher;
     }
 
     public List<Reservation> findReservations(int page, int size) {
@@ -89,14 +91,9 @@ public class ReservationService {
         reservation.checkCancellable(name, LocalDateTime.now(clock));
         reservationRepository.delete(reservation);
 
-        waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
-                        reservation.getTheme().getId())
-                .ifPresent(waiting -> {
-                    waitingService.promoteWaiting(waiting);
-                    reservationRepository.save(
-                            Reservation.create(waiting.getName(), waiting.getDate(), waiting.getTime(),
-                                    waiting.getTheme(), LocalDateTime.now(clock)));
-                });
+        eventPublisher.publishEvent(
+                new ReservationCancelledEvent(id, reservation.getDate(), reservation.getTime().getId(),
+                        reservation.getTheme().getId()));
     }
 
     private void checkDuplicated(Reservation reservation) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -11,7 +11,7 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
 import roomescape.service.dto.UserReservation;
-import roomescape.service.event.ReservationCancelledEvent;
+import roomescape.service.event.ReservationSlotReleasedEvent;
 import roomescape.service.exception.BusinessConflictException;
 import roomescape.service.exception.ErrorCode;
 import roomescape.service.exception.ResourceNotFoundException;
@@ -80,6 +80,11 @@ public class ReservationService {
         Reservation updated = reservation.changeSchedule(date, time, name, LocalDateTime.now(clock));
         checkDuplicated(updated);
         reservationRepository.update(updated);
+
+        eventPublisher.publishEvent(
+                new ReservationSlotReleasedEvent(id, reservation.getDate(), reservation.getTime().getId(),
+                        reservation.getTheme().getId()));
+
         return updated;
     }
 
@@ -92,7 +97,7 @@ public class ReservationService {
         reservationRepository.delete(reservation);
 
         eventPublisher.publishEvent(
-                new ReservationCancelledEvent(id, reservation.getDate(), reservation.getTime().getId(),
+                new ReservationSlotReleasedEvent(id, reservation.getDate(), reservation.getTime().getId(),
                         reservation.getTheme().getId()));
     }
 

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -23,6 +23,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ReservationService {
 
+    private final WaitingService waitingService;
     private final ReservationRepository reservationRepository;
     private final UserReservationRepository userReservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
@@ -30,12 +31,14 @@ public class ReservationService {
     private final Clock clock;
 
     public ReservationService(
+            WaitingService waitingService,
             ReservationRepository reservationRepository,
             UserReservationRepository userReservationRepository,
             ReservationTimeRepository reservationTimeRepository,
             ThemeRepository themeRepository,
             Clock clock
     ) {
+        this.waitingService = waitingService;
         this.reservationRepository = reservationRepository;
         this.userReservationRepository = userReservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
@@ -85,6 +88,15 @@ public class ReservationService {
 
         reservation.checkCancellable(name, LocalDateTime.now(clock));
         reservationRepository.delete(reservation);
+
+        waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
+                        reservation.getTheme().getId())
+                .ifPresent(waiting -> {
+                    waitingService.promoteWaiting(waiting);
+                    reservationRepository.save(
+                            Reservation.create(waiting.getName(), waiting.getDate(), waiting.getTime(),
+                                    waiting.getTheme(), LocalDateTime.now(clock)));
+                });
     }
 
     private void checkDuplicated(Reservation reservation) {

--- a/src/main/java/roomescape/service/WaitingPromotionListener.java
+++ b/src/main/java/roomescape/service/WaitingPromotionListener.java
@@ -1,0 +1,52 @@
+package roomescape.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import roomescape.domain.Reservation;
+import roomescape.repository.ReservationRepository;
+import roomescape.service.event.ReservationCancelledEvent;
+
+@Component
+public class WaitingPromotionListener {
+    private static final Logger log = LoggerFactory.getLogger(WaitingPromotionListener.class);
+    private final WaitingService waitingService;
+    private final ReservationRepository reservationRepository;
+    private final Clock clock;
+
+    public WaitingPromotionListener(
+            WaitingService waitingService,
+            ReservationRepository reservationRepository,
+            Clock clock) {
+        this.waitingService = waitingService;
+        this.reservationRepository = reservationRepository;
+        this.clock = clock;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    public void onReservationCancelled(ReservationCancelledEvent event) {
+        waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId())
+                .ifPresent(waiting -> {
+                    waitingService.promoteWaiting(waiting);
+                    reservationRepository.save(
+                            Reservation.create(waiting.getName(), waiting.getDate(), waiting.getTime(),
+                                    waiting.getTheme(), LocalDateTime.now(clock)));
+                });
+    }
+
+    @Recover
+    public void recover(Exception e, ReservationCancelledEvent event) {
+        log.error("대기 승격 최종 실패 - reservationId: {}", event.getReservationId());
+    }
+}

--- a/src/main/java/roomescape/service/WaitingPromotionListener.java
+++ b/src/main/java/roomescape/service/WaitingPromotionListener.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
-import roomescape.domain.Reservation;
 import roomescape.repository.ReservationRepository;
 import roomescape.service.event.ReservationCancelledEvent;
 
@@ -38,10 +37,8 @@ public class WaitingPromotionListener {
     public void onReservationCancelled(ReservationCancelledEvent event) {
         waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId())
                 .ifPresent(waiting -> {
-                    waitingService.promoteWaiting(waiting);
-                    reservationRepository.save(
-                            Reservation.create(waiting.getName(), waiting.getDate(), waiting.getTime(),
-                                    waiting.getTheme(), LocalDateTime.now(clock)));
+                    waitingService.deleteForPromotion(waiting);
+                    reservationRepository.save(waiting.promote(LocalDateTime.now(clock)));
                 });
     }
 

--- a/src/main/java/roomescape/service/WaitingPromotionListener.java
+++ b/src/main/java/roomescape/service/WaitingPromotionListener.java
@@ -13,7 +13,7 @@ import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import roomescape.repository.ReservationRepository;
-import roomescape.service.event.ReservationCancelledEvent;
+import roomescape.service.event.ReservationSlotReleasedEvent;
 
 @Component
 public class WaitingPromotionListener {
@@ -34,7 +34,7 @@ public class WaitingPromotionListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000))
-    public void onReservationCancelled(ReservationCancelledEvent event) {
+    public void onSlotReleased(ReservationSlotReleasedEvent event) {
         waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId())
                 .ifPresent(waiting -> {
                     waitingService.deleteForPromotion(waiting);
@@ -43,7 +43,7 @@ public class WaitingPromotionListener {
     }
 
     @Recover
-    public void recover(Exception e, ReservationCancelledEvent event) {
+    public void recover(Exception e, ReservationSlotReleasedEvent event) {
         log.error("대기 승격 최종 실패 - reservationId: {}", event.getReservationId());
     }
 }

--- a/src/main/java/roomescape/service/WaitingService.java
+++ b/src/main/java/roomescape/service/WaitingService.java
@@ -48,7 +48,7 @@ public class WaitingService {
         Theme theme = themeRepository.findById(themeId)
                 .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.THEME_NOT_FOUND));
 
-        checkReservationExists(date, timeId, themeId);
+        checkReservationAndWaitingExists(date, timeId, themeId);
         checkDuplicatedWaiting(date, timeId, themeId, name);
         checkDuplicatedReservation(date, timeId, themeId, name);
 
@@ -93,14 +93,16 @@ public class WaitingService {
         }
     }
 
-    private void checkReservationExists(LocalDate date, long timeId, long themeId) {
-        boolean exists = reservationRepository.findBySchedule(date, timeId, themeId).isPresent();
-        if (!exists) {
-            throw new BusinessException(ErrorCode.RESERVATION_NOT_FOUND);
+    private void checkReservationAndWaitingExists(LocalDate date, long timeId, long themeId) {
+        boolean reservationExists = reservationRepository.findBySchedule(date, timeId, themeId).isPresent();
+        boolean waitingExists = waitingRepository.findFirstBySchedule(date, timeId, themeId).isPresent();
+
+        if (!reservationExists && !waitingExists) {
+            throw new BusinessException(ErrorCode.WAITING_WITHOUT_RESERVATION);
         }
     }
 
-    public Optional<Waiting> findFirstWaiting(LocalDate date, Long timeId, Long themeId) {
+    public Optional<Waiting> findFirstWaiting(LocalDate date, long timeId, long themeId) {
         return waitingRepository.findFirstBySchedule(date, timeId, themeId);
     }
 }

--- a/src/main/java/roomescape/service/WaitingService.java
+++ b/src/main/java/roomescape/service/WaitingService.java
@@ -59,6 +59,7 @@ public class WaitingService {
         return WaitingResult.of(waiting, order);
     }
 
+    @Transactional
     public void deleteWaiting(Long id, String name) {
         Waiting waiting = waitingRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
@@ -68,7 +69,7 @@ public class WaitingService {
     }
 
     @Transactional
-    public void promoteWaiting(Waiting waiting) {
+    public void deleteForPromotion(Waiting waiting) {
         waitingRepository.delete(waiting);
     }
 

--- a/src/main/java/roomescape/service/WaitingService.java
+++ b/src/main/java/roomescape/service/WaitingService.java
@@ -12,6 +12,7 @@ import roomescape.repository.ThemeRepository;
 import roomescape.repository.WaitingRepository;
 import roomescape.service.dto.WaitingResult;
 import roomescape.service.exception.BusinessConflictException;
+import roomescape.service.exception.BusinessException;
 import roomescape.service.exception.ErrorCode;
 import roomescape.service.exception.ResourceNotFoundException;
 
@@ -47,6 +48,7 @@ public class WaitingService {
         Theme theme = themeRepository.findById(themeId)
                 .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.THEME_NOT_FOUND));
 
+        checkReservationExists(date, timeId, themeId);
         checkDuplicatedWaiting(date, timeId, themeId, name);
         checkDuplicatedReservation(date, timeId, themeId, name);
 
@@ -88,6 +90,13 @@ public class WaitingService {
 
         if (duplicated) {
             throw new BusinessConflictException(ErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    private void checkReservationExists(LocalDate date, long timeId, long themeId) {
+        boolean exists = reservationRepository.findBySchedule(date, timeId, themeId).isPresent();
+        if (!exists) {
+            throw new BusinessException(ErrorCode.RESERVATION_NOT_FOUND);
         }
     }
 

--- a/src/main/java/roomescape/service/WaitingService.java
+++ b/src/main/java/roomescape/service/WaitingService.java
@@ -1,5 +1,6 @@
 package roomescape.service;
 
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.ReservationTime;
@@ -66,6 +67,11 @@ public class WaitingService {
         waitingRepository.delete(waiting);
     }
 
+    @Transactional
+    public void promoteWaiting(Waiting waiting) {
+        waitingRepository.delete(waiting);
+    }
+
     private void checkDuplicatedWaiting(LocalDate date, long timeId, long themeId, String name) {
         boolean duplicated = waitingRepository.existsByScheduleAndName(date, timeId, themeId, name);
 
@@ -82,5 +88,9 @@ public class WaitingService {
         if (duplicated) {
             throw new BusinessConflictException(ErrorCode.DUPLICATE_RESERVATION);
         }
+    }
+
+    public Optional<Waiting> findFirstWaiting(LocalDate date, Long timeId, Long themeId) {
+        return waitingRepository.findFirstBySchedule(date, timeId, themeId);
     }
 }

--- a/src/main/java/roomescape/service/dto/UserReservation.java
+++ b/src/main/java/roomescape/service/dto/UserReservation.java
@@ -1,13 +1,9 @@
 package roomescape.service.dto;
 
-import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 
 import java.time.LocalDate;
-import roomescape.domain.Waiting;
-import roomescape.service.exception.BusinessException;
-import roomescape.service.exception.ErrorCode;
 import roomescape.domain.ReservationStatus;
 
 public record UserReservation(
@@ -19,31 +15,4 @@ public record UserReservation(
         ReservationStatus status,
         Long rank
 ) {
-
-    public static UserReservation reserved(Reservation reservation) {
-        return new UserReservation(
-                reservation.getId(),
-                reservation.getName(),
-                reservation.getDate(),
-                reservation.getTime(),
-                reservation.getTheme(),
-                ReservationStatus.RESERVED,
-                null
-        );
-    }
-
-    public static UserReservation waiting(Waiting waiting, long entryRank) {
-        if (entryRank <= 0) {
-            throw new BusinessException(ErrorCode.INVALID_WAITING_RANK);
-        }
-        return new UserReservation(
-                waiting.getId(),
-                waiting.getName(),
-                waiting.getDate(),
-                waiting.getTime(),
-                waiting.getTheme(),
-                ReservationStatus.WAITING,
-                entryRank
-        );
-    }
 }

--- a/src/main/java/roomescape/service/dto/UserReservation.java
+++ b/src/main/java/roomescape/service/dto/UserReservation.java
@@ -1,9 +1,11 @@
 package roomescape.service.dto;
 
+import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 
 import java.time.LocalDate;
+import roomescape.domain.Waiting;
 import roomescape.service.exception.BusinessException;
 import roomescape.service.exception.ErrorCode;
 import roomescape.domain.ReservationStatus;
@@ -18,15 +20,30 @@ public record UserReservation(
         Long rank
 ) {
 
-    public static UserReservation reserved(Long id, String name, LocalDate date, ReservationTime time, Theme theme) {
-        return new UserReservation(id, name, date, time, theme, ReservationStatus.RESERVED, null);
+    public static UserReservation reserved(Reservation reservation) {
+        return new UserReservation(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime(),
+                reservation.getTheme(),
+                ReservationStatus.RESERVED,
+                null
+        );
     }
 
-    public static UserReservation waiting(Long id, String name, LocalDate date, ReservationTime time, Theme theme,
-                                          long entryRank) {
+    public static UserReservation waiting(Waiting waiting, long entryRank) {
         if (entryRank <= 0) {
             throw new BusinessException(ErrorCode.INVALID_WAITING_RANK);
         }
-        return new UserReservation(id, name, date, time, theme, ReservationStatus.WAITING, entryRank);
+        return new UserReservation(
+                waiting.getId(),
+                waiting.getName(),
+                waiting.getDate(),
+                waiting.getTime(),
+                waiting.getTheme(),
+                ReservationStatus.WAITING,
+                entryRank
+        );
     }
 }

--- a/src/main/java/roomescape/service/event/ReservationCancelledEvent.java
+++ b/src/main/java/roomescape/service/event/ReservationCancelledEvent.java
@@ -1,0 +1,33 @@
+package roomescape.service.event;
+
+import java.time.LocalDate;
+
+public class ReservationCancelledEvent {
+    private final Long reservationId;
+    private final LocalDate date;
+    private final Long timeId;
+    private final Long themeId;
+
+    public ReservationCancelledEvent(Long reservationId, LocalDate date, Long timeId, Long themeId) {
+        this.reservationId = reservationId;
+        this.date = date;
+        this.timeId = timeId;
+        this.themeId = themeId;
+    }
+
+    public Long getReservationId() {
+        return reservationId;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public Long getTimeId() {
+        return timeId;
+    }
+
+    public Long getThemeId() {
+        return themeId;
+    }
+}

--- a/src/main/java/roomescape/service/event/ReservationSlotReleasedEvent.java
+++ b/src/main/java/roomescape/service/event/ReservationSlotReleasedEvent.java
@@ -2,13 +2,13 @@ package roomescape.service.event;
 
 import java.time.LocalDate;
 
-public class ReservationCancelledEvent {
+public class ReservationSlotReleasedEvent {
     private final Long reservationId;
     private final LocalDate date;
     private final Long timeId;
     private final Long themeId;
 
-    public ReservationCancelledEvent(Long reservationId, LocalDate date, Long timeId, Long themeId) {
+    public ReservationSlotReleasedEvent(Long reservationId, LocalDate date, Long timeId, Long themeId) {
         this.reservationId = reservationId;
         this.date = date;
         this.timeId = timeId;

--- a/src/main/java/roomescape/service/exception/ErrorCode.java
+++ b/src/main/java/roomescape/service/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
 
     // Waiting
     DUPLICATE_WAITING("이미 대기 중인 시간입니다."),
-    INVALID_WAITING_RANK("대기 순번은 1 이상이어야 합니다.");
+    INVALID_WAITING_RANK("대기 순번은 1 이상이어야 합니다."),
+    WAITING_WITHOUT_RESERVATION("예약 가능한 시간에는 대기를 신청할 수 없습니다.");
 
     private final String message;
 

--- a/src/main/java/roomescape/service/exception/ErrorCode.java
+++ b/src/main/java/roomescape/service/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // Reservation
     RESERVATION_NOT_FOUND("존재하지 않는 예약입니다."),
     DUPLICATE_RESERVATION("이미 예약된 시간입니다."),
+    RESERVATION_NOT_ALLOWED_WITH_WAITING("대기가 존재하는 시간에 예약할 수 없습니다."),
 
     // ReservationTime
     RESERVATION_TIME_NOT_FOUND("존재하지 않는 예약 시간입니다."),

--- a/src/test/java/roomescape/WaitingE2ETest.java
+++ b/src/test/java/roomescape/WaitingE2ETest.java
@@ -46,6 +46,11 @@ class WaitingE2ETest {
     void createWaiting() {
         String futureDate = LocalDate.now().plusDays(1).toString();
 
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(Map.of("name", "브라운", "date", futureDate, "timeId", 1, "themeId", 1))
+                .when().post("/reservations");
+
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(Map.of(

--- a/src/test/java/roomescape/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/controller/ReservationControllerTest.java
@@ -7,9 +7,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import roomescape.domain.Reservation;
+import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
-import roomescape.domain.Waiting;
 import roomescape.service.ReservationService;
 import roomescape.service.dto.UserReservation;
 
@@ -37,12 +37,14 @@ class ReservationControllerTest {
     @Test
     void 내_예약_목록_조회_요청을_Service에_전달하고_예약과_대기를_함께_반환한다() throws Exception {
         List<UserReservation> reservations = List.of(
-                UserReservation.reserved(new Reservation(1L, "레서", LocalDate.of(2026, 5, 6),
+                new UserReservation(1L, "레서", LocalDate.of(2026, 5, 6),
                         new ReservationTime(1L, LocalTime.of(18, 0)),
-                        new Theme(1L, "공포방", "무서운방입니다.", "image-url"))),
-                UserReservation.waiting(new Waiting(2L, "레서", LocalDate.of(2026, 5, 7),
+                        new Theme(1L, "공포방", "무서운방입니다.", "image-url"),
+                        ReservationStatus.RESERVED, null),
+                new UserReservation(2L, "레서", LocalDate.of(2026, 5, 7),
                         new ReservationTime(2L, LocalTime.of(20, 0)),
-                        new Theme(2L, "추리방", "추리하는방입니다.", "image-url2")), 2L)
+                        new Theme(2L, "추리방", "추리하는방입니다.", "image-url2"),
+                        ReservationStatus.WAITING, 2L)
         );
         when(reservationService.findUserReservations("레서", 1, 5)).thenReturn(reservations);
 

--- a/src/test/java/roomescape/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/controller/ReservationControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
+import roomescape.domain.Waiting;
 import roomescape.service.ReservationService;
 import roomescape.service.dto.UserReservation;
 
@@ -36,12 +37,12 @@ class ReservationControllerTest {
     @Test
     void 내_예약_목록_조회_요청을_Service에_전달하고_예약과_대기를_함께_반환한다() throws Exception {
         List<UserReservation> reservations = List.of(
-                UserReservation.reserved(1L, "레서", LocalDate.of(2026, 5, 6),
+                UserReservation.reserved(new Reservation(1L, "레서", LocalDate.of(2026, 5, 6),
                         new ReservationTime(1L, LocalTime.of(18, 0)),
-                        new Theme(1L, "공포방", "무서운방입니다.", "image-url")),
-                UserReservation.waiting(2L, "레서", LocalDate.of(2026, 5, 7),
+                        new Theme(1L, "공포방", "무서운방입니다.", "image-url"))),
+                UserReservation.waiting(new Waiting(2L, "레서", LocalDate.of(2026, 5, 7),
                         new ReservationTime(2L, LocalTime.of(20, 0)),
-                        new Theme(2L, "추리방", "추리하는방입니다.", "image-url2"), 2L)
+                        new Theme(2L, "추리방", "추리하는방입니다.", "image-url2")), 2L)
         );
         when(reservationService.findUserReservations("레서", 1, 5)).thenReturn(reservations);
 

--- a/src/test/java/roomescape/domain/WaitingTest.java
+++ b/src/test/java/roomescape/domain/WaitingTest.java
@@ -76,4 +76,41 @@ class WaitingTest {
         assertThatThrownBy(() -> waiting.validateOwner("어셔"))
                 .isInstanceOf(DomainConflictException.class);
     }
+
+    @Test
+    void 승격한_대기가_예약과_같은_정보를_가진다() {
+        //given
+        Waiting waiting = new Waiting(
+                1L,
+                "밍구",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        //when
+        Reservation reservation = waiting.promote(NOW);
+
+        //then
+        assertThat(reservation.getName()).isEqualTo(waiting.getName());
+        assertThat(reservation.getDate()).isEqualTo(waiting.getDate());
+        assertThat(reservation.getTime()).isEqualTo(waiting.getTime());
+        assertThat(reservation.getTheme()).isEqualTo(waiting.getTheme());
+    }
+
+    @Test
+    void 지난_시간의_대기는_승격할_수_없다() {
+        //given
+        Waiting waiting = new Waiting(
+                1L,
+                "밍구",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        //when & then
+        assertThatThrownBy(() -> waiting.promote(LocalDate.of(2026, 5, 11).atStartOfDay()))
+                .isInstanceOf(DomainConflictException.class);
+    }
 }

--- a/src/test/java/roomescape/integration/ReservationTransactionTest.java
+++ b/src/test/java/roomescape/integration/ReservationTransactionTest.java
@@ -1,0 +1,135 @@
+package roomescape.integration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import roomescape.domain.Reservation;
+import roomescape.domain.ReservationTime;
+import roomescape.domain.Theme;
+import roomescape.domain.Waiting;
+import roomescape.repository.ReservationRepository;
+import roomescape.repository.ReservationTimeRepository;
+import roomescape.repository.ThemeRepository;
+import roomescape.repository.WaitingRepository;
+import roomescape.service.ReservationService;
+
+@SpringBootTest
+public class ReservationTransactionTest {
+    @Autowired
+    ReservationService reservationService;
+
+    @Autowired
+    ReservationTimeRepository reservationTimeRepository;
+
+    @Autowired
+    ThemeRepository themeRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM waiting");
+        jdbcTemplate.execute("DELETE FROM reservation");
+        jdbcTemplate.execute("DELETE FROM reservation_time");
+        jdbcTemplate.execute("DELETE FROM theme");
+    }
+
+    @AfterEach
+    void cleanup() {
+        jdbcTemplate.execute("DELETE FROM waiting");
+        jdbcTemplate.execute("DELETE FROM reservation");
+        jdbcTemplate.execute("DELETE FROM reservation_time");
+        jdbcTemplate.execute("DELETE FROM theme");
+    }
+
+    @MockitoSpyBean
+    ReservationRepository reservationRepository;
+
+    @MockitoSpyBean
+    WaitingRepository waitingRepository;
+
+    @Test
+    void 대기_삭제_실패_시_예약_삭제도_롤백된다() {
+        //given
+        ReservationTime reservationTime = reservationTimeRepository.save(
+                new ReservationTime(null, LocalTime.of(10, 0)));
+
+        Theme theme = themeRepository.save(new Theme(null, "공포방", "무서운방입니다.", "image-url"));
+
+        Reservation reservation = reservationRepository.save(new Reservation(
+                null,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                reservationTime,
+                theme
+        ));
+
+        Waiting waiting = waitingRepository.save(new Waiting(
+                null,
+                "어셔",
+                LocalDate.of(2026, 5, 10),
+                reservationTime,
+                theme
+        ));
+
+        doThrow(new RuntimeException("대기 삭제 실패"))
+                .when(waitingRepository).delete(waiting);
+
+        //when
+        assertThatThrownBy(
+                () -> reservationService.deleteUserReservation(reservation.getId(), reservation.getName()))
+                .isInstanceOf(RuntimeException.class);
+
+        //then
+        assertThat(reservationRepository.findById(reservation.getId())).isPresent();
+        assertThat(waitingRepository.findById(waiting.getId())).isPresent();
+    }
+
+    @Test
+    void 예약_생성_실패_시_예약_삭제와_대기_삭제_모두_롤백된다() {
+        //given
+        ReservationTime reservationTime = reservationTimeRepository.save(new ReservationTime(1L, LocalTime.of(10, 0)));
+
+        Theme theme = themeRepository.save(new Theme(1L, "공포방", "무서운방입니다.", "image-url"));
+
+        Reservation reservation = reservationRepository.save(new Reservation(
+                null,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                reservationTime,
+                theme
+        ));
+
+        Waiting waiting = waitingRepository.save(new Waiting(
+                null,
+                "어셔",
+                LocalDate.of(2026, 5, 10),
+                reservationTime,
+                theme
+        ));
+
+        doThrow(new RuntimeException("예약 생성 실패"))
+                .when(reservationRepository).save(any(Reservation.class));
+
+        //when
+        assertThatThrownBy(
+                () -> reservationService.deleteUserReservation(reservation.getId(), reservation.getName()))
+                .isInstanceOf(RuntimeException.class);
+
+        //then
+        assertThat(reservationRepository.findById(reservation.getId())).isPresent();
+        assertThat(waitingRepository.findById(waiting.getId())).isPresent();
+    }
+}

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -19,7 +19,7 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
 import roomescape.service.dto.UserReservation;
-import roomescape.service.event.ReservationCancelledEvent;
+import roomescape.service.event.ReservationSlotReleasedEvent;
 import roomescape.service.exception.BusinessConflictException;
 import roomescape.service.exception.BusinessException;
 import roomescape.service.exception.ErrorCode;
@@ -280,7 +280,7 @@ class ReservationServiceTest {
     }
 
     @Test
-    void 예약_취소_시_취소_이벤트가_발행된다() {
+    void 예약_취소_시_이벤트가_발행된다() {
         //given
         Reservation reservation = new Reservation(
                 1L,
@@ -296,9 +296,41 @@ class ReservationServiceTest {
         reservationService.deleteUserReservation(1L, "브라운");
 
         //then
-        ArgumentCaptor<ReservationCancelledEvent> captor = ArgumentCaptor.forClass(ReservationCancelledEvent.class);
+        ArgumentCaptor<ReservationSlotReleasedEvent> captor = ArgumentCaptor.forClass(
+                ReservationSlotReleasedEvent.class);
         verify(eventPublisher).publishEvent(captor.capture());
-        ReservationCancelledEvent event = captor.getValue();
+        ReservationSlotReleasedEvent event = captor.getValue();
+
+        assertThat(event.getReservationId()).isEqualTo(1L);
+        assertThat(event.getDate()).isEqualTo(LocalDate.of(2026, 5, 10));
+        assertThat(event.getTimeId()).isEqualTo(1L);
+        assertThat(event.getThemeId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 예약_변경_시_이벤트가_발행된다() {
+        //given
+        Reservation reservation = new Reservation(
+                1L,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(12, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        ReservationTime newTime = new ReservationTime(2L, LocalTime.of(14, 0));
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(reservationTimeRepository.findById(2L)).thenReturn(Optional.of(newTime));
+
+        //when
+        reservationService.updateReservation(1L, "브라운", LocalDate.of(2026, 5, 11), 2L);
+
+        //then
+        ArgumentCaptor<ReservationSlotReleasedEvent> captor = ArgumentCaptor.forClass(
+                ReservationSlotReleasedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ReservationSlotReleasedEvent event = captor.getValue();
 
         assertThat(event.getReservationId()).isEqualTo(1L);
         assertThat(event.getDate()).isEqualTo(LocalDate.of(2026, 5, 10));

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
@@ -18,6 +19,7 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
 import roomescape.service.dto.UserReservation;
+import roomescape.service.event.ReservationCancelledEvent;
 import roomescape.service.exception.BusinessConflictException;
 import roomescape.service.exception.BusinessException;
 import roomescape.service.exception.ErrorCode;
@@ -36,9 +38,6 @@ import static org.mockito.Mockito.*;
 class ReservationServiceTest {
 
     @Mock
-    private WaitingService waitingService;
-
-    @Mock
     private ReservationRepository reservationRepository;
 
     @Mock
@@ -50,6 +49,9 @@ class ReservationServiceTest {
     @Mock
     private ThemeRepository themeRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private ReservationService reservationService;
 
 
@@ -57,8 +59,8 @@ class ReservationServiceTest {
     void setUp() {
         Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
         reservationService = new ReservationService(
-                waitingService, reservationRepository, userReservationRepository, reservationTimeRepository,
-                themeRepository, fixedClock
+                reservationRepository, userReservationRepository, reservationTimeRepository,
+                themeRepository, fixedClock, eventPublisher
         );
     }
 
@@ -258,7 +260,7 @@ class ReservationServiceTest {
     }
 
     @Test
-    void 예약_취소_시_대기_1번이_자동으로_예약으로_전환된다() {
+    void 예약_취소_시_예약이_삭제된다() {
         //given
         Reservation reservation = new Reservation(
                 1L,
@@ -268,106 +270,39 @@ class ReservationServiceTest {
                 new Theme(1L, "공포방", "무서운방입니다.", "image-url")
         );
 
-        Waiting waiting = new Waiting(
-                1L,
-                "어셔",
-                LocalDate.of(2026, 5, 10),
-                new ReservationTime(1L, LocalTime.of(10, 0)),
-                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
-        );
-
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
-        when(waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
-                reservation.getTheme().getId()))
-                .thenReturn(Optional.of(waiting));
 
         //when
         reservationService.deleteUserReservation(1L, "브라운");
 
         //then
         verify(reservationRepository).delete(reservation);
-        verify(waitingService).promoteWaiting(waiting);
-
-        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
-        verify(reservationRepository).save(captor.capture());
-        Reservation saved = captor.getValue();
-
-        assertThat(saved.getName()).isEqualTo(waiting.getName());
-        assertThat(saved.getDate()).isEqualTo(waiting.getDate());
-        assertThat(saved.getTime()).isEqualTo(waiting.getTime());
-        assertThat(saved.getTheme()).isEqualTo(waiting.getTheme());
     }
 
     @Test
-    void 대기가_없는_예약을_취소하면_예약만_삭제된다() {
+    void 예약_취소_시_취소_이벤트가_발행된다() {
         //given
         Reservation reservation = new Reservation(
                 1L,
                 "브라운",
                 LocalDate.of(2026, 5, 10),
-                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new ReservationTime(1L, LocalTime.of(12, 0)),
                 new Theme(1L, "공포방", "무서운방입니다.", "image-url")
         );
 
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
-        when(waitingService.findFirstWaiting(any(), any(), any())).thenReturn(Optional.empty());
 
         //when
         reservationService.deleteUserReservation(1L, "브라운");
 
         //then
-        verify(reservationRepository).delete(reservation);
-        verify(waitingService, never()).promoteWaiting(any(Waiting.class));
-        verify(reservationRepository, never()).save(any(Reservation.class));
-    }
+        ArgumentCaptor<ReservationCancelledEvent> captor = ArgumentCaptor.forClass(ReservationCancelledEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ReservationCancelledEvent event = captor.getValue();
 
-    @Test
-    void 대기가_여러_개일_때_대기_1번만_예약으로_전환되고_나머지는_그대로다() {
-        //given
-        Reservation reservation = new Reservation(
-                1L,
-                "브라운",
-                LocalDate.of(2026, 5, 10),
-                new ReservationTime(1L, LocalTime.of(10, 0)),
-                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
-        );
-
-        Waiting waiting1 = new Waiting(
-                1L,
-                "레서",
-                LocalDate.of(2026, 5, 10),
-                new ReservationTime(1L, LocalTime.of(10, 0)),
-                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
-        );
-
-        Waiting waiting2 = new Waiting(
-                2L,
-                "밍구",
-                LocalDate.of(2026, 5, 10),
-                new ReservationTime(1L, LocalTime.of(10, 0)),
-                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
-        );
-
-        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
-        when(waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
-                reservation.getTheme().getId()))
-                .thenReturn(Optional.of(waiting1));
-
-        //when
-        reservationService.deleteUserReservation(1L, "브라운");
-
-        //then
-        verify(reservationRepository).delete(reservation);
-        verify(waitingService).promoteWaiting(waiting1);
-        verify(waitingService, never()).promoteWaiting(waiting2);
-
-        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
-        verify(reservationRepository).save(captor.capture());
-        Reservation saved = captor.getValue();
-
-        assertThat(saved.getName()).isEqualTo(waiting1.getName());
-        assertThat(saved.getDate()).isEqualTo(waiting1.getDate());
-        assertThat(saved.getTime()).isEqualTo(waiting1.getTime());
-        assertThat(saved.getTheme()).isEqualTo(waiting1.getTheme());
+        assertThat(event.getReservationId()).isEqualTo(1L);
+        assertThat(event.getDate()).isEqualTo(LocalDate.of(2026, 5, 10));
+        assertThat(event.getTimeId()).isEqualTo(1L);
+        assertThat(event.getThemeId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -12,12 +12,12 @@ import roomescape.domain.Reservation;
 import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
-import roomescape.domain.Waiting;
 import roomescape.domain.exception.DomainConflictException;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
+import roomescape.repository.WaitingRepository;
 import roomescape.service.dto.UserReservation;
 import roomescape.service.event.ReservationSlotReleasedEvent;
 import roomescape.service.exception.BusinessConflictException;
@@ -41,6 +41,9 @@ class ReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
+    private WaitingRepository waitingRepository;
+
+    @Mock
     private UserReservationRepository userReservationRepository;
 
     @Mock
@@ -59,7 +62,7 @@ class ReservationServiceTest {
     void setUp() {
         Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
         reservationService = new ReservationService(
-                reservationRepository, userReservationRepository, reservationTimeRepository,
+                reservationRepository, waitingRepository, userReservationRepository, reservationTimeRepository,
                 themeRepository, fixedClock, eventPublisher
         );
     }
@@ -237,8 +240,9 @@ class ReservationServiceTest {
         Theme theme = new Theme(1L, "공포방", "무서운방입니다.", "image-url");
 
         List<UserReservation> userReservations = List.of(
-                UserReservation.reserved(new Reservation(1L, "브라운", LocalDate.of(2026, 5, 11), time, theme)),
-                UserReservation.waiting(new Waiting(2L, "브라운", LocalDate.of(2026, 5, 11), time, theme), 2L)
+                new UserReservation(1L, "브라운", LocalDate.of(2026, 5, 11), time, theme, ReservationStatus.RESERVED,
+                        null),
+                new UserReservation(2L, "브라운", LocalDate.of(2026, 5, 11), time, theme, ReservationStatus.WAITING, 2L)
         );
 
         when(userReservationRepository.findByName("브라운", 0, 10)).thenReturn(userReservations);

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import roomescape.domain.Reservation;
@@ -16,7 +17,6 @@ import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.repository.UserReservationRepository;
-import roomescape.repository.WaitingRepository;
 import roomescape.service.dto.UserReservation;
 import roomescape.service.exception.BusinessConflictException;
 import roomescape.service.exception.BusinessException;
@@ -36,10 +36,10 @@ import static org.mockito.Mockito.*;
 class ReservationServiceTest {
 
     @Mock
-    private ReservationRepository reservationRepository;
+    private WaitingService waitingService;
 
     @Mock
-    private WaitingRepository waitingRepository;
+    private ReservationRepository reservationRepository;
 
     @Mock
     private UserReservationRepository userReservationRepository;
@@ -57,7 +57,8 @@ class ReservationServiceTest {
     void setUp() {
         Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
         reservationService = new ReservationService(
-                reservationRepository, userReservationRepository, reservationTimeRepository, themeRepository, fixedClock
+                waitingService, reservationRepository, userReservationRepository, reservationTimeRepository,
+                themeRepository, fixedClock
         );
     }
 
@@ -234,8 +235,8 @@ class ReservationServiceTest {
         Theme theme = new Theme(1L, "공포방", "무서운방입니다.", "image-url");
 
         List<UserReservation> userReservations = List.of(
-                UserReservation.reserved(1L, "브라운", LocalDate.of(2026, 5, 11), time, theme),
-                UserReservation.waiting(2L, "브라운", LocalDate.of(2026, 5, 11), time, theme, 2L)
+                UserReservation.reserved(new Reservation(1L, "브라운", LocalDate.of(2026, 5, 11), time, theme)),
+                UserReservation.waiting(new Waiting(2L, "브라운", LocalDate.of(2026, 5, 11), time, theme), 2L)
         );
 
         when(userReservationRepository.findByName("브라운", 0, 10)).thenReturn(userReservations);
@@ -254,5 +255,119 @@ class ReservationServiceTest {
                 .orElseThrow();
         assertThat(waitingResult.name()).isEqualTo("브라운");
         assertThat(waitingResult.rank()).isEqualTo(2L);
+    }
+
+    @Test
+    void 예약_취소_시_대기_1번이_자동으로_예약으로_전환된다() {
+        //given
+        Reservation reservation = new Reservation(
+                1L,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        Waiting waiting = new Waiting(
+                1L,
+                "어셔",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
+                reservation.getTheme().getId()))
+                .thenReturn(Optional.of(waiting));
+
+        //when
+        reservationService.deleteUserReservation(1L, "브라운");
+
+        //then
+        verify(reservationRepository).delete(reservation);
+        verify(waitingService).promoteWaiting(waiting);
+
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationRepository).save(captor.capture());
+        Reservation saved = captor.getValue();
+
+        assertThat(saved.getName()).isEqualTo(waiting.getName());
+        assertThat(saved.getDate()).isEqualTo(waiting.getDate());
+        assertThat(saved.getTime()).isEqualTo(waiting.getTime());
+        assertThat(saved.getTheme()).isEqualTo(waiting.getTheme());
+    }
+
+    @Test
+    void 대기가_없는_예약을_취소하면_예약만_삭제된다() {
+        //given
+        Reservation reservation = new Reservation(
+                1L,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(waitingService.findFirstWaiting(any(), any(), any())).thenReturn(Optional.empty());
+
+        //when
+        reservationService.deleteUserReservation(1L, "브라운");
+
+        //then
+        verify(reservationRepository).delete(reservation);
+        verify(waitingService, never()).promoteWaiting(any(Waiting.class));
+        verify(reservationRepository, never()).save(any(Reservation.class));
+    }
+
+    @Test
+    void 대기가_여러_개일_때_대기_1번만_예약으로_전환되고_나머지는_그대로다() {
+        //given
+        Reservation reservation = new Reservation(
+                1L,
+                "브라운",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        Waiting waiting1 = new Waiting(
+                1L,
+                "레서",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        Waiting waiting2 = new Waiting(
+                2L,
+                "밍구",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(waitingService.findFirstWaiting(reservation.getDate(), reservation.getTime().getId(),
+                reservation.getTheme().getId()))
+                .thenReturn(Optional.of(waiting1));
+
+        //when
+        reservationService.deleteUserReservation(1L, "브라운");
+
+        //then
+        verify(reservationRepository).delete(reservation);
+        verify(waitingService).promoteWaiting(waiting1);
+        verify(waitingService, never()).promoteWaiting(waiting2);
+
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationRepository).save(captor.capture());
+        Reservation saved = captor.getValue();
+
+        assertThat(saved.getName()).isEqualTo(waiting1.getName());
+        assertThat(saved.getDate()).isEqualTo(waiting1.getDate());
+        assertThat(saved.getTime()).isEqualTo(waiting1.getTime());
+        assertThat(saved.getTheme()).isEqualTo(waiting1.getTheme());
     }
 }

--- a/src/test/java/roomescape/service/WaitingPromotionTest.java
+++ b/src/test/java/roomescape/service/WaitingPromotionTest.java
@@ -1,0 +1,91 @@
+package roomescape.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import roomescape.domain.Reservation;
+import roomescape.domain.ReservationTime;
+import roomescape.domain.Theme;
+import roomescape.domain.Waiting;
+import roomescape.repository.ReservationRepository;
+import roomescape.service.event.ReservationCancelledEvent;
+
+@ExtendWith(MockitoExtension.class)
+public class WaitingPromotionTest {
+    @Mock
+    private WaitingService waitingService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private WaitingPromotionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
+        listener = new WaitingPromotionListener(waitingService, reservationRepository, fixedClock);
+    }
+
+    @Test
+    void 이벤트_수신_시_대기_1번이_예약으로_전환된다() {
+        // given
+        Waiting waiting = new Waiting(
+                1L,
+                "밍구",
+                LocalDate.of(2026, 5, 10),
+                new ReservationTime(1L, LocalTime.of(10, 0)),
+                new Theme(1L, "공포방", "무서운방입니다.", "image-url")
+        );
+
+        ReservationCancelledEvent event = new ReservationCancelledEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
+
+        when(waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId()))
+                .thenReturn(Optional.of(waiting));
+
+        // when
+        listener.onReservationCancelled(event);
+
+        // then
+        verify(waitingService).promoteWaiting(waiting);
+
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationRepository).save(captor.capture());
+        Reservation saved = captor.getValue();
+
+        assertThat(saved.getName()).isEqualTo(waiting.getName());
+        assertThat(saved.getDate()).isEqualTo(waiting.getDate());
+        assertThat(saved.getTime()).isEqualTo(waiting.getTime());
+        assertThat(saved.getTheme()).isEqualTo(waiting.getTheme());
+    }
+
+    @Test
+    void 이벤트_수신_시_대기가_없으면_승격하지_않는다() {
+        // given
+        ReservationCancelledEvent event = new ReservationCancelledEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
+
+        when(waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId()))
+                .thenReturn(Optional.empty());
+
+        // when
+        listener.onReservationCancelled(event);
+
+        // then
+        verify(waitingService, never()).promoteWaiting(any(Waiting.class));
+        verify(reservationRepository, never()).save(any(Reservation.class));
+    }
+}

--- a/src/test/java/roomescape/service/WaitingPromotionTest.java
+++ b/src/test/java/roomescape/service/WaitingPromotionTest.java
@@ -61,7 +61,7 @@ public class WaitingPromotionTest {
         listener.onReservationCancelled(event);
 
         // then
-        verify(waitingService).promoteWaiting(waiting);
+        verify(waitingService).deleteForPromotion(waiting);
 
         ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
         verify(reservationRepository).save(captor.capture());
@@ -85,7 +85,7 @@ public class WaitingPromotionTest {
         listener.onReservationCancelled(event);
 
         // then
-        verify(waitingService, never()).promoteWaiting(any(Waiting.class));
+        verify(waitingService, never()).deleteForPromotion(any(Waiting.class));
         verify(reservationRepository, never()).save(any(Reservation.class));
     }
 }

--- a/src/test/java/roomescape/service/WaitingPromotionTest.java
+++ b/src/test/java/roomescape/service/WaitingPromotionTest.java
@@ -23,7 +23,7 @@ import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.domain.Waiting;
 import roomescape.repository.ReservationRepository;
-import roomescape.service.event.ReservationCancelledEvent;
+import roomescape.service.event.ReservationSlotReleasedEvent;
 
 @ExtendWith(MockitoExtension.class)
 public class WaitingPromotionTest {
@@ -52,13 +52,13 @@ public class WaitingPromotionTest {
                 new Theme(1L, "공포방", "무서운방입니다.", "image-url")
         );
 
-        ReservationCancelledEvent event = new ReservationCancelledEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
+        ReservationSlotReleasedEvent event = new ReservationSlotReleasedEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
 
         when(waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId()))
                 .thenReturn(Optional.of(waiting));
 
         // when
-        listener.onReservationCancelled(event);
+        listener.onSlotReleased(event);
 
         // then
         verify(waitingService).deleteForPromotion(waiting);
@@ -76,13 +76,13 @@ public class WaitingPromotionTest {
     @Test
     void 이벤트_수신_시_대기가_없으면_승격하지_않는다() {
         // given
-        ReservationCancelledEvent event = new ReservationCancelledEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
+        ReservationSlotReleasedEvent event = new ReservationSlotReleasedEvent(1L, LocalDate.of(2026, 5, 10), 1L, 1L);
 
         when(waitingService.findFirstWaiting(event.getDate(), event.getTimeId(), event.getThemeId()))
                 .thenReturn(Optional.empty());
 
         // when
-        listener.onReservationCancelled(event);
+        listener.onSlotReleased(event);
 
         // then
         verify(waitingService, never()).deleteForPromotion(any(Waiting.class));

--- a/src/test/java/roomescape/service/WaitingServiceTest.java
+++ b/src/test/java/roomescape/service/WaitingServiceTest.java
@@ -65,7 +65,8 @@ class WaitingServiceTest {
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(time));
         when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
         when(waitingRepository.existsByScheduleAndName(any(), anyLong(), anyLong(), any())).thenReturn(false);
-        when(reservationRepository.findBySchedule(futureDate, 1L, 1L)).thenReturn(Optional.empty());
+        Reservation reservation = new Reservation(1L, "브라운", futureDate, time, theme);
+        when(reservationRepository.findBySchedule(futureDate, 1L, 1L)).thenReturn(Optional.of(reservation));
         Waiting saved = new Waiting(1L, "레서", futureDate, time, theme);
         when(waitingRepository.save(any())).thenReturn(saved);
         when(waitingRepository.countByThemeIdAndDateAndTimeIdAndIdLessThanEqual(1L, theme, futureDate, time))
@@ -104,6 +105,9 @@ class WaitingServiceTest {
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(time));
         when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
 
+        when(reservationRepository.findBySchedule(pastDate, 1L, 1L))
+                .thenReturn(Optional.of(new Reservation(1L, "브라운", pastDate, time, theme)));
+
         assertThatThrownBy(() -> waitingService.createWaiting("레서", pastDate, 1L, 1L))
                 .isInstanceOf(DomainConflictException.class);
         verify(waitingRepository, never()).save(any());
@@ -111,6 +115,9 @@ class WaitingServiceTest {
 
     @Test
     void 동일한_일정에_이미_대기_중이면_예외가_발생한다() {
+        Reservation reservation = new Reservation(1L, "브라운", futureDate, time, theme);
+        when(reservationRepository.findBySchedule(any(), anyLong(), anyLong()))
+                .thenReturn(Optional.of(reservation));
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(time));
         when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
         when(waitingRepository.existsByScheduleAndName(any(), anyLong(), anyLong(), any())).thenReturn(true);


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [x] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->


### 사이클 2에서 구현한 부분

---

- 예약 취소 시 대기 1번이 자동으로 예약으로 전환되는 기능을 구현했습니다.
- 자동 전환 선택 이유: 수동으로 승인하게 되면 매번 관리자가 승인하고 사용자가 기다리는 상황이 발생합니다. 예약이 취소되는 순간 대기 1번이 예약으로 전환되는 게 자연스러운 흐름이라 판단하여 자동 전환 방식을 선택했습니다.

### 트랜잭션 경계 결정

---

```
1. 예약 삭제
2. 대기 1번 삭제
3. 삭제된 대기 1번을 예약으로 등록
```

- 예약 취소 시 흐름 세 가지를 하나의 트랜잭션으로 묶었습니다.
- 이유: 중간에 실패하면 예약만 삭제되거나 대기가 사라지는 등 데이터 정합성이 깨지기 때문입니다.

### 구현한 테스트

---

**단위 테스트** (`ReservationServiceTest`): Mock을 사용해 비즈니스 로직을 검증했습니다.

- 대기가 1개 있을 때 대기가 예약으로 전환되는지
- 대기가 없을 때 예약만 삭제되는지
- 대기가 여러 개일 때 1번만 전환되고 나머지는 그대로인지

**통합 테스트** (`integration/ReservationTransactionTest`): H2 DB를 사용해 트랜잭션 롤백이 일어나는지 테스트했습니다.

- 대기 삭제 실패 시 예약 삭제도 롤백되는지
- 예약 생성 실패 시 예약 삭제와 대기 삭제 모두 롤백되는지


### 질문

---

예약 취소 이후의 대기 승격이 실패하더라도 취소는 확정되어야 한다고 생각해서 예약 취소와 대기 승격을 별도의 트랜잭션으로 분리하는 방식도 고민했습니다. 그러나 대기 승격 실패 시 예약이 비어버리는 문제가 생길 수 있어서 하나의 트랜잭션으로 묶었습니다. 트랜잭션을 분리하는 것이 더 나은 선택일 수 있는지 의견이 궁금합니다.