### PR TITLE
[🚀 방탈출 예약 외부 API 연동] 캐모(김제신) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'

--- a/src/main/java/roomescape/RoomescapeApplication.java
+++ b/src/main/java/roomescape/RoomescapeApplication.java
@@ -2,8 +2,10 @@ package roomescape;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableRetry
 @EnableScheduling
 @SpringBootApplication
 public class RoomescapeApplication {

--- a/src/main/java/roomescape/admin/theme/AdminThemeRepository.java
+++ b/src/main/java/roomescape/admin/theme/AdminThemeRepository.java
@@ -26,16 +26,18 @@ public class AdminThemeRepository {
             resultSet.getLong("id"),
             resultSet.getString("name"),
             resultSet.getString("description"),
-            resultSet.getString("image_url")
+            resultSet.getString("image_url"),
+            resultSet.getLong("price")
     );
 
     public Theme save(Theme theme) {
         SqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("name", theme.getName())
                 .addValue("description", theme.getDescription())
-                .addValue("image_url", theme.getImageUrl());
+                .addValue("image_url", theme.getImageUrl())
+                .addValue("price", theme.getPrice());
         Long id = simpleJdbcInsert.executeAndReturnKey(parameters).longValue();
-        return Theme.of(id, theme.getName(), theme.getDescription(), theme.getImageUrl());
+        return Theme.of(id, theme.getName(), theme.getDescription(), theme.getImageUrl(), theme.getPrice());
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/admin/theme/AdminThemeService.java
+++ b/src/main/java/roomescape/admin/theme/AdminThemeService.java
@@ -32,7 +32,8 @@ public class AdminThemeService {
         Theme theme = Theme.of(
                 request.name(),
                 request.description(),
-                request.imageUrl()
+                request.imageUrl(),
+                request.price()
         );
 
         Theme saved = adminThemeRepository.save(theme);

--- a/src/main/java/roomescape/admin/theme/dto/AdminThemeRequest.java
+++ b/src/main/java/roomescape/admin/theme/dto/AdminThemeRequest.java
@@ -1,6 +1,7 @@
 package roomescape.admin.theme.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record AdminThemeRequest(
@@ -12,7 +13,10 @@ public record AdminThemeRequest(
         String description,
 
         @Size(max = 255, message = "URL은 255자를 초과할 수 없습니다.")
-        String imageUrl
+        String imageUrl,
+
+        @Positive(message = "가격은 양수여야 합니다.")
+        long price
 ) {
 
 }

--- a/src/main/java/roomescape/admin/theme/dto/AdminThemeResponse.java
+++ b/src/main/java/roomescape/admin/theme/dto/AdminThemeResponse.java
@@ -6,7 +6,8 @@ public record AdminThemeResponse(
         Long id,
         String name,
         String description,
-        String imageUrl
+        String imageUrl,
+        long price
 ) {
 
     public static AdminThemeResponse from(Theme saved) {
@@ -14,7 +15,8 @@ public record AdminThemeResponse(
                 saved.getId(),
                 saved.getName(),
                 saved.getDescription(),
-                saved.getImageUrl()
+                saved.getImageUrl(),
+                saved.getPrice()
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/Reservation.java
+++ b/src/main/java/roomescape/domain/reservation/Reservation.java
@@ -13,22 +13,35 @@ public class Reservation {
     private LocalDate date;
     private ReservationTime time;
     private final Theme theme;
+    private final ReservationStatus status;
+    private final String orderId;
 
-    private Reservation(Long id, String name, LocalDate date, ReservationTime time, Theme theme) {
+    private Reservation(Long id, String name, LocalDate date, ReservationTime time, Theme theme, ReservationStatus status, String orderId) {
         this.id = id;
         this.name = name;
         this.date = date;
         this.time = time;
         this.theme = theme;
+        this.status = status;
+        this.orderId = orderId;
+    }
+
+    public static Reservation of(Long id, String name, LocalDate date, ReservationTime time, Theme theme, ReservationStatus status, String orderId) {
+        return new Reservation(id, name, date, time, theme, status, orderId);
     }
 
     public static Reservation of(Long id, String name, LocalDate date, ReservationTime time, Theme theme) {
-        return new Reservation(id, name, date, time, theme);
+        return new Reservation(id, name, date, time, theme, ReservationStatus.CONFIRMED, null);
     }
 
     public static Reservation of(String name, LocalDate date, ReservationTime time, Theme theme) {
         time.validateIfTimePast(date);
-        return new Reservation(null, name, date, time, theme);
+        return new Reservation(null, name, date, time, theme, ReservationStatus.CONFIRMED, null);
+    }
+
+    public static Reservation pendingPayment(String name, LocalDate date, ReservationTime time, Theme theme, String orderId) {
+        time.validateIfTimePast(date);
+        return new Reservation(null, name, date, time, theme, ReservationStatus.PENDING_PAYMENT, orderId);
     }
 
     public void validateOwner(String newRequestOwner) {
@@ -47,28 +60,15 @@ public class Reservation {
         this.time = newTime;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public ReservationTime getTime() {
-        return time;
-    }
-
-    public Theme getTheme() {
-        return theme;
-    }
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public LocalDate getDate() { return date; }
+    public ReservationTime getTime() { return time; }
+    public Theme getTheme() { return theme; }
+    public ReservationStatus getStatus() { return status; }
+    public String getOrderId() { return orderId; }
 
     public ReservationSlot getSlot() {
         return ReservationSlot.of(date, time, theme);
     }
-
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationRepository.java
@@ -31,8 +31,11 @@ public class ReservationRepository {
                     resultSet.getLong("theme_id"),
                     resultSet.getString("theme_name"),
                     resultSet.getString("theme_description"),
-                    resultSet.getString("theme_image_url")
-            )
+                    resultSet.getString("theme_image_url"),
+                    resultSet.getLong("theme_price")
+            ),
+            ReservationStatus.valueOf(resultSet.getString("status")),
+            resultSet.getString("order_id")
     );
 
     private final RowMapper<Long> timeMapper = (resultSet, rowNum) ->
@@ -46,7 +49,9 @@ public class ReservationRepository {
             resultSet.getString("name"),
             resultSet.getDate("date").toLocalDate(),
             resultSet.getTime("time_start_at").toLocalTime(),
-            resultSet.getString("theme_name")
+            resultSet.getString("theme_name"),
+            ReservationStatus.valueOf(resultSet.getString("status")),
+            resultSet.getString("order_id")
     );
 
     public ReservationRepository(JdbcTemplate jdbcTemplate) {
@@ -61,10 +66,16 @@ public class ReservationRepository {
                 .addValue("name", reservation.getName())
                 .addValue("date", reservation.getDate())
                 .addValue("time_id", reservation.getTime().getId())
-                .addValue("theme_id", reservation.getTheme().getId());
+                .addValue("theme_id", reservation.getTheme().getId())
+                .addValue("status", reservation.getStatus().name())
+                .addValue("order_id", reservation.getOrderId());
         Long id = simpleJdbcInsert.executeAndReturnKey(parameters).longValue();
         return Reservation.of(id, reservation.getName(), reservation.getDate(), reservation.getTime(),
-                reservation.getTheme());
+                reservation.getTheme(), reservation.getStatus(), reservation.getOrderId());
+    }
+
+    public void updateStatus(Long id, ReservationStatus status) {
+        jdbcTemplate.update("UPDATE reservation SET status = ? WHERE id = ?", status.name(), id);
     }
 
     public boolean existsBySlot(ReservationSlot slot) {
@@ -88,7 +99,7 @@ public class ReservationRepository {
     }
 
     public int deleteById(Long id) {
-        String query = "delete from reservation where id = ?";
+        String query = "DELETE FROM reservation WHERE id = ?";
         return jdbcTemplate.update(query, id);
     }
 
@@ -109,7 +120,7 @@ public class ReservationRepository {
 
     public List<ReservationSummary> findByName(String name) {
         String query = """
-                SELECT r.id AS reservation_id, r.name, r.date,
+                SELECT r.id AS reservation_id, r.name, r.date, r.status, r.order_id,
                        t.start_at AS time_start_at,
                        th.name AS theme_name
                 FROM reservation r
@@ -117,49 +128,44 @@ public class ReservationRepository {
                 JOIN theme th ON r.theme_id = th.id
                 WHERE r.name = ?
                 """;
-
         return jdbcTemplate.query(query, summaryMapper, name);
     }
 
     public Optional<Reservation> findById(Long id) {
         String query = """
-                SELECT r.id AS reservation_id, r.name, r.date,
+                SELECT r.id AS reservation_id, r.name, r.date, r.status, r.order_id,
                        t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM reservation r
                 JOIN reservation_time t ON r.time_id = t.id
                 JOIN theme th ON r.theme_id = th.id
                 WHERE r.id = ?
                 """;
-
-        return jdbcTemplate.query(query, rowMapper, id).stream()
-                .findFirst();
+        return jdbcTemplate.query(query, rowMapper, id).stream().findFirst();
     }
 
     public Optional<Reservation> findByIdForUpdate(Long id) {
         String query = """
-                SELECT r.id AS reservation_id, r.name, r.date,
+                SELECT r.id AS reservation_id, r.name, r.date, r.status, r.order_id,
                        t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM reservation r
                 JOIN reservation_time t ON r.time_id = t.id
                 JOIN theme th ON r.theme_id = th.id
                 WHERE r.id = ?
                 FOR UPDATE
                 """;
-
-        return jdbcTemplate.query(query, rowMapper, id).stream()
-                .findFirst();
+        return jdbcTemplate.query(query, rowMapper, id).stream().findFirst();
     }
 
     public Optional<Reservation> findBySlot(ReservationSlot slot) {
         String query = """
-                SELECT r.id AS reservation_id, r.name, r.date,
+                SELECT r.id AS reservation_id, r.name, r.date, r.status, r.order_id,
                        t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM reservation r
                 JOIN reservation_time t ON r.time_id = t.id
                 JOIN theme th ON r.theme_id = th.id
@@ -167,8 +173,21 @@ public class ReservationRepository {
                 """;
         return jdbcTemplate.query(query, rowMapper,
                         slot.getDate(), slot.getTime().getId(), slot.getTheme().getId())
-                .stream()
-                .findFirst();
+                .stream().findFirst();
+    }
+
+    public Optional<Reservation> findByOrderId(String orderId) {
+        String query = """
+                SELECT r.id AS reservation_id, r.name, r.date, r.status, r.order_id,
+                       t.id AS time_id, t.start_at AS time_start_at, t.finish_at AS time_finish_at,
+                       th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
+                       th.image_url AS theme_image_url, th.price AS theme_price
+                FROM reservation r
+                JOIN reservation_time t ON r.time_id = t.id
+                JOIN theme th ON r.theme_id = th.id
+                WHERE r.order_id = ?
+                """;
+        return jdbcTemplate.query(query, rowMapper, orderId).stream().findFirst();
     }
 
     public void update(Reservation reservation) {

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -2,6 +2,7 @@ package roomescape.domain.reservation;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,10 @@ import roomescape.domain.waiting.WaitingRepository;
 import roomescape.domain.waiting.Waitings;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
+import roomescape.payment.client.TossPaymentGateway;
+import roomescape.payment.client.dto.TossPaymentResponse;
+import roomescape.payment.domain.Payment;
+import roomescape.payment.domain.PaymentRepository;
 
 @Service
 public class ReservationService {
@@ -29,17 +34,23 @@ public class ReservationService {
     private final ReservationTimeRepository reservationTimeRepository;
     private final ThemeRepository themeRepository;
     private final WaitingRepository waitingRepository;
+    private final PaymentRepository paymentRepository;
+    private final TossPaymentGateway tossPaymentGateway;
 
     public ReservationService(
             ReservationRepository reservationRepository,
             ReservationTimeRepository reservationTimeRepository,
             ThemeRepository themeRepository,
-            WaitingRepository waitingRepository
+            WaitingRepository waitingRepository,
+            PaymentRepository paymentRepository,
+            TossPaymentGateway tossPaymentGateway
     ) {
         this.reservationRepository = reservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
         this.waitingRepository = waitingRepository;
+        this.paymentRepository = paymentRepository;
+        this.tossPaymentGateway = tossPaymentGateway;
     }
 
     @Transactional
@@ -52,13 +63,7 @@ public class ReservationService {
         ReservationSlot slot = ReservationSlot.of(request.date(), time, theme);
         validateDuplicateReservation(slot);
 
-        Reservation reservation = Reservation.of(
-                request.name(),
-                request.date(),
-                time,
-                theme
-        );
-
+        Reservation reservation = Reservation.of(request.name(), request.date(), time, theme);
         try {
             Reservation saved = reservationRepository.save(reservation);
             return ReservationResponse.from(saved);
@@ -67,11 +72,43 @@ public class ReservationService {
         }
     }
 
+    @Transactional
+    public void createPendingReservation(ReservationRequest request, String orderId) {
+        ReservationTime time = reservationTimeRepository.findById(request.timeId())
+                .orElseThrow(() -> new RoomescapeException(ErrorCode.TIME_ID_NOT_FOUND));
+        Theme theme = themeRepository.findById(request.themeId())
+                .orElseThrow(() -> new RoomescapeException(ErrorCode.THEME_ID_NOT_FOUND));
+
+        ReservationSlot slot = ReservationSlot.of(request.date(), time, theme);
+        validateDuplicateReservation(slot);
+
+        Reservation pending = Reservation.pendingPayment(request.name(), request.date(), time, theme, orderId);
+        try {
+            reservationRepository.save(pending);
+        } catch (DuplicateKeyException exception) {
+            throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    @Transactional
+    public ReservationResponse confirmPayment(String orderId, TossPaymentResponse tossResponse) {
+        Reservation reservation = reservationRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
+        reservationRepository.updateStatus(reservation.getId(), ReservationStatus.CONFIRMED);
+        paymentRepository.save(Payment.of(
+                tossResponse.paymentKey(),
+                tossResponse.orderId(),
+                tossResponse.totalAmount(),
+                tossResponse.status(),
+                reservation.getId()
+        ));
+        return ReservationResponse.from(reservation);
+    }
+
     @Transactional(readOnly = true)
     public List<TimeResponse> getReservations(LocalDate date, Long themeId) {
         ReservationTimes allTimes = ReservationTimes.of(reservationTimeRepository.findAll());
         List<Long> bookedTimeIds = reservationRepository.findTimeByDateAndThemeId(date, themeId);
-
         return allTimes.availableExcluding(bookedTimeIds).stream()
                 .map(TimeResponse::from)
                 .toList();
@@ -82,6 +119,11 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findByIdForUpdate(id)
                 .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
 
+        paymentRepository.findByReservationId(id).ifPresent(payment -> {
+            tossPaymentGateway.cancel(payment.getPaymentKey(), "예약 취소");
+            paymentRepository.deleteByReservationId(id);
+        });
+
         int deleted = reservationRepository.deleteById(id);
 
         if (deleted > 0) {
@@ -91,8 +133,12 @@ public class ReservationService {
     }
 
     private void promoteToReservation(Waiting waiting) {
+        String orderId = "order-" + UUID.randomUUID().toString().replace("-", "");
         try {
-            reservationRepository.save(waiting.toReservation());
+            Reservation pending = Reservation.pendingPayment(
+                    waiting.getName(), waiting.getDate(), waiting.getTime(), waiting.getTheme(), orderId
+            );
+            reservationRepository.save(pending);
             waitingRepository.deleteById(waiting.getId());
         } catch (DuplicateKeyException e) {
             throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
@@ -128,5 +174,4 @@ public class ReservationService {
             throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
         }
     }
-
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -23,7 +23,7 @@ import roomescape.domain.waiting.Waitings;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
 import roomescape.payment.client.TossPaymentGateway;
-import roomescape.payment.client.dto.TossPaymentResponse;
+import roomescape.payment.dto.PaymentResult;
 import roomescape.payment.domain.Payment;
 import roomescape.payment.domain.PaymentRepository;
 
@@ -91,15 +91,15 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationResponse confirmPayment(String orderId, TossPaymentResponse tossResponse) {
+    public ReservationResponse confirmPayment(String orderId, PaymentResult paymentResult) {
         Reservation reservation = reservationRepository.findByOrderId(orderId)
                 .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
         reservationRepository.updateStatus(reservation.getId(), ReservationStatus.CONFIRMED);
         paymentRepository.save(Payment.of(
-                tossResponse.paymentKey(),
-                tossResponse.orderId(),
-                tossResponse.totalAmount(),
-                tossResponse.status(),
+                paymentResult.paymentKey(),
+                paymentResult.orderId(),
+                paymentResult.totalAmount(),
+                paymentResult.status(),
                 reservation.getId()
         ));
         return ReservationResponse.from(reservation);

--- a/src/main/java/roomescape/domain/reservation/ReservationStatus.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationStatus.java
@@ -1,0 +1,5 @@
+package roomescape.domain.reservation;
+
+public enum ReservationStatus {
+    PENDING_PAYMENT, CONFIRMED
+}

--- a/src/main/java/roomescape/domain/reservation/ReservationSummary.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationSummary.java
@@ -8,6 +8,8 @@ public record ReservationSummary(
         String name,
         LocalDate date,
         LocalTime startAt,
-        String themeName
+        String themeName,
+        ReservationStatus status,
+        String orderId
 ) {
 }

--- a/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
@@ -2,6 +2,7 @@ package roomescape.domain.reservation.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import roomescape.domain.reservation.ReservationStatus;
 import roomescape.domain.reservation.ReservationSummary;
 
 public record MyReservationResponse(
@@ -9,7 +10,9 @@ public record MyReservationResponse(
         String name,
         LocalDate date,
         LocalTime time,
-        String themeName
+        String themeName,
+        ReservationStatus status,
+        String orderId
 ) {
 
     public static MyReservationResponse from(ReservationSummary summary) {
@@ -18,7 +21,9 @@ public record MyReservationResponse(
                 summary.name(),
                 summary.date(),
                 summary.startAt(),
-                summary.themeName()
+                summary.themeName(),
+                summary.status(),
+                summary.orderId()
         );
     }
 }

--- a/src/main/java/roomescape/domain/theme/Theme.java
+++ b/src/main/java/roomescape/domain/theme/Theme.java
@@ -5,35 +5,27 @@ public class Theme {
     private final String name;
     private final String description;
     private final String imageUrl;
+    private final long price;
 
-    private Theme(Long id, String name, String description, String imageUrl) {
+    private Theme(Long id, String name, String description, String imageUrl, long price) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.imageUrl = imageUrl;
+        this.price = price;
     }
 
-    public static Theme of(Long id, String name, String description, String imageUrl) {
-        return new Theme(id, name, description, imageUrl);
+    public static Theme of(Long id, String name, String description, String imageUrl, long price) {
+        return new Theme(id, name, description, imageUrl, price);
     }
 
-    public static Theme of(String name, String description, String imageUrl) {
-        return new Theme(null, name, description, imageUrl);
+    public static Theme of(String name, String description, String imageUrl, long price) {
+        return new Theme(null, name, description, imageUrl, price);
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
-    }
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+    public String getImageUrl() { return imageUrl; }
+    public long getPrice() { return price; }
 }

--- a/src/main/java/roomescape/domain/theme/ThemeRepository.java
+++ b/src/main/java/roomescape/domain/theme/ThemeRepository.java
@@ -20,7 +20,8 @@ public class ThemeRepository {
             resultSet.getLong("id"),
             resultSet.getString("name"),
             resultSet.getString("description"),
-            resultSet.getString("image_url")
+            resultSet.getString("image_url"),
+            resultSet.getLong("price")
     );
 
     public Optional<Theme> findById(Long id) {

--- a/src/main/java/roomescape/domain/theme/dto/ThemeResponse.java
+++ b/src/main/java/roomescape/domain/theme/dto/ThemeResponse.java
@@ -6,7 +6,8 @@ public record ThemeResponse(
         Long id,
         String name,
         String description,
-        String imageUrl
+        String imageUrl,
+        long price
 ) {
 
     public static ThemeResponse from(Theme theme) {
@@ -14,7 +15,8 @@ public record ThemeResponse(
                 theme.getId(),
                 theme.getName(),
                 theme.getDescription(),
-                theme.getImageUrl()
+                theme.getImageUrl(),
+                theme.getPrice()
         );
     }
 }

--- a/src/main/java/roomescape/domain/waiting/Waiting.java
+++ b/src/main/java/roomescape/domain/waiting/Waiting.java
@@ -1,7 +1,6 @@
 package roomescape.domain.waiting;
 
 import java.time.LocalDate;
-import roomescape.domain.reservation.Reservation;
 import roomescape.domain.reservation.ReservationSlot;
 import roomescape.domain.reservationtime.ReservationTime;
 import roomescape.domain.theme.Theme;
@@ -53,10 +52,6 @@ public class Waiting {
 
     public ReservationSlot getSlot() {
         return ReservationSlot.of(date, time, theme);
-    }
-
-    public Reservation toReservation() {
-        return Reservation.of(name, date, time, theme);
     }
 
 }

--- a/src/main/java/roomescape/domain/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/domain/waiting/WaitingRepository.java
@@ -30,7 +30,8 @@ public class WaitingRepository {
                     rs.getLong("theme_id"),
                     rs.getString("theme_name"),
                     rs.getString("theme_description"),
-                    rs.getString("theme_image_url")
+                    rs.getString("theme_image_url"),
+                    rs.getLong("theme_price")
             )
     );
 
@@ -66,7 +67,7 @@ public class WaitingRepository {
                 SELECT w.id AS waiting_id, w.name, w.date,
                        rt.id AS time_id, rt.start_at AS time_start_at, rt.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM waiting w
                 JOIN reservation_time rt ON w.time_id = rt.id
                 JOIN theme th ON w.theme_id = th.id
@@ -82,7 +83,7 @@ public class WaitingRepository {
                 SELECT w.id AS waiting_id, w.name, w.date,
                        rt.id AS time_id, rt.start_at AS time_start_at, rt.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM waiting w
                 JOIN reservation_time rt ON w.time_id = rt.id
                 JOIN theme th ON w.theme_id = th.id
@@ -100,7 +101,7 @@ public class WaitingRepository {
                 SELECT w.id AS waiting_id, w.name, w.date,
                        rt.id AS time_id, rt.start_at AS time_start_at, rt.finish_at AS time_finish_at,
                        th.id AS theme_id, th.name AS theme_name, th.description AS theme_description,
-                       th.image_url AS theme_image_url
+                       th.image_url AS theme_image_url, th.price AS theme_price
                 FROM waiting w
                 JOIN reservation_time rt ON w.time_id = rt.id
                 JOIN theme th ON w.theme_id = th.id

--- a/src/main/java/roomescape/exception/ErrorCode.java
+++ b/src/main/java/roomescape/exception/ErrorCode.java
@@ -28,6 +28,10 @@ public enum ErrorCode {
     RESERVATION_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "해당 예약은 점유되어있지 않습니다."),
     WAITING_NOT_AVAILABLE(HttpStatus.UNPROCESSABLE_ENTITY, "예약이 이미 등록되어있습니다."),
 
+    //400 - PAYMENT
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+    PAYMENT_CONFIRM_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "예약 확정에 실패했습니다."),
+
     //503 - SERVICE_UNAVAILABLE
     SERVER_OVERLOADED(HttpStatus.SERVICE_UNAVAILABLE, "서버가 일시적으로 처리할 수 없습니다.");
 

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -2,15 +2,20 @@ package roomescape.exception;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import roomescape.payment.client.TossPaymentException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(RoomescapeException.class)
     public ResponseEntity<ErrorResponse> handleRoomEscapeException(RoomescapeException exception) {
@@ -20,6 +25,20 @@ public class GlobalExceptionHandler {
                 .body(
                         ErrorResponse.of(code.getMessage())
                 );
+    }
+
+    @ExceptionHandler(TossPaymentException.class)
+    public ResponseEntity<ErrorResponse> handleTossPaymentException(TossPaymentException exception) {
+        if (exception instanceof TossPaymentException.GatewayConfig) {
+            log.error("[운영 알람] Toss API 키 설정 오류 code={} message={}", exception.getCode(), exception.getMessage());
+        } else if (exception instanceof TossPaymentException.Retryable) {
+            log.error("[운영 알람] Toss 내부 오류 재시도 초과 code={} message={}", exception.getCode(), exception.getMessage());
+        } else {
+            log.warn("Toss 결제 오류 code={} message={}", exception.getCode(), exception.getMessage());
+        }
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(ErrorResponse.of(exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import roomescape.payment.PaymentGatewayException;
 import roomescape.payment.client.TossPaymentException;
 
 @RestControllerAdvice
@@ -27,8 +28,8 @@ public class GlobalExceptionHandler {
                 );
     }
 
-    @ExceptionHandler(TossPaymentException.class)
-    public ResponseEntity<ErrorResponse> handleTossPaymentException(TossPaymentException exception) {
+    @ExceptionHandler(PaymentGatewayException.class)
+    public ResponseEntity<ErrorResponse> handlePaymentGatewayException(PaymentGatewayException exception) {
         if (exception instanceof TossPaymentException.GatewayConfig) {
             log.error("[운영 알람] Toss API 키 설정 오류 code={} message={}", exception.getCode(), exception.getMessage());
         } else if (exception instanceof TossPaymentException.Retryable) {

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -28,15 +28,25 @@ public class GlobalExceptionHandler {
                 );
     }
 
+    @ExceptionHandler(TossPaymentException.GatewayConfig.class)
+    public ResponseEntity<ErrorResponse> handleTossGatewayConfig(TossPaymentException.GatewayConfig exception) {
+        log.error("[운영 알람] Toss API 키 설정 오류 code={} message={}", exception.getCode(), exception.getMessage());
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(ErrorResponse.of(exception.getMessage()));
+    }
+
+    @ExceptionHandler(TossPaymentException.Retryable.class)
+    public ResponseEntity<ErrorResponse> handleTossRetryable(TossPaymentException.Retryable exception) {
+        log.error("[운영 알람] Toss 내부 오류 재시도 초과 code={} message={}", exception.getCode(), exception.getMessage());
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(ErrorResponse.of(exception.getMessage()));
+    }
+
     @ExceptionHandler(PaymentGatewayException.class)
     public ResponseEntity<ErrorResponse> handlePaymentGatewayException(PaymentGatewayException exception) {
-        if (exception instanceof TossPaymentException.GatewayConfig) {
-            log.error("[운영 알람] Toss API 키 설정 오류 code={} message={}", exception.getCode(), exception.getMessage());
-        } else if (exception instanceof TossPaymentException.Retryable) {
-            log.error("[운영 알람] Toss 내부 오류 재시도 초과 code={} message={}", exception.getCode(), exception.getMessage());
-        } else {
-            log.warn("Toss 결제 오류 code={} message={}", exception.getCode(), exception.getMessage());
-        }
+        log.warn("결제 게이트웨이 오류 code={} message={}", exception.getCode(), exception.getMessage());
         return ResponseEntity
                 .status(exception.getStatus())
                 .body(ErrorResponse.of(exception.getMessage()));

--- a/src/main/java/roomescape/payment/PaymentController.java
+++ b/src/main/java/roomescape/payment/PaymentController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import roomescape.domain.reservation.dto.ReservationRequest;
 import roomescape.exception.RoomescapeException;
-import roomescape.payment.client.TossPaymentException;
 import roomescape.payment.dto.CheckoutResult;
 import roomescape.payment.dto.PaymentConfirmResult;
 
@@ -49,12 +48,12 @@ public class PaymentController {
     ) {
         try {
             PaymentConfirmResult result = paymentService.confirm(paymentKey, orderId, amount);
-            model.addAttribute("payment", result.tossResponse());
+            model.addAttribute("payment", result.paymentResult());
             model.addAttribute("reservation", result.reservation());
             return "payment/success";
         } catch (RoomescapeException e) {
             return failView(model, e.getErrorCode().name(), e.getMessage(), orderId);
-        } catch (TossPaymentException e) {
+        } catch (PaymentGatewayException e) {
             return failView(model, e.getCode(), e.getMessage(), orderId);
         }
     }

--- a/src/main/java/roomescape/payment/PaymentController.java
+++ b/src/main/java/roomescape/payment/PaymentController.java
@@ -1,0 +1,78 @@
+package roomescape.payment;
+
+import java.time.LocalDate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import roomescape.domain.reservation.dto.ReservationRequest;
+import roomescape.exception.RoomescapeException;
+import roomescape.payment.client.TossPaymentException;
+import roomescape.payment.dto.CheckoutResult;
+import roomescape.payment.dto.PaymentConfirmResult;
+
+@Controller
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    private final String clientKey;
+
+    public PaymentController(PaymentService paymentService, @Value("${toss.client-key:}") String clientKey) {
+        this.paymentService = paymentService;
+        this.clientKey = clientKey;
+    }
+
+    @GetMapping("/payments/checkout")
+    public String checkout(
+            @RequestParam String name,
+            @RequestParam LocalDate date,
+            @RequestParam Long timeId,
+            @RequestParam Long themeId,
+            @RequestParam(defaultValue = "") String themeName,
+            Model model
+    ) {
+        CheckoutResult result = paymentService.checkout(new ReservationRequest(name, date, timeId, themeId), themeName);
+        model.addAttribute("clientKey", clientKey);
+        model.addAttribute("orderId", result.orderId());
+        model.addAttribute("orderName", result.orderName());
+        model.addAttribute("amount", result.amount());
+        return "payment/checkout";
+    }
+
+    @GetMapping("/payments/success")
+    public String success(
+            @RequestParam String paymentKey,
+            @RequestParam String orderId,
+            @RequestParam Long amount,
+            Model model
+    ) {
+        try {
+            PaymentConfirmResult result = paymentService.confirm(paymentKey, orderId, amount);
+            model.addAttribute("payment", result.tossResponse());
+            model.addAttribute("reservation", result.reservation());
+            return "payment/success";
+        } catch (RoomescapeException e) {
+            return failView(model, e.getErrorCode().name(), e.getMessage(), orderId);
+        } catch (TossPaymentException e) {
+            return failView(model, e.getCode(), e.getMessage(), orderId);
+        }
+    }
+
+    @GetMapping("/payments/fail")
+    public String fail(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String message,
+            @RequestParam(required = false) String orderId,
+            Model model
+    ) {
+        return failView(model, code, message, orderId);
+    }
+
+    private String failView(Model model, String code, String message, String orderId) {
+        model.addAttribute("code", code);
+        model.addAttribute("message", message);
+        model.addAttribute("orderId", orderId);
+        return "payment/fail";
+    }
+}

--- a/src/main/java/roomescape/payment/PaymentGatewayException.java
+++ b/src/main/java/roomescape/payment/PaymentGatewayException.java
@@ -1,0 +1,14 @@
+package roomescape.payment;
+
+import org.springframework.http.HttpStatusCode;
+
+public abstract class PaymentGatewayException extends RuntimeException {
+
+    public PaymentGatewayException(String message) {
+        super(message);
+    }
+
+    public abstract HttpStatusCode getStatus();
+
+    public abstract String getCode();
+}

--- a/src/main/java/roomescape/payment/PaymentService.java
+++ b/src/main/java/roomescape/payment/PaymentService.java
@@ -11,6 +11,7 @@ import roomescape.domain.theme.Theme;
 import roomescape.domain.theme.ThemeRepository;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
+import roomescape.payment.PaymentGatewayException;
 import roomescape.payment.client.TossPaymentGateway;
 import roomescape.payment.dto.CheckoutResult;
 import roomescape.payment.dto.PaymentConfirmResult;
@@ -51,7 +52,13 @@ public class PaymentService {
         if (amount != reservation.getTheme().getPrice()) {
             throw new RoomescapeException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
-        PaymentResult paymentResult = tossPaymentGateway.confirm(paymentKey, orderId, amount);
+        PaymentResult paymentResult;
+        try {
+            paymentResult = tossPaymentGateway.confirm(paymentKey, orderId, amount);
+        } catch (PaymentGatewayException e) {
+            reservationService.deleteReservation(reservation.getId());
+            throw e;
+        }
         try {
             ReservationResponse result = reservationService.confirmPayment(orderId, paymentResult);
             return new PaymentConfirmResult(paymentResult, result);

--- a/src/main/java/roomescape/payment/PaymentService.java
+++ b/src/main/java/roomescape/payment/PaymentService.java
@@ -1,0 +1,63 @@
+package roomescape.payment;
+
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import roomescape.domain.reservation.Reservation;
+import roomescape.domain.reservation.ReservationRepository;
+import roomescape.domain.reservation.ReservationService;
+import roomescape.domain.reservation.dto.ReservationRequest;
+import roomescape.domain.reservation.dto.ReservationResponse;
+import roomescape.domain.theme.Theme;
+import roomescape.domain.theme.ThemeRepository;
+import roomescape.exception.ErrorCode;
+import roomescape.exception.RoomescapeException;
+import roomescape.payment.client.TossPaymentGateway;
+import roomescape.payment.client.dto.TossPaymentResponse;
+import roomescape.payment.dto.CheckoutResult;
+import roomescape.payment.dto.PaymentConfirmResult;
+
+@Service
+public class PaymentService {
+
+    private final TossPaymentGateway tossPaymentGateway;
+    private final ReservationService reservationService;
+    private final ThemeRepository themeRepository;
+    private final ReservationRepository reservationRepository;
+
+    public PaymentService(
+            TossPaymentGateway tossPaymentGateway,
+            ReservationService reservationService,
+            ThemeRepository themeRepository,
+            ReservationRepository reservationRepository
+    ) {
+        this.tossPaymentGateway = tossPaymentGateway;
+        this.reservationService = reservationService;
+        this.themeRepository = themeRepository;
+        this.reservationRepository = reservationRepository;
+    }
+
+    public CheckoutResult checkout(ReservationRequest request, String themeName) {
+        Theme theme = themeRepository.findById(request.themeId())
+                .orElseThrow(() -> new RoomescapeException(ErrorCode.THEME_ID_NOT_FOUND));
+        String orderId = "order-" + UUID.randomUUID().toString().replace("-", "");
+        reservationService.createPendingReservation(request, orderId);
+        String orderName = themeName.isBlank() ? "방탈출 예약" : "방탈출 예약 — " + themeName;
+        return new CheckoutResult(orderId, orderName, theme.getPrice());
+    }
+
+    public PaymentConfirmResult confirm(String paymentKey, String orderId, long amount) {
+        Reservation reservation = reservationRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new RoomescapeException(ErrorCode.RESERVATION_ID_NOT_FOUND));
+        if (amount != reservation.getTheme().getPrice()) {
+            throw new RoomescapeException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+        TossPaymentResponse tossResponse = tossPaymentGateway.confirm(paymentKey, orderId, amount);
+        try {
+            ReservationResponse result = reservationService.confirmPayment(orderId, tossResponse);
+            return new PaymentConfirmResult(tossResponse, result);
+        } catch (RoomescapeException e) {
+            tossPaymentGateway.cancel(paymentKey, "예약 확정 실패");
+            throw new RoomescapeException(ErrorCode.PAYMENT_CONFIRM_FAILED);
+        }
+    }
+}

--- a/src/main/java/roomescape/payment/PaymentService.java
+++ b/src/main/java/roomescape/payment/PaymentService.java
@@ -12,9 +12,9 @@ import roomescape.domain.theme.ThemeRepository;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
 import roomescape.payment.client.TossPaymentGateway;
-import roomescape.payment.client.dto.TossPaymentResponse;
 import roomescape.payment.dto.CheckoutResult;
 import roomescape.payment.dto.PaymentConfirmResult;
+import roomescape.payment.dto.PaymentResult;
 
 @Service
 public class PaymentService {
@@ -51,10 +51,10 @@ public class PaymentService {
         if (amount != reservation.getTheme().getPrice()) {
             throw new RoomescapeException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
-        TossPaymentResponse tossResponse = tossPaymentGateway.confirm(paymentKey, orderId, amount);
+        PaymentResult paymentResult = tossPaymentGateway.confirm(paymentKey, orderId, amount);
         try {
-            ReservationResponse result = reservationService.confirmPayment(orderId, tossResponse);
-            return new PaymentConfirmResult(tossResponse, result);
+            ReservationResponse result = reservationService.confirmPayment(orderId, paymentResult);
+            return new PaymentConfirmResult(paymentResult, result);
         } catch (RoomescapeException e) {
             tossPaymentGateway.cancel(paymentKey, "예약 확정 실패");
             throw new RoomescapeException(ErrorCode.PAYMENT_CONFIRM_FAILED);

--- a/src/main/java/roomescape/payment/client/TossClientConfig.java
+++ b/src/main/java/roomescape/payment/client/TossClientConfig.java
@@ -1,0 +1,26 @@
+package roomescape.payment.client;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class TossClientConfig {
+
+    @Bean
+    public RestClient tossRestClient(
+            @Value("${toss.base-url}") String baseUrl,
+            @Value("${toss.secret-key}") String secretKey
+    ) {
+        String basic = Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basic)
+                .build();
+    }
+}

--- a/src/main/java/roomescape/payment/client/TossPaymentException.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentException.java
@@ -1,0 +1,87 @@
+package roomescape.payment.client;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import roomescape.payment.client.dto.TossErrorResponse;
+
+public class TossPaymentException extends RuntimeException {
+
+    private final HttpStatusCode status;
+    private final String code;
+
+    public TossPaymentException(HttpStatusCode status, String code, String message) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+
+    public static TossPaymentException of(HttpStatusCode status, TossErrorResponse error) {
+        return switch (error.code()) {
+            case "ALREADY_PROCESSED_PAYMENT" -> new AlreadyProcessed(error.message());
+            case "DUPLICATED_ORDER_ID" -> new DuplicatedOrder(error.message());
+            case "NOT_FOUND_PAYMENT_SESSION" -> new SessionExpired(error.message());
+            case "INVALID_REQUEST" -> new InvalidRequest(error.message());
+            case "UNAUTHORIZED_KEY", "INVALID_API_KEY" -> new GatewayConfig(error.message());
+            case "REJECT_CARD_PAYMENT" -> new CardRejected(error.message());
+            case "NOT_FOUND_PAYMENT" -> new PaymentNotFound(error.message());
+            case "FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING" -> new Retryable(error.message());
+            default -> new TossPaymentException(status, error.code(), error.message());
+        };
+    }
+
+    public HttpStatusCode getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static class AlreadyProcessed extends TossPaymentException {
+        public AlreadyProcessed(String message) {
+            super(HttpStatus.BAD_REQUEST, "ALREADY_PROCESSED_PAYMENT", message);
+        }
+    }
+
+    public static class DuplicatedOrder extends TossPaymentException {
+        public DuplicatedOrder(String message) {
+            super(HttpStatus.BAD_REQUEST, "DUPLICATED_ORDER_ID", message);
+        }
+    }
+
+    public static class SessionExpired extends TossPaymentException {
+        public SessionExpired(String message) {
+            super(HttpStatus.BAD_REQUEST, "NOT_FOUND_PAYMENT_SESSION", message);
+        }
+    }
+
+    public static class InvalidRequest extends TossPaymentException {
+        public InvalidRequest(String message) {
+            super(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", message);
+        }
+    }
+
+    public static class GatewayConfig extends TossPaymentException {
+        public GatewayConfig(String message) {
+            super(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_KEY", message);
+        }
+    }
+
+    public static class CardRejected extends TossPaymentException {
+        public CardRejected(String message) {
+            super(HttpStatus.FORBIDDEN, "REJECT_CARD_PAYMENT", message);
+        }
+    }
+
+    public static class PaymentNotFound extends TossPaymentException {
+        public PaymentNotFound(String message) {
+            super(HttpStatus.NOT_FOUND, "NOT_FOUND_PAYMENT", message);
+        }
+    }
+
+    public static class Retryable extends TossPaymentException {
+        public Retryable(String message) {
+            super(HttpStatus.INTERNAL_SERVER_ERROR, "FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING", message);
+        }
+    }
+}

--- a/src/main/java/roomescape/payment/client/TossPaymentException.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentException.java
@@ -2,9 +2,10 @@ package roomescape.payment.client;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import roomescape.payment.PaymentGatewayException;
 import roomescape.payment.client.dto.TossErrorResponse;
 
-public class TossPaymentException extends RuntimeException {
+public class TossPaymentException extends PaymentGatewayException {
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/roomescape/payment/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentGateway.java
@@ -13,6 +13,7 @@ import roomescape.payment.client.dto.CancelRequest;
 import roomescape.payment.client.dto.ConfirmRequest;
 import roomescape.payment.client.dto.TossErrorResponse;
 import roomescape.payment.client.dto.TossPaymentResponse;
+import roomescape.payment.dto.PaymentResult;
 
 @Component
 public class TossPaymentGateway {
@@ -28,7 +29,7 @@ public class TossPaymentGateway {
     }
 
     @Retryable(retryFor = TossPaymentException.Retryable.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
-    public TossPaymentResponse confirm(String paymentKey, String orderId, long amount) {
+    public PaymentResult confirm(String paymentKey, String orderId, long amount) {
         log.info("결제 승인 요청 paymentKey={} orderId={} amount={}", paymentKey, orderId, amount);
         TossPaymentResponse response = tossRestClient.post()
                 .uri("/v1/payments/confirm")
@@ -41,7 +42,7 @@ public class TossPaymentGateway {
                 })
                 .body(TossPaymentResponse.class);
         log.info("결제 승인 완료 paymentKey={} orderId={}", paymentKey, orderId);
-        return response;
+        return new PaymentResult(response.paymentKey(), response.orderId(), response.status(), response.totalAmount());
     }
 
     public void cancel(String paymentKey, String cancelReason) {

--- a/src/main/java/roomescape/payment/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentGateway.java
@@ -1,0 +1,61 @@
+package roomescape.payment.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import roomescape.payment.client.dto.CancelRequest;
+import roomescape.payment.client.dto.ConfirmRequest;
+import roomescape.payment.client.dto.TossErrorResponse;
+import roomescape.payment.client.dto.TossPaymentResponse;
+
+@Component
+public class TossPaymentGateway {
+
+    private static final Logger log = LoggerFactory.getLogger(TossPaymentGateway.class);
+
+    private final RestClient tossRestClient;
+    private final ObjectMapper objectMapper;
+
+    public TossPaymentGateway(RestClient tossRestClient, ObjectMapper objectMapper) {
+        this.tossRestClient = tossRestClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Retryable(retryFor = TossPaymentException.Retryable.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    public TossPaymentResponse confirm(String paymentKey, String orderId, long amount) {
+        log.info("결제 승인 요청 paymentKey={} orderId={} amount={}", paymentKey, orderId, amount);
+        TossPaymentResponse response = tossRestClient.post()
+                .uri("/v1/payments/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new ConfirmRequest(paymentKey, orderId, amount))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    var error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
+                    throw TossPaymentException.of(res.getStatusCode(), error);
+                })
+                .body(TossPaymentResponse.class);
+        log.info("결제 승인 완료 paymentKey={} orderId={}", paymentKey, orderId);
+        return response;
+    }
+
+    public void cancel(String paymentKey, String cancelReason) {
+        log.info("결제 취소 요청 paymentKey={} reason={}", paymentKey, cancelReason);
+        tossRestClient.post()
+                .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new CancelRequest(cancelReason))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    var error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
+                    throw TossPaymentException.of(res.getStatusCode(), error);
+                })
+                .toBodilessEntity();
+        log.info("결제 취소 완료 paymentKey={}", paymentKey);
+    }
+}

--- a/src/main/java/roomescape/payment/client/dto/CancelRequest.java
+++ b/src/main/java/roomescape/payment/client/dto/CancelRequest.java
@@ -1,0 +1,4 @@
+package roomescape.payment.client.dto;
+
+public record CancelRequest(String cancelReason) {
+}

--- a/src/main/java/roomescape/payment/client/dto/ConfirmRequest.java
+++ b/src/main/java/roomescape/payment/client/dto/ConfirmRequest.java
@@ -1,0 +1,4 @@
+package roomescape.payment.client.dto;
+
+public record ConfirmRequest(String paymentKey, String orderId, long amount) {
+}

--- a/src/main/java/roomescape/payment/client/dto/TossErrorResponse.java
+++ b/src/main/java/roomescape/payment/client/dto/TossErrorResponse.java
@@ -1,0 +1,4 @@
+package roomescape.payment.client.dto;
+
+public record TossErrorResponse(String code, String message) {
+}

--- a/src/main/java/roomescape/payment/client/dto/TossPaymentResponse.java
+++ b/src/main/java/roomescape/payment/client/dto/TossPaymentResponse.java
@@ -1,0 +1,4 @@
+package roomescape.payment.client.dto;
+
+public record TossPaymentResponse(String paymentKey, String orderId, String status, long totalAmount) {
+}

--- a/src/main/java/roomescape/payment/domain/Payment.java
+++ b/src/main/java/roomescape/payment/domain/Payment.java
@@ -1,0 +1,31 @@
+package roomescape.payment.domain;
+
+public class Payment {
+
+    private final Long id;
+    private final String paymentKey;
+    private final String orderId;
+    private final long amount;
+    private final String status;
+    private final Long reservationId;
+
+    private Payment(Long id, String paymentKey, String orderId, long amount, String status, Long reservationId) {
+        this.id = id;
+        this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.amount = amount;
+        this.status = status;
+        this.reservationId = reservationId;
+    }
+
+    public static Payment of(String paymentKey, String orderId, long amount, String status, Long reservationId) {
+        return new Payment(null, paymentKey, orderId, amount, status, reservationId);
+    }
+
+    public Long getId() { return id; }
+    public String getPaymentKey() { return paymentKey; }
+    public String getOrderId() { return orderId; }
+    public long getAmount() { return amount; }
+    public String getStatus() { return status; }
+    public Long getReservationId() { return reservationId; }
+}

--- a/src/main/java/roomescape/payment/domain/PaymentRepository.java
+++ b/src/main/java/roomescape/payment/domain/PaymentRepository.java
@@ -1,0 +1,52 @@
+package roomescape.payment.domain;
+
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PaymentRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert simpleJdbcInsert;
+
+    private static final RowMapper<Payment> ROW_MAPPER = (rs, rowNum) -> Payment.of(
+            rs.getString("payment_key"),
+            rs.getString("order_id"),
+            rs.getLong("amount"),
+            rs.getString("status"),
+            rs.getLong("reservation_id")
+    );
+
+    public PaymentRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.simpleJdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("payment")
+                .usingGeneratedKeyColumns("id");
+    }
+
+    public void save(Payment payment) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("payment_key", payment.getPaymentKey())
+                .addValue("order_id", payment.getOrderId())
+                .addValue("amount", payment.getAmount())
+                .addValue("status", payment.getStatus())
+                .addValue("reservation_id", payment.getReservationId());
+        simpleJdbcInsert.execute(parameters);
+    }
+
+    public Optional<Payment> findByReservationId(Long reservationId) {
+        String sql = "SELECT * FROM payment WHERE reservation_id = ?";
+        return jdbcTemplate.query(sql, ROW_MAPPER, reservationId)
+                .stream()
+                .findFirst();
+    }
+
+    public void deleteByReservationId(Long reservationId) {
+        jdbcTemplate.update("DELETE FROM payment WHERE reservation_id = ?", reservationId);
+    }
+}

--- a/src/main/java/roomescape/payment/dto/CheckoutResult.java
+++ b/src/main/java/roomescape/payment/dto/CheckoutResult.java
@@ -1,0 +1,3 @@
+package roomescape.payment.dto;
+
+public record CheckoutResult(String orderId, String orderName, long amount) {}

--- a/src/main/java/roomescape/payment/dto/PaymentConfirmResult.java
+++ b/src/main/java/roomescape/payment/dto/PaymentConfirmResult.java
@@ -1,6 +1,5 @@
 package roomescape.payment.dto;
 
 import roomescape.domain.reservation.dto.ReservationResponse;
-import roomescape.payment.client.dto.TossPaymentResponse;
 
-public record PaymentConfirmResult(TossPaymentResponse tossResponse, ReservationResponse reservation) {}
+public record PaymentConfirmResult(PaymentResult paymentResult, ReservationResponse reservation) {}

--- a/src/main/java/roomescape/payment/dto/PaymentConfirmResult.java
+++ b/src/main/java/roomescape/payment/dto/PaymentConfirmResult.java
@@ -1,0 +1,6 @@
+package roomescape.payment.dto;
+
+import roomescape.domain.reservation.dto.ReservationResponse;
+import roomescape.payment.client.dto.TossPaymentResponse;
+
+public record PaymentConfirmResult(TossPaymentResponse tossResponse, ReservationResponse reservation) {}

--- a/src/main/java/roomescape/payment/dto/PaymentResult.java
+++ b/src/main/java/roomescape/payment/dto/PaymentResult.java
@@ -1,0 +1,3 @@
+package roomescape.payment.dto;
+
+public record PaymentResult(String paymentKey, String orderId, String status, long totalAmount) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
+
+toss.base-url=https://api.tosspayments.com
+toss.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
+toss.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS waiting;
+DROP TABLE IF EXISTS payment;
 DROP TABLE IF EXISTS reservation;
 DROP TABLE IF EXISTS theme;
 DROP TABLE IF EXISTS reservation_time;
@@ -18,6 +19,7 @@ CREATE TABLE theme
     name        VARCHAR(255) NOT NULL UNIQUE,
     description VARCHAR(500) NOT NULL,
     image_url   VARCHAR(255) NOT NULL,
+    price       BIGINT       NOT NULL DEFAULT 50000,
     PRIMARY KEY (id)
 );
 
@@ -28,10 +30,24 @@ CREATE TABLE reservation
     date     DATE         NOT NULL,
     time_id  BIGINT       NOT NULL,
     theme_id BIGINT       NOT NULL,
+    status   VARCHAR(20)  NOT NULL DEFAULT 'CONFIRMED',
+    order_id VARCHAR(64)  UNIQUE NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (time_id) REFERENCES reservation_time (id),
     FOREIGN KEY (theme_id) REFERENCES theme (id),
     CONSTRAINT unique_reservation UNIQUE (date, time_id, theme_id)
+);
+
+CREATE TABLE payment
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    payment_key    VARCHAR(200) NOT NULL UNIQUE,
+    order_id       VARCHAR(64)  NOT NULL UNIQUE,
+    amount         BIGINT       NOT NULL,
+    status         VARCHAR(20)  NOT NULL,
+    reservation_id BIGINT       NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (reservation_id) REFERENCES reservation (id)
 );
 
 CREATE TABLE waiting

--- a/src/main/resources/static/js/reservation.js
+++ b/src/main/resources/static/js/reservation.js
@@ -226,18 +226,14 @@ async function confirmBooking() {
         showError(new Error(result.errorMessage));
       }
     } else {
-      const { jobId } = await apiFetch(RESERVATION_API, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body
+      const params = new URLSearchParams({
+        name,
+        date: state.date,
+        timeId: state.timeId,
+        themeId: state.themeId,
+        themeName: state.themeName || ''
       });
-      const result = await pollJobUntilDone(`/reservations/status/${jobId}`);
-      if (result.status === 'SUCCESS') {
-        alert('예약이 완료되었습니다.');
-        refreshTimes();
-      } else {
-        showError(new Error(result.errorMessage));
-      }
+      window.location.href = `/payments/checkout?${params}`;
     }
   } catch (err) {
     showError(err);

--- a/src/main/resources/static/js/theme.js
+++ b/src/main/resources/static/js/theme.js
@@ -72,16 +72,22 @@ function closeForm() {
   document.getElementById('new-name').value = '';
   document.getElementById('new-desc').value = '';
   document.getElementById('new-image').value = '';
+  document.getElementById('new-price').value = '';
 }
 
 function saveTheme() {
   const body = {
     name: document.getElementById('new-name').value.trim(),
     description: document.getElementById('new-desc').value.trim(),
-    imageUrl: document.getElementById('new-image').value.trim()
+    imageUrl: document.getElementById('new-image').value.trim(),
+    price: parseInt(document.getElementById('new-price').value, 10) || 0
   };
   if (!body.name || !body.description) {
     alert('이름과 설명을 입력해주세요.');
+    return;
+  }
+  if (body.price <= 0) {
+    alert('가격을 1원 이상 입력해주세요.');
     return;
   }
   apiFetch(THEME_API, {

--- a/src/main/resources/templates/payment/checkout.html
+++ b/src/main/resources/templates/payment/checkout.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>결제하기 — ESCAPE ROOM</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"/>
+  <link rel="stylesheet" href="/css/styles.css"/>
+  <script src="https://js.tosspayments.com/v2/standard"></script>
+  <style>
+    .payment-wrap {
+      max-width: 520px;
+      margin: 40px auto;
+      padding: 0 16px;
+    }
+
+    .payment-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, .07);
+    }
+
+    .payment-card h2 {
+      font-size: 20px;
+      margin: 0 0 24px;
+    }
+
+    .order-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 14px;
+    }
+
+    .order-row .label {
+      color: #888;
+    }
+
+    .order-row .value {
+      font-weight: 600;
+    }
+
+    .order-row code {
+      font-size: 12px;
+      color: #555;
+      word-break: break-all;
+    }
+
+    #payment-method,
+    #agreement {
+      margin-top: 16px;
+    }
+
+    #pay-btn {
+      width: 100%;
+      margin-top: 20px;
+      padding: 16px;
+      border: 0;
+      border-radius: 10px;
+      background: var(--accent, #3182f6);
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background .2s;
+    }
+
+    #pay-btn:hover:not(:disabled) {
+      filter: brightness(1.1);
+    }
+
+    #pay-btn:disabled {
+      background: #c3d7f5;
+      cursor: not-allowed;
+    }
+
+    .pay-hint {
+      margin-top: 14px;
+      font-size: 13px;
+      color: #aaa;
+      line-height: 1.6;
+    }
+
+    .back-link {
+      display: inline-block;
+      margin-top: 16px;
+      font-size: 13px;
+      color: #888;
+      text-decoration: none;
+    }
+
+    .back-link:hover {
+      color: var(--accent, #3182f6);
+    }
+  </style>
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar-inner">
+    <a href="/admin/theme" class="admin-entry" title="관리자 페이지">
+      <i class="fas fa-user-shield"></i><span>관리자</span>
+    </a>
+    <a href="/" class="brand">
+      <span class="brand-mark"><i class="fas fa-key"></i></span>
+      ESCAPE ROOM
+    </a>
+    <nav class="nav">
+      <a href="/">홈</a>
+      <a href="/popular">인기 테마</a>
+      <a href="/reservation" class="active">예약하기</a>
+      <a href="/my-reservations">예약 관리</a>
+    </nav>
+  </div>
+</header>
+
+<div class="payment-wrap">
+  <div class="payment-card">
+    <h2><i class="fas fa-credit-card" style="color:var(--accent,#3182f6);margin-right:8px;"></i>결제하기</h2>
+
+    <div class="order-row">
+      <span class="label">주문명</span>
+      <span class="value" th:text="${orderName}">방탈출 예약</span>
+    </div>
+    <div class="order-row">
+      <span class="label">주문번호</span>
+      <code th:text="${orderId}">order-xxxx</code>
+    </div>
+    <div class="order-row">
+      <span class="label">결제금액</span>
+      <span class="value">
+        <span th:text="${#numbers.formatInteger(amount, 0, 'COMMA')}">50,000</span>원
+      </span>
+    </div>
+
+    <div id="payment-method"></div>
+    <div id="agreement"></div>
+
+    <button id="pay-btn" disabled>결제하기</button>
+    <p class="pay-hint">샌드박스 테스트 환경입니다. 실제 결제가 이루어지지 않습니다.</p>
+    <a href="/reservation" class="back-link"><i class="fas fa-arrow-left"></i> 예약 선택으로 돌아가기</a>
+  </div>
+</div>
+
+<script th:inline="javascript">
+  /*<![CDATA[*/
+  const clientKey = /*[[${clientKey}]]*/ "test_ck_xxx";
+  const orderId = /*[[${orderId}]]*/ "order-1";
+  const orderName = /*[[${orderName}]]*/ "방탈출 예약";
+  const amountValue = /*[[${amount}]]*/ 50000;
+
+  const tossPayments = TossPayments(clientKey);
+  const widgets = tossPayments.widgets({customerKey: TossPayments.ANONYMOUS});
+  const payBtn = document.getElementById("pay-btn");
+
+  (async () => {
+    try {
+      await widgets.setAmount({currency: "KRW", value: amountValue});
+      await Promise.all([
+        widgets.renderPaymentMethods({selector: "#payment-method", variantKey: "DEFAULT"}),
+        widgets.renderAgreement({selector: "#agreement", variantKey: "AGREEMENT"})
+      ]);
+      payBtn.disabled = false;
+    } catch (error) {
+      document.querySelector(".pay-hint").textContent = "결제위젯 렌더링 실패: " + error.message;
+    }
+  })();
+
+  payBtn.addEventListener("click", async () => {
+    try {
+      await widgets.requestPayment({
+        orderId: orderId,
+        orderName: orderName,
+        successUrl: window.location.origin + "/payments/success",
+        failUrl: window.location.origin + "/payments/fail"
+      });
+    } catch (error) {
+      if (error.code !== "USER_CANCEL") {
+        document.querySelector(".pay-hint").textContent = "결제 요청 실패: " + error.message;
+      }
+    }
+  });
+  /*]]>*/
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/payment/fail.html
+++ b/src/main/resources/templates/payment/fail.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>결제 실패 — ESCAPE ROOM</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"/>
+  <link rel="stylesheet" href="/css/styles.css"/>
+  <style>
+    .result-wrap {
+      max-width: 520px;
+      margin: 40px auto;
+      padding: 0 16px;
+    }
+
+    .result-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, .07);
+    }
+
+    .result-card h2 {
+      font-size: 20px;
+      margin: 0 0 24px;
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      padding: 10px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 14px;
+      gap: 16px;
+    }
+
+    .info-row .label {
+      color: #888;
+      white-space: nowrap;
+    }
+
+    .info-row .value-error {
+      text-align: right;
+      word-break: break-all;
+      color: #e03131;
+      font-weight: 600;
+    }
+
+    .info-row .value {
+      text-align: right;
+      word-break: break-all;
+      color: #555;
+    }
+
+    .result-actions {
+      margin-top: 24px;
+    }
+
+    .result-actions a {
+      display: inline-block;
+      padding: 12px 24px;
+      border-radius: 10px;
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      background: var(--accent, #3182f6);
+      color: #fff;
+      transition: background .2s;
+    }
+
+    .result-actions a:hover {
+      filter: brightness(1.1);
+    }
+  </style>
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar-inner">
+    <a href="/admin/theme" class="admin-entry" title="관리자 페이지">
+      <i class="fas fa-user-shield"></i><span>관리자</span>
+    </a>
+    <a href="/" class="brand">
+      <span class="brand-mark"><i class="fas fa-key"></i></span>
+      ESCAPE ROOM
+    </a>
+    <nav class="nav">
+      <a href="/">홈</a>
+      <a href="/popular">인기 테마</a>
+      <a href="/reservation">예약하기</a>
+      <a href="/my-reservations">예약 관리</a>
+    </nav>
+  </div>
+</header>
+
+<div class="result-wrap">
+  <div class="result-card">
+    <h2><i class="fas fa-times-circle" style="color:#e03131;margin-right:8px;"></i>결제를 실패했어요</h2>
+
+    <div class="info-row">
+      <span class="label">에러 코드</span>
+      <span class="value-error" th:text="${code} ?: '알 수 없음'">REJECT_CARD_PAYMENT</span>
+    </div>
+    <div class="info-row">
+      <span class="label">에러 메시지</span>
+      <span class="value-error" th:text="${message} ?: '알 수 없는 오류가 발생했습니다.'">에러 메시지</span>
+    </div>
+    <div class="info-row">
+      <span class="label">주문번호</span>
+      <span class="value" th:text="${orderId} ?: '(전달되지 않음)'">order-xxxx</span>
+    </div>
+
+    <div class="result-actions">
+      <a href="/reservation"><i class="fas fa-redo"></i> 다시 예약하기</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/payment/success.html
+++ b/src/main/resources/templates/payment/success.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>결제 완료 — ESCAPE ROOM</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"/>
+  <link rel="stylesheet" href="/css/styles.css"/>
+  <style>
+    .result-wrap {
+      max-width: 520px;
+      margin: 40px auto;
+      padding: 0 16px;
+    }
+
+    .result-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, .07);
+    }
+
+    .result-card h2 {
+      font-size: 20px;
+      margin: 0 0 8px;
+    }
+
+    .result-card .subtitle {
+      color: #888;
+      font-size: 14px;
+      margin: 0 0 24px;
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 14px;
+      gap: 16px;
+    }
+
+    .info-row .label {
+      color: #888;
+      white-space: nowrap;
+    }
+
+    .info-row .value {
+      text-align: right;
+      word-break: break-all;
+      font-weight: 600;
+    }
+
+    .result-actions {
+      display: flex;
+      gap: 12px;
+      margin-top: 24px;
+    }
+
+    .result-actions a {
+      flex: 1;
+      text-align: center;
+      padding: 12px;
+      border-radius: 10px;
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background .2s;
+    }
+
+    .btn-primary-link {
+      background: var(--accent, #3182f6);
+      color: #fff;
+    }
+
+    .btn-primary-link:hover {
+      filter: brightness(1.1);
+    }
+
+    .btn-ghost-link {
+      background: #f0f0f0;
+      color: #555;
+    }
+
+    .btn-ghost-link:hover {
+      background: #e0e0e0;
+    }
+  </style>
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar-inner">
+    <a href="/admin/theme" class="admin-entry" title="관리자 페이지">
+      <i class="fas fa-user-shield"></i><span>관리자</span>
+    </a>
+    <a href="/" class="brand">
+      <span class="brand-mark"><i class="fas fa-key"></i></span>
+      ESCAPE ROOM
+    </a>
+    <nav class="nav">
+      <a href="/">홈</a>
+      <a href="/popular">인기 테마</a>
+      <a href="/reservation">예약하기</a>
+      <a href="/my-reservations">예약 관리</a>
+    </nav>
+  </div>
+</header>
+
+<div class="result-wrap">
+  <div class="result-card">
+    <h2><i class="fas fa-check-circle" style="color:#2ecc71;margin-right:8px;"></i>예약 및 결제 완료</h2>
+    <p class="subtitle">결제가 확정되고 예약이 생성되었습니다.</p>
+
+    <div class="info-row">
+      <span class="label">결제 상태</span>
+      <span class="value" th:text="${payment.status()}">DONE</span>
+    </div>
+    <div class="info-row">
+      <span class="label">결제 금액</span>
+      <span class="value">
+        <span th:text="${#numbers.formatInteger(payment.totalAmount(), 0, 'COMMA')}">50,000</span>원
+      </span>
+    </div>
+    <div class="info-row">
+      <span class="label">예약 번호</span>
+      <span class="value" th:text="${reservation.id()}">1</span>
+    </div>
+    <div class="info-row">
+      <span class="label">예약자</span>
+      <span class="value" th:text="${reservation.name()}">홍길동</span>
+    </div>
+    <div class="info-row">
+      <span class="label">예약 날짜</span>
+      <span class="value" th:text="${reservation.date()}">2025-01-01</span>
+    </div>
+    <div class="info-row">
+      <span class="label">주문번호</span>
+      <span class="value" style="font-size:12px;font-weight:400;" th:text="${payment.orderId()}">order-xxx</span>
+    </div>
+
+    <div class="result-actions">
+      <a href="/my-reservations" class="btn-primary-link"><i class="fas fa-list"></i> 예약 관리</a>
+      <a href="/reservation" class="btn-ghost-link"><i class="fas fa-plus"></i> 추가 예약</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/theme.html
+++ b/src/main/resources/templates/theme.html
@@ -36,7 +36,7 @@
   </div>
 
   <div id="theme-form" class="filter-card d-none" style="margin-bottom:20px;">
-    <div class="filter-row" style="grid-template-columns: 1fr 2fr 2fr auto;">
+    <div class="filter-row" style="grid-template-columns: 1fr 2fr 2fr 1fr auto;">
       <div>
         <label class="form-label">이름</label>
         <input id="new-name" type="text" class="form-control" placeholder="테마 이름">
@@ -48,6 +48,10 @@
       <div>
         <label class="form-label">이미지 URL</label>
         <input id="new-image" type="text" class="form-control" placeholder="https://...">
+      </div>
+      <div>
+        <label class="form-label">가격 (원)</label>
+        <input id="new-price" type="number" class="form-control" placeholder="50000" min="1">
       </div>
       <div style="display:flex;gap:8px;">
         <button id="save-theme" class="btn btn-success">확인</button>

--- a/src/test/java/roomescape/admin/theme/AdminThemeControllerTest.java
+++ b/src/test/java/roomescape/admin/theme/AdminThemeControllerTest.java
@@ -33,10 +33,11 @@ class AdminThemeControllerTest {
 
     @Test
     void 테마_정상_생성_확인_테스트() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "테마1");
         params.put("description", "테마 설명");
         params.put("imageUrl", "https://example.com/image.jpg");
+        params.put("price", 50000);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -52,10 +53,11 @@ class AdminThemeControllerTest {
 
     @Test
     void createTheme_이름이_비어있는경우_에러_반환_테스트() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "");
         params.put("description", "테마 설명");
         params.put("imageUrl", "https://example.com/image.jpg");
+        params.put("price", 50000);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -68,10 +70,11 @@ class AdminThemeControllerTest {
 
     @Test
     void createTheme_중복된_이름인경우_에러_반환_테스트() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "테마1");
         params.put("description", "테마 설명");
         params.put("imageUrl", "https://example.com/image.jpg");
+        params.put("price", 50000);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)

--- a/src/test/java/roomescape/admin/theme/AdminThemeRepositoryTest.java
+++ b/src/test/java/roomescape/admin/theme/AdminThemeRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.context.annotation.Import;
 import roomescape.domain.theme.Theme;
 
@@ -25,7 +25,7 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 저장하면_id가_부여된다() {
-            Theme theme = Theme.of("테마1", "설명", "https://example.com/image.jpg");
+            Theme theme = Theme.of("테마1", "설명", "https://example.com/image.jpg", 50_000L);
 
             Theme saved = adminThemeRepository.save(theme);
 
@@ -44,7 +44,7 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 삭제하면_해당_테마가_조회되지_않는다() {
-            Theme saved = adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg"));
+            Theme saved = adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg", 50_000L));
 
             adminThemeRepository.deleteById(saved.getId());
 
@@ -58,8 +58,8 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 저장된_테마를_전체_조회한다() {
-            Theme first = adminThemeRepository.save(Theme.of("테마1", "설명1", "https://example.com/1.jpg"));
-            Theme second = adminThemeRepository.save(Theme.of("테마2", "설명2", "https://example.com/2.jpg"));
+            Theme first = adminThemeRepository.save(Theme.of("테마1", "설명1", "https://example.com/1.jpg", 50_000L));
+            Theme second = adminThemeRepository.save(Theme.of("테마2", "설명2", "https://example.com/2.jpg", 50_000L));
 
             List<Theme> result = adminThemeRepository.findAll();
 
@@ -79,7 +79,7 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 존재하는_id면_true를_반환한다() {
-            Theme saved = adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg"));
+            Theme saved = adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg", 50_000L));
 
             boolean result = adminThemeRepository.existsById(saved.getId());
 
@@ -100,7 +100,7 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 존재하는_이름이면_true를_반환한다() {
-            adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg"));
+            adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg", 50_000L));
 
             boolean result = adminThemeRepository.existsByName("테마1");
 
@@ -109,7 +109,7 @@ class AdminThemeRepositoryTest {
 
         @Test
         void 존재하지_않는_이름이면_false를_반환한다() {
-            adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg"));
+            adminThemeRepository.save(Theme.of("테마1", "설명", "https://example.com/image.jpg", 50_000L));
 
             boolean result = adminThemeRepository.existsByName("테마2");
 

--- a/src/test/java/roomescape/admin/theme/AdminThemeRepositoryTest.java
+++ b/src/test/java/roomescape/admin/theme/AdminThemeRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 import roomescape.domain.theme.Theme;
 

--- a/src/test/java/roomescape/admin/theme/AdminThemeServiceTest.java
+++ b/src/test/java/roomescape/admin/theme/AdminThemeServiceTest.java
@@ -38,8 +38,8 @@ class AdminThemeServiceTest {
 
     @Test
     void createTheme_정상_생성() {
-        AdminThemeRequest request = new AdminThemeRequest("테마1", "설명", "https://example.com/image.jpg");
-        Theme saved = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg");
+        AdminThemeRequest request = new AdminThemeRequest("테마1", "설명", "https://example.com/image.jpg", 50_000L);
+        Theme saved = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg", 50_000L);
 
         when(adminThemeRepository.existsByName("테마1")).thenReturn(false);
         when(adminThemeRepository.save(any(Theme.class))).thenReturn(saved);
@@ -53,7 +53,7 @@ class AdminThemeServiceTest {
 
     @Test
     void createTheme_중복된_이름이면_예외() {
-        AdminThemeRequest request = new AdminThemeRequest("테마1", "설명", "https://example.com/image.jpg");
+        AdminThemeRequest request = new AdminThemeRequest("테마1", "설명", "https://example.com/image.jpg", 50_000L);
 
         when(adminThemeRepository.existsByName("테마1")).thenReturn(true);
 
@@ -64,8 +64,8 @@ class AdminThemeServiceTest {
 
     @Test
     void getAllThemes_정상_조회() {
-        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1");
-        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2");
+        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1", 50_000L);
+        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2", 50_000L);
 
         when(adminThemeRepository.findAll()).thenReturn(List.of(theme1, theme2));
 

--- a/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.domain.reservationtime.ReservationTime;
@@ -55,8 +55,8 @@ class ReservationRepositoryTest {
 
         time = ReservationTime.of(timeId, LocalTime.of(10, 0), LocalTime.of(11, 0));
         anotherTime = ReservationTime.of(anotherTimeId, LocalTime.of(12, 0), LocalTime.of(13, 0));
-        theme = Theme.of(themeId, "테마1", "설명1", "https://example.com/1.jpg");
-        anotherTheme = Theme.of(anotherThemeId, "테마2", "설명2", "https://example.com/2.jpg");
+        theme = Theme.of(themeId, "테마1", "설명1", "https://example.com/1.jpg", 50_000L);
+        anotherTheme = Theme.of(anotherThemeId, "테마2", "설명2", "https://example.com/2.jpg", 50_000L);
     }
 
     @Nested

--- a/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationRepositoryTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.domain.reservationtime.ReservationTime;

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -230,7 +230,7 @@ class ReservationServiceTest {
 
         @Test
         void 이름으로_조회() {
-            ReservationSummary summary = new ReservationSummary(1L, "유저1", LocalDate.of(2099, 12, 31), time.getStartAt(), "테마1", ReservationStatus.CONFIRMED);
+            ReservationSummary summary = new ReservationSummary(1L, "유저1", LocalDate.of(2099, 12, 31), time.getStartAt(), "테마1", ReservationStatus.CONFIRMED, null);
             when(reservationRepository.findByName("유저1")).thenReturn(List.of(summary));
 
             MyReservationsResponse response = reservationService.getMyReservations("유저1");

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -23,8 +23,10 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DuplicateKeyException;
 import roomescape.domain.reservation.ReservationSlot;
+import roomescape.payment.domain.PaymentRepository;
 import roomescape.domain.reservation.ReservationSummary;
 import roomescape.domain.reservation.dto.MyReservationsResponse;
 import roomescape.domain.reservation.dto.ReservationFixRequest;
@@ -55,6 +57,12 @@ class ReservationServiceTest {
     @Mock
     private WaitingRepository waitingRepository;
 
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private ReservationService reservationService;
 
@@ -64,7 +72,7 @@ class ReservationServiceTest {
     @BeforeEach
     void setUp() {
         time = ReservationTime.of(1L, LocalTime.of(10, 0), LocalTime.of(11, 0));
-        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg");
+        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg", 50_000L);
     }
 
     @Nested
@@ -193,9 +201,11 @@ class ReservationServiceTest {
             Reservation reservation = Reservation.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
             Waiting waiting1 = Waiting.of(10L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
             Waiting waiting2 = Waiting.of(11L, "대기자2", LocalDate.of(2099, 12, 31), time, theme);
+            Reservation promoted = Reservation.of(20L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
             when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
             when(reservationRepository.deleteById(1L)).thenReturn(1);
             when(waitingRepository.findAllBySlotForUpdate(any(ReservationSlot.class))).thenReturn(List.of(waiting1, waiting2));
+            when(reservationRepository.save(any(Reservation.class))).thenReturn(promoted);
 
             reservationService.deleteReservation(1L);
 
@@ -220,7 +230,7 @@ class ReservationServiceTest {
 
         @Test
         void 이름으로_조회() {
-            ReservationSummary summary = new ReservationSummary(1L, "유저1", LocalDate.of(2099, 12, 31), time.getStartAt(), "테마1");
+            ReservationSummary summary = new ReservationSummary(1L, "유저1", LocalDate.of(2099, 12, 31), time.getStartAt(), "테마1", ReservationStatus.CONFIRMED);
             when(reservationRepository.findByName("유저1")).thenReturn(List.of(summary));
 
             MyReservationsResponse response = reservationService.getMyReservations("유저1");

--- a/src/test/java/roomescape/domain/reservation/ReservationTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationTest.java
@@ -22,7 +22,8 @@ class ReservationTest {
             1L,
             "테마1",
             "설명",
-            "https://example.com/image.png"
+            "https://example.com/image.png",
+            50_000L
     );
 
     @Test

--- a/src/test/java/roomescape/domain/reservationtime/ReservationTimeRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservationtime/ReservationTimeRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 
 @JdbcTest

--- a/src/test/java/roomescape/domain/reservationtime/ReservationTimeRepositoryTest.java
+++ b/src/test/java/roomescape/domain/reservationtime/ReservationTimeRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.context.annotation.Import;
 
 @JdbcTest

--- a/src/test/java/roomescape/domain/theme/ThemeRepositoryTest.java
+++ b/src/test/java/roomescape/domain/theme/ThemeRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/src/test/java/roomescape/domain/theme/ThemeRepositoryTest.java
+++ b/src/test/java/roomescape/domain/theme/ThemeRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/src/test/java/roomescape/domain/theme/ThemeServiceTest.java
+++ b/src/test/java/roomescape/domain/theme/ThemeServiceTest.java
@@ -29,8 +29,8 @@ class ThemeServiceTest {
 
     @Test
     void getTopThemes_예약_많은_테마_순서대로_반환() {
-        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1");
-        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2");
+        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1", 50_000L);
+        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2", 50_000L);
         // theme1 이 2번, theme2 가 1번 예약됨
         when(reservationRepository.findThemeIdsByDateRange(any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(List.of(1L, 1L, 2L));
@@ -44,8 +44,8 @@ class ThemeServiceTest {
 
     @Test
     void getAllThemes_정상_조회() {
-        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1");
-        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2");
+        Theme theme1 = Theme.of(1L, "테마1", "설명1", "url1", 50_000L);
+        Theme theme2 = Theme.of(2L, "테마2", "설명2", "url2", 50_000L);
         when(themeRepository.findAll()).thenReturn(List.of(theme1, theme2));
 
         List<ThemeResponse> responses = themeService.getAllThemes();

--- a/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.domain.reservation.ReservationSlot;

--- a/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingRepositoryTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import roomescape.domain.reservation.ReservationSlot;
@@ -41,7 +41,7 @@ class WaitingRepositoryTest {
         Long themeId = jdbcTemplate.queryForObject("SELECT id FROM theme LIMIT 1", Long.class);
 
         time = ReservationTime.of(timeId, LocalTime.of(10, 0), LocalTime.of(11, 0));
-        theme = Theme.of(themeId, "테마1", "설명", "https://example.com/image.jpg");
+        theme = Theme.of(themeId, "테마1", "설명", "https://example.com/image.jpg", 50_000L);
     }
 
     @Nested

--- a/src/test/java/roomescape/domain/waiting/WaitingServiceTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingServiceTest.java
@@ -58,7 +58,7 @@ class WaitingServiceTest {
     @BeforeEach
     void setUp() {
         time = ReservationTime.of(1L, LocalTime.of(10, 0), LocalTime.of(11, 0));
-        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg");
+        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg", 50_000L);
     }
 
     @Nested

--- a/src/test/java/roomescape/domain/waiting/WaitingTest.java
+++ b/src/test/java/roomescape/domain/waiting/WaitingTest.java
@@ -29,7 +29,7 @@ class WaitingTest {
     @BeforeEach
     void setUp() {
         time = ReservationTime.of(1L, LocalTime.of(10, 0), LocalTime.of(11, 0));
-        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg");
+        theme = Theme.of(1L, "테마1", "설명", "https://example.com/image.jpg", 50_000L);
         waiting1 = Waiting.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
         waiting2 = Waiting.of(2L, "유저2", LocalDate.of(2099, 12, 31), time, theme);
         waiting3 = Waiting.of(3L, "유저3", LocalDate.of(2099, 12, 31), time, theme);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,3 +2,7 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
 spring.sql.init.data-locations=
+
+toss.base-url=https://api.tosspayments.com
+toss.secret-key=test_sk_dummy
+toss.client-key=test_ck_dummy


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x]  애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

### 예약과 결제 시점
도입한 Toss 결제 위젯은 페이지 렌더링 시점에 orderId, amount, orderName 등의 주문 정보를 필요로 합니다. 즉, 사용자가 결제 버튼을 누르기 전에 서버 측에서 주문 정보를 미리 확정해야 하는 제약이 있었습니다. 이를 해결하기 위해 두 가지 방식을 비교했습니다.

대안 A: 결제 완료 후 예약 생성 (미채택)
결제가 성공하더라도 예약 저장 과정에서 실패할 경우 복잡한 환불 로직이 추가로 필요합니다.
결제가 완료되는 시점까지 슬롯이 열려 있으므로, 동일한 슬롯에 다수의 결제가 몰리는 동시성 문제가 발생할 위험이 큽니다.

대안 B: 예약 선점 후 결제 (채택)
결제 진입(checkout) 시점에 슬롯을 PENDING_PAYMENT 상태로 먼저 잠그고, 결제 위젯에 필요한 orderId를 생성합니다.
이후 결제가 성공하면 CONFIRMED로 승격시키고, 실패하면 선점을 해제합니다.

선택 이유: 슬롯 중복 방지에 대한 책임을 DB의 Unique 제약조건과 PENDING_PAYMENT 상태만으로 깔끔하게 통제할 수 있습니다.

보완점 : 이 설계가 온전히 동작하기 위해서는 '결제 실패 및 이탈 시 선점 해제(deleteReservation)' 로직이 필수적인 짝꿍이며, 이를 구현하여 상태 정합성을 맞췄습니다.

### 대기와 결제 시점
기존 예약이 취소되어 빈 슬롯이 생겼을 때, 대기자를 자동으로 CONFIRMED(확정) 상태로 승격시킬지 고민했습니다. 하지만 다음 두 가지 이유로 대기자 역시 PENDING_PAYMENT(결제 대기) 상태로 올린 뒤 직접 결제를 진행하도록 설계했습니다.

대기 등록과 동시에 결제를 미리 받아두는 방식도 고려해 볼 수 있었습니다. 하지만 이 방식은 예약 불발이나 취소 발생 시 다음과 같이 복잡한 환불 시나리오를 만들어냅니다.
- 내 차례가 오지 않는 경우: 앞 순번 대기자가 예약을 확정하여 대기 슬롯이 완전히 소멸하는 경우
- 단순 변심: 대기자가 기다리는 도중 직접 대기 상태를 취소하는 경우 

선결제 방식의 문제점
위의 두 경로 모두 외부 PG사 API를 통한 환불 요청이 필수적입니다. 만약 네트워크 장애나 PG사 사정으로 인해 환불 요청이 실패할 경우, 사용자의 돈은 인출되었으나 시스템상에서는 취소된 '상태 불일치'가 발생합니다. 이를 안정적으로 처리하려면 환불 실패에 대한 재시도 스케줄러, 데드레터 큐, 혹은 관리자 알림 시스템 등 추가적인 인프라와 운영 비용이 투입되어야 하며 시스템 복잡도가 급격히 증가합니다.

현재 채택한 '순번 도래 후 결제' 방식은 사용자가 실제 예약을 확정 지을 수 있는 시점이 되기 전까지는 어떠한 결제 이벤트도 발생시키지 않습니다.
이로 인해 환불이라는 복잡한 예외 경로 자체를 도메인에서 원천 차단할 수 있었습니다. 대기자의 순번이 돌아왔을 때 결제를 포기하더라도, 그저 선점된 임시 예약 상태를 해제하고 다음 대기자에게 순번을 넘겨주면 되므로, 외부 API 의존성 없이 내부 DB 상태 변경만으로 안전하게 제어할 수 있게 되었습니다.