### PR TITLE
[🌱 JPA 방탈출 예약 대기] 코로구(구진) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/roomescape/common/config/JpaConfig.java
+++ b/src/main/java/roomescape/common/config/JpaConfig.java
@@ -1,0 +1,20 @@
+package roomescape.common.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.vendor.HibernateJpaDialect;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager(entityManagerFactory);
+        jpaTransactionManager.setNestedTransactionAllowed(true);
+        jpaTransactionManager.setJpaDialect(new HibernateJpaDialect());
+        return jpaTransactionManager;
+    }
+}

--- a/src/main/java/roomescape/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/ReservationController.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @RestController
-@RequestMapping("/reservations")
+@RequestMapping("/api/reservations")
 @RequiredArgsConstructor
 public class ReservationController {
 

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -3,7 +3,6 @@ package roomescape.reservation.repository;
 import roomescape.reservation.domain.CustomerName;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.repository.dto.ReservationTimesWithStatus;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,5 +26,5 @@ public interface ReservationRepository {
 
     boolean existsBySlot(LocalDate date, long reservationTimeId, long themeId);
 
-    Optional<Reservation> findBySlotForUpdate(LocalDate date, long timeId, long themeId);
+    Optional<Reservation> findBySlot(LocalDate date, long timeId, long themeId);
 }

--- a/src/main/java/roomescape/reservation/repository/jdbc/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/jdbc/JdbcReservationRepository.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -20,10 +21,10 @@ import roomescape.reservation.domain.CustomerName;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.reservation.repository.dto.ReservationTimesWithStatus;
-import roomescape.reservation.repository.entity.ReservationEntity;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
+@Profile("jdbc")
 @Repository
 @RequiredArgsConstructor
 public class JdbcReservationRepository implements ReservationRepository {
@@ -135,9 +136,7 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public Reservation save(final Reservation newReservation) {
-        final ReservationEntity reservationEntity = toEntity(newReservation);
-
-        final long newReservationId = insertReservation(reservationEntity);
+        final long newReservationId = insertReservation(newReservation);
 
         return Reservation.of(
                 newReservationId,
@@ -209,7 +208,7 @@ public class JdbcReservationRepository implements ReservationRepository {
 
 
     @Override
-    public Optional<Reservation> findBySlotForUpdate(final LocalDate date, final long timeId, final long themeId) {
+    public Optional<Reservation> findBySlot(final LocalDate date, final long timeId, final long themeId) {
         final String sql = """
                 SELECT
                     r.id AS reservation_id,
@@ -232,7 +231,7 @@ public class JdbcReservationRepository implements ReservationRepository {
             .findFirst();
     }
 
-    private long insertReservation(final ReservationEntity reservationEntity) {
+    private long insertReservation(final Reservation reservation) {
         final String sql = """
                 INSERT INTO reservation (name, date, time_id, theme_id)
                 VALUES (?, ?, ?, ?)
@@ -246,10 +245,10 @@ public class JdbcReservationRepository implements ReservationRepository {
                     Statement.RETURN_GENERATED_KEYS
             );
 
-            preparedStatement.setString(1, reservationEntity.name());
-            preparedStatement.setDate(2, reservationEntity.date());
-            preparedStatement.setLong(3, reservationEntity.timeId());
-            preparedStatement.setLong(4, reservationEntity.themeId());
+            preparedStatement.setString(1, reservation.getCustomerName());
+            preparedStatement.setDate(2, Date.valueOf(reservation.getDate()));
+            preparedStatement.setLong(3, reservation.getTime().getId());
+            preparedStatement.setLong(4, reservation.getTheme().getId());
 
             return preparedStatement;
         }, keyHolder);
@@ -286,16 +285,6 @@ public class JdbcReservationRepository implements ReservationRepository {
                 resultSet.getDate("reservation_date").toLocalDate(),
                 reservationTime,
                 theme
-        );
-    }
-
-    private ReservationEntity toEntity(final Reservation reservation) {
-        return new ReservationEntity(
-                reservation.getId(),
-                reservation.getCustomerName(),
-                Date.valueOf(reservation.getDate()),
-                reservation.getTime().getId(),
-                reservation.getTheme().getId()
         );
     }
 

--- a/src/main/java/roomescape/reservation/repository/jpa/ReservationJpaRepository.java
+++ b/src/main/java/roomescape/reservation/repository/jpa/ReservationJpaRepository.java
@@ -1,0 +1,54 @@
+package roomescape.reservation.repository.jpa;
+
+import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import roomescape.reservation.repository.entity.ReservationEntity;
+
+public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
+
+    @EntityGraph(attributePaths = {"time", "theme"})
+    List<ReservationEntity> findAll();
+
+    Optional<ReservationEntity> findById(Long id);
+
+    boolean existsByDateAndTimeIdAndThemeId(LocalDate date, long timeId, long themeId);
+
+    @EntityGraph(attributePaths = {"time", "theme"})
+    @Query("SELECT r FROM ReservationEntity r WHERE r.customerName = :customerName AND (r.date > :date OR (r.date = :date AND r.time.startAt > :time))")
+    List<ReservationEntity> findByCustomerNameAfter(
+        @Param("customerName") String customerName,
+        @Param("date") LocalDate date,
+        @Param("time") LocalTime time
+    );
+
+    @Query(nativeQuery = true, value = """
+        SELECT rt.id, rt.start_at AS startAt,
+               CASE WHEN r.id IS NOT NULL THEN TRUE ELSE FALSE END AS reserved
+        FROM reservation_time rt
+        LEFT JOIN reservation r
+            ON r.time_id = rt.id
+           AND r.date = :date
+           AND r.theme_id = :themeId
+        ORDER BY rt.start_at
+        """)
+    List<ReservationTimeStatusProjection> findTimeStatuses(
+        @Param("date") LocalDate date,
+        @Param("themeId") Long themeId
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ReservationEntity r WHERE r.date = :date AND r.timeId = :timeId AND r.themeId = :themeId")
+    Optional<ReservationEntity> findBySlotForUpdate(
+        @Param("date") LocalDate date,
+        @Param("timeId") long timeId,
+        @Param("themeId") long themeId
+    );
+}

--- a/src/main/java/roomescape/reservation/repository/jpa/ReservationRepositoryImpl.java
+++ b/src/main/java/roomescape/reservation/repository/jpa/ReservationRepositoryImpl.java
@@ -1,0 +1,114 @@
+package roomescape.reservation.repository.jpa;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+import roomescape.reservation.domain.CustomerName;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.exception.ReservationAlreadyExistsException;
+import roomescape.reservation.domain.exception.ReservationOptionChangedException;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.reservation.repository.dto.ReservationTimesWithStatus;
+import roomescape.reservation.repository.entity.ReservationEntity;
+
+@Profile("jpa")
+@Repository
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepository {
+
+    private static final String UNIQUE_CONSTRAINT_NAME = "unique_reservation_date_time_theme";
+
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    @Override
+    public List<Reservation> findAll() {
+        return reservationJpaRepository.findAll().stream()
+            .map(ReservationEntity::toDomain)
+            .toList();
+    }
+
+    @Override
+    public Optional<Reservation> findById(final Long reservationId) {
+        return reservationJpaRepository.findById(reservationId).map(ReservationEntity::toDomain);
+    }
+
+    @Override
+    public Reservation save(final Reservation reservation) {
+        try {
+            ReservationEntity saved = reservationJpaRepository.saveAndFlush(ReservationEntity.from(reservation));
+            return Reservation.of(saved.getId(), reservation.getCustomerName(), reservation.getDate(),
+                reservation.getTime(), reservation.getTheme());
+        } catch (DataIntegrityViolationException e) {
+            throw translateViolation(e);
+        }
+    }
+
+    @Override
+    public boolean update(final Reservation reservation) {
+        Optional<ReservationEntity> optEntity = reservationJpaRepository.findById(reservation.getId());
+        if (optEntity.isEmpty()) {
+            return false;
+        }
+        try {
+            optEntity.get().updateSchedule(reservation.getDate(), reservation.getTimeId());
+            reservationJpaRepository.saveAndFlush(optEntity.get());
+        } catch (DataIntegrityViolationException e) {
+            throw translateViolation(e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean deleteById(final Long reservationId) {
+        if (!reservationJpaRepository.existsById(reservationId)) {
+            return false;
+        }
+        reservationJpaRepository.deleteById(reservationId);
+        return true;
+    }
+
+    @Override
+    public List<ReservationTimesWithStatus> findReservationTimeStatusesByDateAndThemeId(
+        final LocalDate date,
+        final Long themeId
+    ) {
+        return reservationJpaRepository.findTimeStatuses(date, themeId).stream()
+            .map(p -> new ReservationTimesWithStatus(p.getId(), p.getStartAt(), p.getReserved()))
+            .toList();
+    }
+
+    @Override
+    public List<Reservation> findAllByCustomerNameAndReservationDateTimeAfter(
+        final CustomerName customerName,
+        final LocalDateTime now
+    ) {
+        return reservationJpaRepository
+            .findByCustomerNameAfter(customerName.name(), now.toLocalDate(), now.toLocalTime())
+            .stream()
+            .map(ReservationEntity::toDomain)
+            .toList();
+    }
+
+    @Override
+    public boolean existsBySlot(final LocalDate date, final long reservationTimeId, final long themeId) {
+        return reservationJpaRepository.existsByDateAndTimeIdAndThemeId(date, reservationTimeId, themeId);
+    }
+
+    @Override
+    public Optional<Reservation> findBySlot(final LocalDate date, final long timeId, final long themeId) {
+        return reservationJpaRepository.findBySlotForUpdate(date, timeId, themeId)
+            .map(ReservationEntity::toDomain);
+    }
+
+    private static RuntimeException translateViolation(final DataIntegrityViolationException e) {
+        if (e.getMessage() != null && e.getMessage().toLowerCase().contains(UNIQUE_CONSTRAINT_NAME)) {
+            return new ReservationAlreadyExistsException();
+        }
+        return new ReservationOptionChangedException(e);
+    }
+}

--- a/src/main/java/roomescape/reservation/repository/jpa/ReservationTimeStatusProjection.java
+++ b/src/main/java/roomescape/reservation/repository/jpa/ReservationTimeStatusProjection.java
@@ -1,0 +1,9 @@
+package roomescape.reservation.repository.jpa;
+
+import java.time.LocalTime;
+
+public interface ReservationTimeStatusProjection {
+    Long getId();
+    LocalTime getStartAt();
+    Boolean getReserved();
+}

--- a/src/main/java/roomescape/reservation/service/ReservationApplicationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationApplicationService.java
@@ -100,7 +100,6 @@ public class ReservationApplicationService {
         return ReservationResponse.from(reservation);
     }
 
-    @Transactional
     public ReservationResponse updateByCustomer(final Long reservationId, final ReservationUpdateRequest request) {
         final Reservation oldReservation = reservationService.getReservation(reservationId);
         final ReservationTime time = reservationTimeService.getById(request.timeId());
@@ -111,7 +110,6 @@ public class ReservationApplicationService {
         return ReservationResponse.from(reservation);
     }
 
-    @Transactional
     public ReservationResponse updateByAdmin(final Long reservationId, final ReservationUpdateRequest request) {
         final Reservation oldReservation = reservationService.getReservation(reservationId);
         final ReservationTime time = reservationTimeService.getById(request.timeId());
@@ -122,7 +120,6 @@ public class ReservationApplicationService {
         return ReservationResponse.from(reservation);
     }
 
-    @Transactional
     public void cancelReservationByIdAndPromoteWaiting(final long reservationId) {
         final Reservation reservation = reservationService.getReservation(reservationId);
         reservationService.cancel(reservation);
@@ -130,7 +127,6 @@ public class ReservationApplicationService {
         promoteIfFutureSlot(reservation);
     }
 
-    @Transactional
     public void deleteReservationById(final long reservationId) {
         final Reservation reservation = reservationService.getReservation(reservationId);
         reservationService.deleteById(reservationId);

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -6,15 +6,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.reservation.domain.CustomerName;
 import roomescape.reservation.domain.Reservation;
-import roomescape.reservation.domain.exception.ReservationAlreadyExistsException;
 import roomescape.reservation.domain.exception.ReservationNotFoundException;
-import roomescape.reservation.domain.exception.ReservationOptionChangedException;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.reservation.repository.dto.ReservationTimesWithStatus;
 import roomescape.reservationtime.domain.ReservationTime;
@@ -29,7 +25,9 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public List<Reservation> findAllReservations() {
-        return reservationRepository.findAll();
+        reservationRepository.findById(1L).get().getTime().getStartAt();
+        return null;
+//        return reservationRepository.findAll();
     }
 
     @Transactional(readOnly = true)
@@ -50,9 +48,9 @@ public class ReservationService {
         return reservationRepository.existsBySlot(date, reservationTimeId, themeId);
     }
 
-    @Transactional
-    public Optional<Reservation> findBySlotForUpdate(final LocalDate date, final long timeId, final long themeId) {
-        return reservationRepository.findBySlotForUpdate(date, timeId, themeId);
+    @Transactional(readOnly = true)
+    public Optional<Reservation> findBySlot(final LocalDate date, final long timeId, final long themeId) {
+        return reservationRepository.findBySlot(date, timeId, themeId);
     }
 
     @Transactional(readOnly = true)
@@ -75,7 +73,7 @@ public class ReservationService {
             theme,
             LocalDateTime.now(clock)
         );
-        return saveReservation(reservation);
+        return reservationRepository.save(reservation);
     }
 
     @Transactional
@@ -91,7 +89,7 @@ public class ReservationService {
             time,
             theme
         );
-        saveReservation(promotedReservation);
+        reservationRepository.save(promotedReservation);
     }
 
     @Transactional
@@ -126,45 +124,29 @@ public class ReservationService {
         deleteReservation(reservationId);
     }
 
-    private Reservation updateSchedule(final LocalDate date, final ReservationTime time,
-                                       final Reservation originReservation) {
+    private Reservation updateSchedule(
+        final LocalDate date,
+        final ReservationTime time,
+        final Reservation originReservation
+    ) {
         final Reservation updatedReservation = originReservation.changeSchedule(
             date,
             time,
             LocalDateTime.now(clock)
         );
-
         return updateReservation(updatedReservation);
     }
 
-    private Reservation saveReservation(final Reservation reservation) {
-        try {
-            return reservationRepository.save(reservation);
-        } catch (DuplicateKeyException exception) {
-            throw new ReservationAlreadyExistsException();
-        } catch (DataIntegrityViolationException exception) {
-            throw new ReservationOptionChangedException(exception);
-        }
-    }
-
     private Reservation updateReservation(final Reservation reservation) {
-        try {
-            final boolean updated = reservationRepository.update(reservation);
-
-            if (!updated) {
-                throw new ReservationNotFoundException();
-            }
-            return reservation;
-        } catch (DuplicateKeyException exception) {
-            throw new ReservationAlreadyExistsException();
-        } catch (DataIntegrityViolationException exception) {
-            throw new ReservationOptionChangedException(exception);
+        final boolean updated = reservationRepository.update(reservation);
+        if (!updated) {
+            throw new ReservationNotFoundException();
         }
+        return reservation;
     }
 
     private void deleteReservation(final Long reservationId) {
         final boolean deleted = reservationRepository.deleteById(reservationId);
-
         if (!deleted) {
             throw new ReservationNotFoundException();
         }

--- a/src/main/java/roomescape/reservation/service/WaitingPromotionService.java
+++ b/src/main/java/roomescape/reservation/service/WaitingPromotionService.java
@@ -14,7 +14,7 @@ public class WaitingPromotionService {
     private final WaitingService waitingService;
     private final ReservationService reservationService;
 
-    @Transactional(propagation = Propagation.NESTED)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void promoteBySlot(final LocalDate reservationDate, final long timeId, final long themeId) {
         waitingService.findEarliestWaitingBySlot(
             reservationDate,

--- a/src/main/java/roomescape/reservationtime/controller/ReservationTimeController.java
+++ b/src/main/java/roomescape/reservationtime/controller/ReservationTimeController.java
@@ -12,7 +12,7 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/times")
+@RequestMapping("/api/times")
 @RequiredArgsConstructor
 public class ReservationTimeController {
 

--- a/src/main/java/roomescape/reservationtime/repository/entity/ReservationTimeEntity.java
+++ b/src/main/java/roomescape/reservationtime/repository/entity/ReservationTimeEntity.java
@@ -1,9 +1,36 @@
 package roomescape.reservationtime.repository.entity;
 
-import java.sql.Time;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import roomescape.reservationtime.domain.ReservationTime;
 
-public record ReservationTimeEntity(
-        Long id,
-        Time startAt
-) {
+@Entity
+@Table(name = "reservation_time")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReservationTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalTime startAt;
+
+    private ReservationTimeEntity(final LocalTime startAt) {
+        this.startAt = startAt;
+    }
+
+    public static ReservationTimeEntity from(final ReservationTime time) {
+        return new ReservationTimeEntity(time.getStartAt());
+    }
+
+    public ReservationTime toDomain() {
+        return ReservationTime.of(id, startAt);
+    }
 }

--- a/src/main/java/roomescape/reservationtime/repository/jdbc/JdbcReservationTimeRepository.java
+++ b/src/main/java/roomescape/reservationtime/repository/jdbc/JdbcReservationTimeRepository.java
@@ -5,10 +5,10 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
-import roomescape.reservationtime.repository.entity.ReservationTimeEntity;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,6 +18,7 @@ import java.sql.Time;
 import java.util.List;
 import java.util.Optional;
 
+@Profile("jdbc")
 @Repository
 @RequiredArgsConstructor
 public class JdbcReservationTimeRepository implements ReservationTimeRepository {
@@ -60,9 +61,7 @@ public class JdbcReservationTimeRepository implements ReservationTimeRepository 
 
     @Override
     public ReservationTime save(final ReservationTime newReservationTime) {
-        final ReservationTimeEntity reservationTimeEntity = toEntity(newReservationTime);
-
-        final long newTimeId = insertReservationTime(reservationTimeEntity);
+        final long newTimeId = insertReservationTime(newReservationTime);
 
         return ReservationTime.of(
                 newTimeId,
@@ -80,7 +79,7 @@ public class JdbcReservationTimeRepository implements ReservationTimeRepository 
         return jdbcTemplate.update(sql, timeId) > 0;
     }
 
-    private long insertReservationTime(final ReservationTimeEntity reservationTimeEntity) {
+    private long insertReservationTime(final ReservationTime reservationTime) {
         final String sql = """
                 INSERT INTO reservation_time (start_at)
                 VALUES (?)
@@ -94,7 +93,7 @@ public class JdbcReservationTimeRepository implements ReservationTimeRepository 
                     Statement.RETURN_GENERATED_KEYS
             );
 
-            preparedStatement.setTime(1, reservationTimeEntity.startAt());
+            preparedStatement.setTime(1, Time.valueOf(reservationTime.getStartAt()));
 
             return preparedStatement;
         }, keyHolder);
@@ -117,10 +116,4 @@ public class JdbcReservationTimeRepository implements ReservationTimeRepository 
         );
     }
 
-    private ReservationTimeEntity toEntity(final ReservationTime reservationTime) {
-        return new ReservationTimeEntity(
-                reservationTime.getId(),
-                Time.valueOf(reservationTime.getStartAt())
-        );
-    }
 }

--- a/src/main/java/roomescape/reservationtime/repository/jpa/ReservationTimeJpaRepository.java
+++ b/src/main/java/roomescape/reservationtime/repository/jpa/ReservationTimeJpaRepository.java
@@ -1,0 +1,7 @@
+package roomescape.reservationtime.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import roomescape.reservationtime.repository.entity.ReservationTimeEntity;
+
+public interface ReservationTimeJpaRepository extends JpaRepository<ReservationTimeEntity, Long> {
+}

--- a/src/main/java/roomescape/reservationtime/repository/jpa/ReservationTimeRepositoryImpl.java
+++ b/src/main/java/roomescape/reservationtime/repository/jpa/ReservationTimeRepositoryImpl.java
@@ -1,0 +1,53 @@
+package roomescape.reservationtime.repository.jpa;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.domain.exception.ReservationTimeInUseException;
+import roomescape.reservationtime.repository.ReservationTimeRepository;
+import roomescape.reservationtime.repository.entity.ReservationTimeEntity;
+
+@Profile("jpa")
+@Repository
+@RequiredArgsConstructor
+public class ReservationTimeRepositoryImpl implements ReservationTimeRepository {
+
+    private final ReservationTimeJpaRepository reservationTimeJpaRepository;
+
+    @Override
+    public List<ReservationTime> findAll() {
+        return reservationTimeJpaRepository.findAll().stream()
+            .map(ReservationTimeEntity::toDomain)
+            .toList();
+    }
+
+    @Override
+    public Optional<ReservationTime> findById(final Long timeId) {
+        return reservationTimeJpaRepository.findById(timeId).map(ReservationTimeEntity::toDomain);
+    }
+
+    @Override
+    public ReservationTime save(final ReservationTime newReservationTime) {
+        return reservationTimeJpaRepository.saveAndFlush(
+            ReservationTimeEntity.from(newReservationTime)
+        ).toDomain();
+    }
+
+    @Override
+    public boolean delete(final Long timeId) {
+        if (!reservationTimeJpaRepository.existsById(timeId)) {
+            return false;
+        }
+        try {
+            reservationTimeJpaRepository.deleteById(timeId);
+            reservationTimeJpaRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new ReservationTimeInUseException(e);
+        }
+        return true;
+    }
+}

--- a/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/reservationtime/service/ReservationTimeService.java
@@ -2,11 +2,9 @@ package roomescape.reservationtime.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.reservationtime.domain.ReservationTime;
-import roomescape.reservationtime.domain.exception.ReservationTimeInUseException;
 import roomescape.reservationtime.domain.exception.ReservationTimeNotFoundException;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
 import roomescape.reservationtime.service.dto.request.ReservationTimeCreateRequest;
@@ -50,10 +48,6 @@ public class ReservationTimeService {
     }
 
     private boolean deleteReservationTime(final Long timeId) {
-        try {
-            return reservationTimeRepository.delete(timeId);
-        } catch (DataIntegrityViolationException exception) {
-            throw new ReservationTimeInUseException(exception);
-        }
+        return reservationTimeRepository.delete(timeId);
     }
 }

--- a/src/main/java/roomescape/theme/controller/ThemeController.java
+++ b/src/main/java/roomescape/theme/controller/ThemeController.java
@@ -12,7 +12,7 @@ import roomescape.theme.service.dto.response.ThemeResponse;
 import java.util.List;
 
 @RestController
-@RequestMapping("/themes")
+@RequestMapping("/api/themes")
 @RequiredArgsConstructor
 public class ThemeController {
 

--- a/src/main/java/roomescape/theme/repository/entity/ThemeEntity.java
+++ b/src/main/java/roomescape/theme/repository/entity/ThemeEntity.java
@@ -1,9 +1,39 @@
 package roomescape.theme.repository.entity;
 
-public record ThemeEntity(
-        Long id,
-        String name,
-        String description,
-        String thumbnailUrl
-) {
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import roomescape.theme.domain.Theme;
+
+@Entity
+@Table(name = "theme")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ThemeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+
+    private ThemeEntity(final String name, final String description, final String thumbnailUrl) {
+        this.name = name;
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static ThemeEntity from(final Theme theme) {
+        return new ThemeEntity(theme.getName(), theme.getDescription(), theme.getThumbnailUrl());
+    }
+
+    public Theme toDomain() {
+        return Theme.of(id, name, description, thumbnailUrl);
+    }
 }

--- a/src/main/java/roomescape/theme/repository/jdbc/JdbcThemeRepository.java
+++ b/src/main/java/roomescape/theme/repository/jdbc/JdbcThemeRepository.java
@@ -5,10 +5,10 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.ThemeRepository;
-import roomescape.theme.repository.entity.ThemeEntity;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+@Profile("jdbc")
 @Repository
 @RequiredArgsConstructor
 public class JdbcThemeRepository implements ThemeRepository {
@@ -52,9 +53,7 @@ public class JdbcThemeRepository implements ThemeRepository {
 
     @Override
     public Theme save(final Theme themeWithoutId) {
-        final ThemeEntity themeEntity = toEntity(themeWithoutId);
-
-        final long themeId = insertTheme(themeEntity);
+        final long themeId = insertTheme(themeWithoutId);
 
         return Theme.of(
                 themeId,
@@ -108,7 +107,7 @@ public class JdbcThemeRepository implements ThemeRepository {
                 .toList();
     }
 
-    private long insertTheme(final ThemeEntity themeEntity) {
+    private long insertTheme(final Theme theme) {
         final String sql = """
                 INSERT INTO theme (name, description, thumbnail_url)
                 VALUES (?, ?, ?)
@@ -122,9 +121,9 @@ public class JdbcThemeRepository implements ThemeRepository {
                     Statement.RETURN_GENERATED_KEYS
             );
 
-            preparedStatement.setString(1, themeEntity.name());
-            preparedStatement.setString(2, themeEntity.description());
-            preparedStatement.setString(3, themeEntity.thumbnailUrl());
+            preparedStatement.setString(1, theme.getName());
+            preparedStatement.setString(2, theme.getDescription());
+            preparedStatement.setString(3, theme.getThumbnailUrl());
 
             return preparedStatement;
         }, keyHolder);
@@ -149,12 +148,4 @@ public class JdbcThemeRepository implements ThemeRepository {
         );
     }
 
-    private ThemeEntity toEntity(final Theme theme) {
-        return new ThemeEntity(
-                theme.getId(),
-                theme.getName(),
-                theme.getDescription(),
-                theme.getThumbnailUrl()
-        );
-    }
 }

--- a/src/main/java/roomescape/theme/repository/jpa/ThemeJpaRepository.java
+++ b/src/main/java/roomescape/theme/repository/jpa/ThemeJpaRepository.java
@@ -1,0 +1,21 @@
+package roomescape.theme.repository.jpa;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import roomescape.theme.repository.entity.ThemeEntity;
+
+public interface ThemeJpaRepository extends JpaRepository<ThemeEntity, Long> {
+
+    @Query(nativeQuery = true, value = """
+        SELECT t.id, t.name, t.description, t.thumbnail_url
+        FROM theme t
+        LEFT JOIN reservation r ON r.theme_id = t.id AND r.date >= :startDate AND r.date < :today
+        GROUP BY t.id, t.name, t.description, t.thumbnail_url
+        ORDER BY COUNT(r.id) DESC, t.name ASC
+        LIMIT 10
+        """)
+    List<ThemeEntity> findPopularThemes(@Param("startDate") LocalDate startDate, @Param("today") LocalDate today);
+}

--- a/src/main/java/roomescape/theme/repository/jpa/ThemeRepositoryImpl.java
+++ b/src/main/java/roomescape/theme/repository/jpa/ThemeRepositoryImpl.java
@@ -1,0 +1,59 @@
+package roomescape.theme.repository.jpa;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.domain.exception.ThemeInUseException;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.theme.repository.entity.ThemeEntity;
+
+@Profile("jpa")
+@Repository
+@RequiredArgsConstructor
+public class ThemeRepositoryImpl implements ThemeRepository {
+
+    private final ThemeJpaRepository themeJpaRepository;
+
+    @Override
+    public List<Theme> findAll() {
+        return themeJpaRepository.findAll().stream()
+            .map(ThemeEntity::toDomain)
+            .toList();
+    }
+
+    @Override
+    public Optional<Theme> findById(final Long themeId) {
+        return themeJpaRepository.findById(themeId).map(ThemeEntity::toDomain);
+    }
+
+    @Override
+    public Theme save(final Theme theme) {
+        return themeJpaRepository.saveAndFlush(ThemeEntity.from(theme)).toDomain();
+    }
+
+    @Override
+    public boolean deleteById(final Long themeId) {
+        if (!themeJpaRepository.existsById(themeId)) {
+            return false;
+        }
+        try {
+            themeJpaRepository.deleteById(themeId);
+            themeJpaRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new ThemeInUseException(e);
+        }
+        return true;
+    }
+
+    @Override
+    public List<Theme> findPopularThemes(final LocalDate startDate, final LocalDate today) {
+        return themeJpaRepository.findPopularThemes(startDate, today).stream()
+            .map(ThemeEntity::toDomain)
+            .toList();
+    }
+}

--- a/src/main/java/roomescape/theme/service/ThemeService.java
+++ b/src/main/java/roomescape/theme/service/ThemeService.java
@@ -4,11 +4,9 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.theme.domain.Theme;
-import roomescape.theme.domain.exception.ThemeInUseException;
 import roomescape.theme.domain.exception.ThemeNotFoundException;
 import roomescape.theme.repository.ThemeRepository;
 import roomescape.theme.service.dto.request.ThemeCreateRequest;
@@ -67,10 +65,6 @@ public class ThemeService {
     }
 
     private boolean deleteTheme(final Long themeId) {
-        try {
-            return themeRepository.deleteById(themeId);
-        } catch (DataIntegrityViolationException exception) {
-            throw new ThemeInUseException(exception);
-        }
+        return themeRepository.deleteById(themeId);
     }
 }

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -1,6 +1,5 @@
 package roomescape.waiting.domain;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -60,7 +59,7 @@ public class Waiting {
     public static Waiting of(
         final Long id,
         final String customerName,
-        final Date date,
+        final LocalDate date,
         final LocalDateTime createdAt,
         final ReservationTime time,
         final Theme theme
@@ -68,7 +67,7 @@ public class Waiting {
         return new Waiting(
             id,
             new CustomerName(customerName),
-            date.toLocalDate(),
+            date,
             createdAt,
             time,
             theme

--- a/src/main/java/roomescape/waiting/repository/entity/WaitingEntity.java
+++ b/src/main/java/roomescape/waiting/repository/entity/WaitingEntity.java
@@ -1,4 +1,4 @@
-package roomescape.reservation.repository.entity;
+package roomescape.waiting.repository.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,33 +11,38 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import roomescape.reservation.domain.Reservation;
+import org.hibernate.annotations.CreationTimestamp;
 import roomescape.reservationtime.repository.entity.ReservationTimeEntity;
 import roomescape.theme.repository.entity.ThemeEntity;
+import roomescape.waiting.domain.Waiting;
 
 @Entity
 @Table(
-    name = "reservation",
+    name = "waiting",
     uniqueConstraints = @UniqueConstraint(
-        name = "unique_reservation_date_time_theme",
-        columnNames = {"date", "time_id", "theme_id"}
+        name = "unique_reservation_date_time_theme_name",
+        columnNames = {"reservation_date", "time_id", "theme_id", "customer_name"}
     )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ReservationEntity {
+public class WaitingEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name")
     private String customerName;
 
-    private LocalDate date;
+    private LocalDate reservationDate;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
     @Column(name = "time_id")
     private Long timeId;
@@ -45,41 +50,36 @@ public class ReservationEntity {
     @Column(name = "theme_id")
     private Long themeId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_id", insertable = false, updatable = false)
     private ReservationTimeEntity time;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id", insertable = false, updatable = false)
     private ThemeEntity theme;
 
-    private ReservationEntity(
+    private WaitingEntity(
         final String customerName,
-        final LocalDate date,
+        final LocalDate reservationDate,
         final Long timeId,
         final Long themeId
     ) {
         this.customerName = customerName;
-        this.date = date;
+        this.reservationDate = reservationDate;
         this.timeId = timeId;
         this.themeId = themeId;
     }
 
-    public static ReservationEntity from(final Reservation reservation) {
-        return new ReservationEntity(
-            reservation.getCustomerName(),
-            reservation.getDate(),
-            reservation.getTimeId(),
-            reservation.getThemeId()
+    public static WaitingEntity from(final Waiting waiting) {
+        return new WaitingEntity(
+            waiting.getCustomerNameValue(),
+            waiting.getReservationDate(),
+            waiting.getTimeId(),
+            waiting.getThemeId()
         );
     }
 
-    public void updateSchedule(final LocalDate date, final Long timeId) {
-        this.date = date;
-        this.timeId = timeId;
-    }
-
-    public Reservation toDomain() {
-        return Reservation.of(id, customerName, date, time.toDomain(), theme.toDomain());
+    public Waiting toDomain() {
+        return Waiting.of(id, customerName, reservationDate, createdAt, time.toDomain(), theme.toDomain());
     }
 }

--- a/src/main/java/roomescape/waiting/repository/jdbc/JdbcWaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/jdbc/JdbcWaitingRepository.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
@@ -19,6 +20,7 @@ import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.repository.WaitingRepository;
 import roomescape.waiting.repository.dto.WaitingWithRank;
 
+@Profile("jdbc")
 @Repository
 @RequiredArgsConstructor
 public class JdbcWaitingRepository implements WaitingRepository {
@@ -27,7 +29,7 @@ public class JdbcWaitingRepository implements WaitingRepository {
         Waiting.of(
             rs.getLong("id"),
             rs.getString("customer_name"),
-            rs.getDate("reservation_date"),
+            rs.getDate("reservation_date").toLocalDate(),
             rs.getTimestamp("created_at").toLocalDateTime(),
             ReservationTime.of(
                 rs.getLong("t_id"),
@@ -46,7 +48,7 @@ public class JdbcWaitingRepository implements WaitingRepository {
             Waiting.of(
                 rs.getLong("id"),
                 rs.getString("customer_name"),
-                rs.getDate("reservation_date"),
+                rs.getDate("reservation_date").toLocalDate(),
                 rs.getTimestamp("created_at").toLocalDateTime(),
                 ReservationTime.of(
                     rs.getLong("t_id"),

--- a/src/main/java/roomescape/waiting/repository/jpa/WaitingJpaRepository.java
+++ b/src/main/java/roomescape/waiting/repository/jpa/WaitingJpaRepository.java
@@ -1,0 +1,91 @@
+package roomescape.waiting.repository.jpa;
+
+import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import roomescape.waiting.repository.entity.WaitingEntity;
+
+public interface WaitingJpaRepository extends JpaRepository<WaitingEntity, Long> {
+
+    @Query("""
+        SELECT w FROM WaitingEntity w
+        JOIN FETCH w.time
+        JOIN FETCH w.theme
+        WHERE w.id = :id
+        """)
+    Optional<WaitingEntity> findByIdWithJoins(@Param("id") Long id);
+
+    boolean existsByReservationDateAndTimeIdAndThemeId(LocalDate reservationDate, long timeId, long themeId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT w FROM WaitingEntity w
+        JOIN FETCH w.time
+        JOIN FETCH w.theme
+        WHERE w.reservationDate = :date
+          AND w.timeId = :timeId
+          AND w.themeId = :themeId
+        ORDER BY w.createdAt ASC, w.id ASC
+        LIMIT 1
+        """)
+    Optional<WaitingEntity> findEarliestBySlotForUpdate(
+        @Param("date") LocalDate date,
+        @Param("timeId") long timeId,
+        @Param("themeId") long themeId
+    );
+
+    @Query(nativeQuery = true, value = """
+        WITH ranked AS (
+            SELECT w.id, w.customer_name, w.reservation_date, w.created_at,
+                   w.time_id, w.theme_id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY w.reservation_date, w.time_id, w.theme_id
+                       ORDER BY w.created_at
+                   ) AS rank
+            FROM waiting w
+        )
+        SELECT r.id, r.customer_name AS customerName, r.reservation_date AS reservationDate,
+               r.created_at AS createdAt, r.rank AS rank,
+               t.id AS timeId, t.start_at AS timeStartAt,
+               th.id AS themeId, th.name AS themeName, th.description AS themeDescription,
+               th.thumbnail_url AS themeThumbnailUrl
+        FROM ranked r
+        JOIN reservation_time t ON r.time_id = t.id
+        JOIN theme th ON r.theme_id = th.id
+        ORDER BY r.reservation_date ASC, t.start_at ASC, r.rank ASC
+        """)
+    List<WaitingRankProjection> findAllWithRankProjection();
+
+    @Query(nativeQuery = true, value = """
+        WITH ranked AS (
+            SELECT w.id, w.customer_name, w.reservation_date, w.created_at,
+                   w.time_id, w.theme_id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY w.reservation_date, w.time_id, w.theme_id
+                       ORDER BY w.created_at
+                   ) AS rank
+            FROM waiting w
+        )
+        SELECT r.id, r.customer_name AS customerName, r.reservation_date AS reservationDate,
+               r.created_at AS createdAt, r.rank AS rank,
+               t.id AS timeId, t.start_at AS timeStartAt,
+               th.id AS themeId, th.name AS themeName, th.description AS themeDescription,
+               th.thumbnail_url AS themeThumbnailUrl
+        FROM ranked r
+        JOIN reservation_time t ON r.time_id = t.id
+        JOIN theme th ON r.theme_id = th.id
+        WHERE r.customer_name = :customerName
+          AND (r.reservation_date > :date OR (r.reservation_date = :date AND t.start_at > :time))
+        ORDER BY r.reservation_date ASC
+        """)
+    List<WaitingRankProjection> findWithRankByCustomerNameAfter(
+        @Param("customerName") String customerName,
+        @Param("date") LocalDate date,
+        @Param("time") String time
+    );
+}

--- a/src/main/java/roomescape/waiting/repository/jpa/WaitingRankProjection.java
+++ b/src/main/java/roomescape/waiting/repository/jpa/WaitingRankProjection.java
@@ -1,0 +1,30 @@
+package roomescape.waiting.repository.jpa;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public interface WaitingRankProjection {
+
+    Long getId();
+
+    String getCustomerName();
+
+    LocalDate getReservationDate();
+
+    LocalDateTime getCreatedAt();
+
+    Integer getRank();
+
+    Long getTimeId();
+
+    LocalTime getTimeStartAt();
+
+    Long getThemeId();
+
+    String getThemeName();
+
+    String getThemeDescription();
+
+    String getThemeThumbnailUrl();
+}

--- a/src/main/java/roomescape/waiting/repository/jpa/WaitingRepositoryImpl.java
+++ b/src/main/java/roomescape/waiting/repository/jpa/WaitingRepositoryImpl.java
@@ -1,0 +1,118 @@
+package roomescape.waiting.repository.jpa;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.theme.domain.Theme;
+import roomescape.waiting.domain.Waiting;
+import roomescape.waiting.domain.exception.WaitingAlreadyExistsException;
+import roomescape.waiting.repository.WaitingRepository;
+import roomescape.waiting.repository.dto.WaitingWithRank;
+import roomescape.waiting.repository.entity.WaitingEntity;
+
+@Profile("jpa")
+@Repository
+@RequiredArgsConstructor
+public class WaitingRepositoryImpl implements WaitingRepository {
+
+    private static final String UNIQUE_CONSTRAINT_NAME = "unique_reservation_date_time_theme_name";
+
+    private final WaitingJpaRepository waitingJpaRepository;
+
+    @Override
+    public Waiting save(final Waiting waiting) {
+        try {
+            WaitingEntity saved = waitingJpaRepository.saveAndFlush(WaitingEntity.from(waiting));
+            return Waiting.of(
+                saved.getId(),
+                waiting.getCustomerNameValue(),
+                waiting.getReservationDate(),
+                saved.getCreatedAt(),
+                waiting.getTime(),
+                waiting.getTheme()
+            );
+        } catch (DataIntegrityViolationException e) {
+            if (e.getMessage() != null && e.getMessage().toLowerCase().contains(UNIQUE_CONSTRAINT_NAME)) {
+                throw new WaitingAlreadyExistsException();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean deleteById(final long id) {
+        if (!waitingJpaRepository.existsById(id)) {
+            return false;
+        }
+        waitingJpaRepository.deleteById(id);
+        return true;
+    }
+
+    @Override
+    public Optional<Waiting> findById(final long id) {
+        return waitingJpaRepository.findByIdWithJoins(id)
+            .map(WaitingEntity::toDomain);
+    }
+
+    @Override
+    public Optional<Waiting> findEarliestBySlotForUpdate(
+        final LocalDate date,
+        final long timeId,
+        final long themeId
+    ) {
+        return waitingJpaRepository.findEarliestBySlotForUpdate(date, timeId, themeId)
+            .map(WaitingEntity::toDomain);
+    }
+
+    @Override
+    public List<WaitingWithRank> findAllWithRankByCustomerNameAndReservationDateTimeAfter(
+        final String customerName,
+        final LocalDateTime now
+    ) {
+        return waitingJpaRepository
+            .findWithRankByCustomerNameAfter(customerName, now.toLocalDate(), now.toLocalTime().toString()).stream()
+            .map(this::toWaitingWithRank)
+            .toList();
+    }
+
+    @Override
+    public boolean existsBySlot(final LocalDate reservationDate, final long timeId, final long themeId) {
+        return waitingJpaRepository.existsByReservationDateAndTimeIdAndThemeId(reservationDate, timeId, themeId);
+    }
+
+    @Override
+    public List<WaitingWithRank> findAllWithRank() {
+        return waitingJpaRepository.findAllWithRankProjection().stream()
+            .map(this::toWaitingWithRank)
+            .toList();
+    }
+
+    private WaitingWithRank toWaitingWithRank(final WaitingRankProjection waitingRankProjection) {
+        ReservationTime time = ReservationTime.of(
+            waitingRankProjection.getTimeId(),
+            waitingRankProjection.getTimeStartAt()
+        );
+        Theme theme = Theme.of(
+            waitingRankProjection.getThemeId(),
+            waitingRankProjection.getThemeName(),
+            waitingRankProjection.getThemeDescription(),
+            waitingRankProjection.getThemeThumbnailUrl()
+        );
+
+        Waiting waiting = Waiting.of(
+            waitingRankProjection.getId(),
+            waitingRankProjection.getCustomerName(),
+            waitingRankProjection.getReservationDate(),
+            waitingRankProjection.getCreatedAt(),
+            time,
+            theme
+        );
+        return new WaitingWithRank(waiting, waitingRankProjection.getRank());
+    }
+}

--- a/src/main/java/roomescape/waiting/service/WaitingApplicationService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingApplicationService.java
@@ -1,11 +1,9 @@
 package roomescape.waiting.service;
 
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.service.ReservationService;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.service.ReservationTimeService;
@@ -31,14 +29,11 @@ public class WaitingApplicationService {
         ReservationTime reservationTime = reservationTimeService.getById(request.timeId());
         Theme theme = themeService.getById(request.themeId());
 
-        final Optional<Reservation> reservation = reservationService.findBySlotForUpdate(
-            request.date(),
-            reservationTime.getId(),
-            theme.getId()
-        );
-        if (reservation.isEmpty()) {
-            throw new NoReservationForWaitingException();
-        }
+        reservationService.findBySlot(
+                request.date(),
+                reservationTime.getId(),
+                theme.getId())
+            .orElseThrow(NoReservationForWaitingException::new);
 
         final Waiting saved = waitingService.create(
             request.name(),

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.reservationtime.domain.ReservationTime;
@@ -14,7 +13,6 @@ import roomescape.theme.domain.Theme;
 import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.domain.exception.PastReservationWaitingCancellationException;
 import roomescape.waiting.domain.exception.WaitingNotFoundException;
-import roomescape.waiting.domain.exception.WaitingAlreadyExistsException;
 import roomescape.waiting.repository.WaitingRepository;
 import roomescape.waiting.repository.dto.WaitingWithRank;
 
@@ -40,7 +38,7 @@ public class WaitingService {
             LocalDateTime.now(clock)
         );
 
-        return saveWaiting(waiting);
+        return waitingRepository.save(waiting);
     }
 
     @Transactional
@@ -97,14 +95,6 @@ public class WaitingService {
         final long themeId
     ) {
         return waitingRepository.existsBySlot(reservationDate, timeId, themeId);
-    }
-
-    private Waiting saveWaiting(final Waiting waiting) {
-        try {
-            return waitingRepository.save(waiting);
-        } catch (DuplicateKeyException exception) {
-            throw new WaitingAlreadyExistsException();
-        }
     }
 
     private void deleteWaiting(final long waitingId) {

--- a/src/main/resources/application-jdbc.yml
+++ b/src/main/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+  sql:
+    init:
+      mode: always
+logging:
+  level:
+    org.springframework.jdbc.core.JdbcTemplate: DEBUG

--- a/src/main/resources/application-jpa.yml
+++ b/src/main/resources/application-jpa.yml
@@ -1,0 +1,9 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:sample-data.sql

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,2 +1,0 @@
-spring.sql.init.mode=always
-spring.sql.init.data-locations=classpath:sample-data.sql

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+spring:
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:sample-data.sql

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
-spring.datasource.url=jdbc:h2:mem:database;MODE=MySQL;DB_CLOSE_DELAY=-1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,12 @@
 spring:
+  profiles:
+    default: jpa
   h2:
     console:
       enabled: true
   datasource:
     url: jdbc:h2:mem:database;MODE=MySQL;DB_CLOSE_DELAY=-1
   jpa:
-    hibernate:
-      ddl-auto: create-drop
-    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:database;MODE=MySQL;DB_CLOSE_DELAY=-1
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/test/java/roomescape/fixture/WaitingFixture.java
+++ b/src/test/java/roomescape/fixture/WaitingFixture.java
@@ -1,6 +1,5 @@
 package roomescape.fixture;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import roomescape.reservationtime.domain.ReservationTime;
@@ -20,7 +19,7 @@ public class WaitingFixture {
         final ReservationTime time,
         final Theme theme
     ) {
-        return Waiting.of(id, customerName, Date.valueOf(date), createdAt, time, theme);
+        return Waiting.of(id, customerName, date, createdAt, time, theme);
     }
 
     public static Waiting saved(
@@ -29,6 +28,6 @@ public class WaitingFixture {
         final ReservationTime time,
         final Theme theme
     ) {
-        return Waiting.of(ID, CUSTOMER_NAME, Date.valueOf(reservationDate), createdAt, time, theme);
+        return Waiting.of(ID, CUSTOMER_NAME, reservationDate, createdAt, time, theme);
     }
 }

--- a/src/test/java/roomescape/reservation/controller/AdminReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/AdminReservationControllerTest.java
@@ -108,7 +108,7 @@ class AdminReservationControllerTest {
                         "timeId", 1,
                         "themeId", 1
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(201);
 

--- a/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/reservation/controller/ReservationControllerTest.java
@@ -79,7 +79,7 @@ class ReservationControllerTest {
     })
     void 전체_날짜와_테마_조회() {
         ReservationOptionResponse responses = RestAssured.given().log().all()
-                .when().get("/reservations/date-and-theme")
+                .when().get("/api/reservations/date-and-theme")
                 .then().log().all()
                 .statusCode(200).extract()
                 .jsonPath().getObject(".", ReservationOptionResponse.class);
@@ -131,7 +131,7 @@ class ReservationControllerTest {
     @Test
     void 예약_가능한_시간_조회시_날짜_형식이_잘못되면_400을_응답한다() {
         RestAssured.given().log().all()
-                .when().get("/reservations/available-times?date=invalid-date&themeId=1")
+                .when().get("/api/reservations/available-times?date=invalid-date&themeId=1")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("잘못된 요청입니다."));
@@ -140,7 +140,7 @@ class ReservationControllerTest {
     @Test
     void 예약_가능한_시간_조회시_테마_id가_없으면_400을_응답한다() {
         RestAssured.given().log().all()
-                .when().get("/reservations/available-times?date=2026-05-05")
+                .when().get("/api/reservations/available-times?date=2026-05-05")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("잘못된 요청입니다."));
@@ -169,7 +169,7 @@ class ReservationControllerTest {
             final Response response = RestAssured
                 .given().log().all()
                 .queryParam("customer-name", customerName)
-                .when().get("/reservations");
+                .when().get("/api/reservations");
 
             // then
             final ReservationsAndWaitingsResponse body = response
@@ -198,7 +198,7 @@ class ReservationControllerTest {
                         "timeId", 1,
                         "themeId", 1
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(201);
 
@@ -206,7 +206,7 @@ class ReservationControllerTest {
         assertThat(count).isEqualTo(1);
 
         RestAssured.given().log().all()
-                .when().delete("/reservations/1")
+                .when().delete("/api/reservations/1")
                 .then().log().all()
                 .statusCode(204);
 
@@ -227,7 +227,7 @@ class ReservationControllerTest {
                         "date", "2026-08-06",
                         "timeId", 2
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(200)
                 .body("id", org.hamcrest.Matchers.is(1))
@@ -254,7 +254,7 @@ class ReservationControllerTest {
                         "date", "2026-08-06",
                         "timeId", 1
                 ))
-                .when().put("/reservations/999")
+                .when().put("/api/reservations/999")
                 .then().log().all()
                 .statusCode(404)
                 .body("message", org.hamcrest.Matchers.is("존재하지 않는 예약입니다."));
@@ -272,7 +272,7 @@ class ReservationControllerTest {
                         "date", "2026-08-06",
                         "timeId", 999
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(404)
                 .body("message", org.hamcrest.Matchers.is("존재하지 않는 예약 시간입니다."));
@@ -285,7 +285,7 @@ class ReservationControllerTest {
                 .body(Map.of(
                         "timeId", 1
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("예약일을 입력해야 합니다."));
@@ -304,7 +304,7 @@ class ReservationControllerTest {
                         "date", "2026-04-30",
                         "timeId", 2
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("과거 시간으로는 예약할 수 없습니다."));
@@ -324,7 +324,7 @@ class ReservationControllerTest {
                         "date", "2026-08-05",
                         "timeId", 2
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(409)
                 .body("message", org.hamcrest.Matchers.is("이미 예약이 있는 슬롯입니다."));
@@ -343,7 +343,7 @@ class ReservationControllerTest {
                         "date", "2026-05-02",
                         "timeId", 2
                 ))
-                .when().put("/reservations/1")
+                .when().put("/api/reservations/1")
                 .then().log().all()
                 .statusCode(409)
                 .body("message", org.hamcrest.Matchers.is("당일 예약은 변경할 수 없습니다."));
@@ -356,7 +356,7 @@ class ReservationControllerTest {
         jdbcTemplate.update("INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)", "브라운", "2026-05-01", "1", "1");
 
         RestAssured.given().log().all()
-                .when().delete("/reservations/1")
+                .when().delete("/api/reservations/1")
                 .then().log().all()
                 .statusCode(409)
                 .body("message", org.hamcrest.Matchers.is("당일 예약은 취소할 수 없습니다."));
@@ -374,7 +374,7 @@ class ReservationControllerTest {
                         "timeId", 999,
                         "themeId", 1
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(404);
     }
@@ -390,7 +390,7 @@ class ReservationControllerTest {
                         "date", "2026-05-05",
                         "themeId", 1
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("예약 시간을 선택해야 합니다."));
@@ -401,7 +401,7 @@ class ReservationControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body("null")
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("잘못된 요청입니다."));
@@ -419,7 +419,7 @@ class ReservationControllerTest {
                         "timeId", 1,
                         "themeId", 999
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(404);
     }
@@ -437,7 +437,7 @@ class ReservationControllerTest {
                         "timeId", 1,
                         "themeId", 1
                 ))
-                .when().post("/reservations")
+                .when().post("/api/reservations")
                 .then().log().all()
                 .statusCode(400);
     }
@@ -456,7 +456,7 @@ class ReservationControllerTest {
 
             // when
             final Response response = RestAssured.given().log().all()
-                .delete("/reservations/{id}", 1L);
+                .delete("/api/reservations/{id}", 1L);
 
             // then
             response.then().log().all()
@@ -479,7 +479,7 @@ class ReservationControllerTest {
 
             // when
             final Response response = RestAssured.given().log().all()
-                .delete("/reservations/{id}", 1L);
+                .delete("/api/reservations/{id}", 1L);
 
             // then
             response.then().log().all()
@@ -509,7 +509,7 @@ class ReservationControllerTest {
                 .body(Map.of(
                     "date", "2026-08-07",
                     "timeId", 1))
-                .put("/reservations/{id}", 1L);
+                .put("/api/reservations/{id}", 1L);
 
             // then
             response.then().log().all()
@@ -538,7 +538,7 @@ class ReservationControllerTest {
                 .body(Map.of(
                     "date", newSlotDate,
                     "timeId", 1))
-                .put("/reservations/{id}", 1L);
+                .put("/api/reservations/{id}", 1L);
 
             // then
             response.then().log().all()
@@ -614,7 +614,7 @@ class ReservationControllerTest {
 
     private static List<ReservationTimesWithStatus> getReservationTimeStatusResponses() {
         return RestAssured.given().log().all()
-            .when().get("/reservations/available-times?date=2026-05-05&themeId=1")
+            .when().get("/api/reservations/available-times?date=2026-05-05&themeId=1")
             .then().log().all()
             .statusCode(200).extract()
             .jsonPath().getList(".", ReservationTimesWithStatus.class);

--- a/src/test/java/roomescape/reservation/repository/jdbc/JdbcReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/repository/jdbc/JdbcReservationRepositoryTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.reservation.domain.CustomerName;
 import roomescape.reservation.domain.Reservation;
@@ -27,6 +28,7 @@ import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
 
 @JdbcTest
+@ActiveProfiles("jdbc")
 @Sql("/clear.sql")
 class JdbcReservationRepositoryTest {
 

--- a/src/test/java/roomescape/reservation/service/support/FakeReservationRepository.java
+++ b/src/test/java/roomescape/reservation/service/support/FakeReservationRepository.java
@@ -1,12 +1,11 @@
 package roomescape.reservation.service.support;
 
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import roomescape.reservation.domain.CustomerName;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.exception.ReservationAlreadyExistsException;
+import roomescape.reservation.domain.exception.ReservationOptionChangedException;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.reservation.repository.dto.ReservationTimesWithStatus;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -97,7 +96,7 @@ public class FakeReservationRepository implements ReservationRepository  {
     }
 
     @Override
-    public Optional<Reservation> findBySlotForUpdate(final LocalDate date, final long timeId, final long themeId) {
+    public Optional<Reservation> findBySlot(final LocalDate date, final long timeId, final long themeId) {
         return reservations.stream()
             .filter(reservation ->
                 reservation.getDate().isEqual(date)
@@ -115,18 +114,18 @@ public class FakeReservationRepository implements ReservationRepository  {
     }
 
     public void failToSaveByDuplicatedReservation() {
-        saveException = new DuplicateKeyException("duplicated reservation");
+        saveException = new ReservationAlreadyExistsException();
     }
 
     public void failToSaveByChangedOption() {
-        saveException = new DataIntegrityViolationException("changed reservation option");
+        saveException = new ReservationOptionChangedException(new RuntimeException("changed reservation option"));
     }
 
     public void failToUpdateByDuplicatedReservation() {
-        updateException = new DuplicateKeyException("duplicated reservation");
+        updateException = new ReservationAlreadyExistsException();
     }
 
     public void failToUpdateByChangedOption() {
-        updateException = new DataIntegrityViolationException("changed reservation option");
+        updateException = new ReservationOptionChangedException(new RuntimeException("changed reservation option"));
     }
 }

--- a/src/test/java/roomescape/reservationtime/controller/ReservationTimeControllerTest.java
+++ b/src/test/java/roomescape/reservationtime/controller/ReservationTimeControllerTest.java
@@ -32,7 +32,7 @@ class ReservationTimeControllerTest {
     @Sql("/clear.sql")
     void 존재하지_않는_예약_시간을_삭제하면_404를_응답한다() {
         RestAssured.given().log().all()
-                .when().delete("/times/0")
+                .when().delete("/api/times/0")
                 .then().log().all()
                 .statusCode(404);
     }
@@ -45,12 +45,12 @@ class ReservationTimeControllerTest {
                 .body(Map.of(
                         "startAt", "10:00"
                 ))
-                .when().post("/times")
+                .when().post("/api/times")
                 .then().log().all()
                 .statusCode(201);
 
         RestAssured.given().log().all()
-                .when().get("/times")
+                .when().get("/api/times")
                 .then().log().all()
                 .statusCode(200);
 
@@ -58,7 +58,7 @@ class ReservationTimeControllerTest {
         assertThat(count).isEqualTo(1);
 
         RestAssured.given().log().all()
-                .when().delete("/times/1")
+                .when().delete("/api/times/1")
                 .then().log().all()
                 .statusCode(204);
     }
@@ -69,7 +69,7 @@ class ReservationTimeControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(Map.of())
-                .when().post("/times")
+                .when().post("/api/times")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("예약 시작 시간을 입력해야 합니다."));
@@ -83,7 +83,7 @@ class ReservationTimeControllerTest {
         jdbcTemplate.update("INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)", "브라운", "2026-08-05", "1", "1");
 
         RestAssured.given().log().all()
-                .when().delete("/times/1")
+                .when().delete("/api/times/1")
                 .then().log().all()
                 .statusCode(409);
     }

--- a/src/test/java/roomescape/reservationtime/repository/jdbc/JdbcReservationTimeRepositoryTest.java
+++ b/src/test/java/roomescape/reservationtime/repository/jdbc/JdbcReservationTimeRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.reservationtime.domain.ReservationTime;
 
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @JdbcTest
+@ActiveProfiles("jdbc")
 @Sql("/clear.sql")
 class JdbcReservationTimeRepositoryTest {
 

--- a/src/test/java/roomescape/reservationtime/service/support/FakeReservationTimeRepository.java
+++ b/src/test/java/roomescape/reservationtime/service/support/FakeReservationTimeRepository.java
@@ -1,7 +1,7 @@
 package roomescape.reservationtime.service.support;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.domain.exception.ReservationTimeInUseException;
 import roomescape.reservationtime.repository.ReservationTimeRepository;
 
 import java.util.ArrayList;
@@ -60,6 +60,6 @@ public class FakeReservationTimeRepository implements ReservationTimeRepository 
     }
 
     public void failToDeleteByInUse() {
-        deleteException = new DataIntegrityViolationException("time in use");
+        deleteException = new ReservationTimeInUseException(new RuntimeException("time in use"));
     }
 }

--- a/src/test/java/roomescape/theme/controller/ThemeControllerTest.java
+++ b/src/test/java/roomescape/theme/controller/ThemeControllerTest.java
@@ -64,7 +64,7 @@ class ThemeControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
-                .when().post("/themes")
+                .when().post("/api/themes")
                 .then().log().all()
                 .statusCode(201);
 
@@ -72,7 +72,7 @@ class ThemeControllerTest {
         assertThat(count).isEqualTo(1);
 
         RestAssured.given().log().all()
-                .when().delete("/themes/1")
+                .when().delete("/api/themes/1")
                 .then().log().all()
                 .statusCode(204);
 
@@ -90,7 +90,7 @@ class ThemeControllerTest {
                         "description", "",
                         "thumbnailUrl", "https://~"
                 ))
-                .when().post("/themes")
+                .when().post("/api/themes")
                 .then().log().all()
                 .statusCode(400)
                 .body("message", org.hamcrest.Matchers.is("테마 설명을 입력해야 합니다."));
@@ -103,7 +103,7 @@ class ThemeControllerTest {
     })
     void 최근_일주일간_예약이_많은_상위_10개_테마_조회() {
         List<ThemeResponse> popularThemes = RestAssured.given().log().all()
-                .when().get("/themes/popular")
+                .when().get("/api/themes/popular")
                 .then().log().all()
                 .statusCode(200).extract()
                 .jsonPath().getList(".", ThemeResponse.class);
@@ -119,7 +119,7 @@ class ThemeControllerTest {
     @Sql("/clear.sql")
     void 존재하지_않는_테마를_삭제하면_404를_응답한다() {
         RestAssured.given().log().all()
-                .when().delete("/themes/999")
+                .when().delete("/api/themes/999")
                 .then().log().all()
                 .statusCode(404);
     }
@@ -132,7 +132,7 @@ class ThemeControllerTest {
         jdbcTemplate.update("INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)", "브라운", "2026-08-05", "1", "1");
 
         RestAssured.given().log().all()
-                .when().delete("/themes/1")
+                .when().delete("/api/themes/1")
                 .then().log().all()
                 .statusCode(409)
                 .body("message", org.hamcrest.Matchers.is("해당 테마에 예약이 존재하여 삭제할 수 없습니다."));

--- a/src/test/java/roomescape/theme/repository/jdbc/JdbcThemeRepositoryTest.java
+++ b/src/test/java/roomescape/theme/repository/jdbc/JdbcThemeRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.theme.domain.Theme;
 
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @JdbcTest
+@ActiveProfiles("jdbc")
 @Sql("/clear.sql")
 class JdbcThemeRepositoryTest {
 

--- a/src/test/java/roomescape/theme/service/support/FakeThemeRepository.java
+++ b/src/test/java/roomescape/theme/service/support/FakeThemeRepository.java
@@ -1,7 +1,7 @@
 package roomescape.theme.service.support;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import roomescape.theme.domain.Theme;
+import roomescape.theme.domain.exception.ThemeInUseException;
 import roomescape.theme.repository.ThemeRepository;
 
 import java.time.LocalDate;
@@ -85,6 +85,6 @@ public class FakeThemeRepository implements ThemeRepository {
     }
 
     public void failToDeleteByInUse() {
-        deleteException = new DataIntegrityViolationException("theme in use");
+        deleteException = new ThemeInUseException(new RuntimeException("theme in use"));
     }
 }

--- a/src/test/java/roomescape/waiting/repository/jdbc/JdbcWaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/repository/jdbc/JdbcWaitingRepositoryTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.theme.domain.Theme;
@@ -27,6 +28,7 @@ import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.repository.dto.WaitingWithRank;
 
 @JdbcTest
+@ActiveProfiles("jdbc")
 @Sql("/clear.sql")
 class JdbcWaitingRepositoryTest {
 

--- a/src/test/java/roomescape/waiting/service/support/FakeWaitingRepository.java
+++ b/src/test/java/roomescape/waiting/service/support/FakeWaitingRepository.java
@@ -1,6 +1,5 @@
 package roomescape.waiting.service.support;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,7 +19,7 @@ public class FakeWaitingRepository implements WaitingRepository {
         final Waiting savedWaitingWithId = Waiting.of(
             1L,
             waiting.getCustomerName().name(),
-            Date.valueOf(waiting.getReservationDate()),
+            waiting.getReservationDate(),
             waiting.getCreatedAt(),
             waiting.getTime(),
             waiting.getTheme()


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?


### 0단계 (JPA 인프라 세팅)

**NESTED → REQUIRES_NEW**

현재 applicationService 단에서 Transactional 을 붙이고 있고, 레포지토리랑 소통하는 service 단에서 트랜잭션을 전파받는 형태입니다. `WaitingPromotionService`는 예약 취소 후 대기 승격을 담당하는데, 승격 실패가 예약 취소 트랜잭션을 롤백시켜서는 안 됩니다.
이전에 `NESTED`를 사용한 이유도 이거 때문인데, `JpaTransactionManager`는 기본적으로 `SavepointManager`를 지원하지 않아서 `NestedTransactionNotSupportedException`이 발생했습니다.

JPA 에서 NESTED 를 사용하기에는 설정이 까다롭다고 판단하여 applicationService 에서 Transactional 을 제거하고, promotion 호출 부를 `REQUIRES_NEW`로 교체했습니다.

---

### 1단계 JPA 전환

**JDBC vs JPA 코드 비교하기**

JDBC에서는 반복되는 쿼리가 존재합니다.

- 모든 읽기 메서드에서 `JOIN reservation_time`, `JOIN theme`을 작성
- ResultSet에서 도메인 객체로 변환하는 `mapToDomain()` 또는 `RowMapper`를 클래스마다 구현
- `Date.valueOf(localDate)`, `rs.getDate(...).toLocalDate()` 같은 타입 변환 코드

JPA에서는 `@ManyToOne`으로 관계를 한 번 선언하면 이후 조회에서 Hibernate가 JOIN 쿼리를 날립니다.
또한, 엔티티 객체로 소통할 수 있게 추상화 되어 있어 타입 변환도 없습니다. 
대신 `FetchType`에 따라 로딩 전략을 선택해야 하고, `LAZY`를 쓰면 N+1 문제로 발생할 수 있어서 `@EntityGraph`나 fetch join 같은 해결 방법을 고민해야 합니다.

<br/>

**INSERT 로그 비교**

같은 예약 생성 요청에서 발행되는 쿼리를 비교했습니다.

JDBC:
```sql
SELECT id, start_at FROM reservation_time WHERE id = ?
SELECT id, name, description, thumbnail_url FROM theme WHERE id = ?
SELECT COUNT(1) FROM waiting WHERE reservation_date = ? AND time_id = ? AND theme_id = ?
INSERT INTO reservation (name, date, time_id, theme_id) VALUES (?, ?, ?, ?)

JPA:
select rte1_0.id, rte1_0.start_at from reservation_time rte1_0 where rte1_0.id=?
select te1_0.id, te1_0.description, te1_0.name, te1_0.thumbnail_url from theme te1_0 where
te1_0.id=?
select we1_0.id from waiting we1_0
    where we1_0.reservation_date=? and we1_0.time_id=? and we1_0.theme_id=?
    fetch first ? rows only
insert into reservation (name, date, theme_id, time_id, id) values (?, ?, ?, ?, default)
```

#### id 처리 방식
JDBC는 id 컬럼을 직접 insert 하지 않고 AUTO_INCREMENT에 위임하고, JPA는 id 컬럼에 default를 전달합니다.

#### 중복 체크 쿼리 차이
JDBC의 `SELECT COUNT(1)`은 전체를 세지만, JPA existsBy~ 메서드는 `FETCH FIRST 1 ROWS ONLY`로 변환되어 하나를 찾으면 즉시 중단합니다.

<br/>

**도메인 엔티티와 JPA 엔티티 분리**

도메인 엔티티에 JPA 관련 코드를 제거하기 위해 JPA 엔티티를 별도로 두었습니다. 
그리고 객체간 변환을 위해 Entity 내부에 toDomain() / from() 정적 변환 메서드를 구현했습니다.

<br/>

---

### 2단계 내 예약 목록 조회

**메서드 이름 쿼리를 JPQL로 전환**

처음에는 메서드 이름 쿼리를 사용하려 했고, `현재 시간 이후의 예약만 필터링` 이라는 조건을 구현하기 위해 date와 time.startAt 두 컬럼이 필요했습니다.

메서드 이름으로 구현했더니 아래와 같았습니다.

```java
findByCustomerNameAndDateAfterOrCustomerNameAndDateAndTime_StartAtAfter(...)
```

메서드가 너무 길어서 가독성이 너무 떨어진다고 판단했고, 현재는 JPQL로 구현했습니다.

```java
@Query("""
    SELECT r FROM ReservationEntity r
    WHERE r.customerName = :customerName
      AND (r.date > :date OR (r.date = :date AND r.time.startAt > :time))
    """)
```

단, JPQL은 문자열이라 컴파일 타임에 오류를 잡을 수 없고, 필드명이 바뀌면 런타임에서 터집니다.
또한 r.time.startAt처럼 연관 엔티티의 필드를 WHERE 조건에서 참조하면 Hibernate가 묵시적으로 INNER JOIN을 추가하는데, 이 JOIN은 코드에 명시되지 않기 때문에 실제 동작 방식을 알고있지 않으면 의도치 않은 결과를 반환받을 수 있습니다.

<br/>

**@EntityGraph로 N+1 방지**

findById 쿼리는 다음과 같습니다.

```sql
select re1_0.id, re1_0.name, re1_0.date,
       t1_0.id, t1_0.description, t1_0.name, t1_0.thumbnail_url, re1_0.theme_id,
       t2_0.id, t2_0.start_at, re1_0.time_id
from reservation re1_0
left join theme t1_0 on t1_0.id=re1_0.theme_id
left join reservation_time t2_0 on t2_0.id=re1_0.time_id
where re1_0.id=?
```

`@EntityGraph(attributePaths = {"time", "theme"})`를 선언하면 이렇게 LEFT JOIN으로 한 번에 가져옵니다. 
JDBC에서 findAll에 매번 JOIN을 직접 작성하던 것과 비교하면 훨씬 간단했습니다.

<br/>

---

### 3단계 예약 대기 (대기 순번)

ROW_NUMBER() OVER (PARTITION BY ...) 윈도우 함수는 JPQL이 지원하지 않기 때문에 대기 순번 계산은 native query 를 사용했습니다.
처음엔 서비스 레이어에서 애플리케이션 레벨로 계산하는 방법도 고민했지만, 대기 수가 많아질수록 전체를 메모리에 올려 처리하는 게 부담스럽다고 판단했습니다.

<br/>

---

###  4단계 예약 취소 시 자동 승격

예약 취소(cancelReservationByIdAndPromoteWaiting)에서 WaitingPromotionService.promoteBySlot()을 호출합니다. 
승격 실패가 예약 취소를 롤백시키지 않도록 REQUIRES_NEW로 분리했고, 승격 중 발생하는 예외는 catch로 잡아서 log.error 로 기록하는 것으로 마무리했습니다.
만약 데이터 정합성 문제를 더 견고하게 잡고싶다면, 대기 승격을 이벤트 기반으로 아예 분리하고, 몇차례의 재시도 로직을 넣는 방법도 있습니다. 하지만, 이 부분은 미션 범위를 벗어난다고 생각하여 아직은 구현하지 않고 구상만 해두었습니다.