### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 마이찬(나의찬) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'

--- a/docs/01-feature/external_API/step2/03-implementation-plan.md
+++ b/docs/01-feature/external_API/step2/03-implementation-plan.md
@@ -1,0 +1,325 @@
+# Step2 구현 계획 — 타임아웃 · 예외 처리 · 멱등 재시도
+
+---
+
+## 결론 먼저
+
+> 변경이 필요한 레이어는 4곳이다.
+> `TossPaymentConfig` (타임아웃 설정) →
+> `TossPaymentGateway` (예외 분류 + 멱등키) →
+> `PaymentService` (uncertain 상태 저장) →
+> 내역 조회 API (신규)
+>
+> `orderId`는 이미 Reservation에 있으므로 멱등키 저장 작업은 없다.
+
+---
+
+## 현재 코드 상태 파악
+
+### 무엇이 없는가
+
+| 위치 | 없는 것 |
+|------|---------|
+| `TossPaymentConfig` | `SimpleClientHttpRequestFactory`, timeout 설정 |
+| `TossPaymentGateway` | `Idempotency-Key` 헤더, timeout 예외 분류 |
+| `PaymentService` | uncertain 상태 분기, 상태 저장 |
+| `Payment` domain | `PaymentStatus` 필드 |
+| `ErrorCode` | `PAYMENT_CONNECTION_TIMEOUT`, `PAYMENT_READ_TIMEOUT` |
+| DB schema | `payment.status` 컬럼 |
+| API | 내역 조회 엔드포인트 |
+
+### 무엇이 이미 있는가
+
+- `Reservation.orderId` → 멱등키로 그대로 쓸 수 있다. 주문 생성 시 UUID가 이미 발급된다.
+- `TossPaymentGateway.mapToErrorCode()` → Toss 비즈니스 에러 분류 완성.
+- `PaymentService.handlePaymentFail()` → Toss 리다이렉트 실패 콜백 처리 완성.
+
+---
+
+## 구현 순서
+
+### Step 1 — ErrorCode 추가
+
+`global/exception/ErrorCode.java`에 두 가지를 추가한다.
+
+```java
+PAYMENT_CONNECTION_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+PAYMENT_READ_TIMEOUT(HttpStatus.ACCEPTED, "결제 요청을 전송했으나 응답이 없습니다. 결제 내역에서 상태를 확인해 주세요."),
+```
+
+- `CONNECTION_TIMEOUT`: 연결조차 못 했으니 확정 실패 → `503`
+- `READ_TIMEOUT`: 서버가 처리했을 수도 있는 불확실한 상태 → `202`(Accepted)
+  클라이언트에게 "됐는지 모르니 내역을 확인하라"는 의미를 담는다.
+
+---
+
+### Step 2 — 타임아웃 설정 (`TossPaymentConfig`)
+
+#### 방식 선택
+
+요구사항은 `simple` 또는 `apache` 팩토리를 권장한다.
+`jdk` 팩토리는 응답 바디 지연을 read timeout으로 잡지 못하기 때문이다.
+→ **`SimpleClientHttpRequestFactory` 코드 방식**을 선택한다.
+
+property 방식(`spring.http.clients.*`)은 Spring Boot 4.0 이상 기능으로,
+현재 프로젝트가 3.4.x이므로 코드 방식이 더 명확하다.
+
+#### 변경 내용
+
+`application.properties` 추가:
+```properties
+toss.connect-timeout=3000
+toss.read-timeout=10000
+```
+
+`TossPaymentConfig.java` 변경:
+```java
+@Value("${toss.connect-timeout}")
+private int connectTimeout;
+
+@Value("${toss.read-timeout}")
+private int readTimeout;
+
+@Bean
+public RestClient tossRestClient() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(connectTimeout);
+    factory.setReadTimeout(readTimeout);
+
+    String encoded = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
+    return RestClient.builder()
+            .requestFactory(factory)
+            .baseUrl("https://api.tosspayments.com")
+            .defaultHeader("Authorization", "Basic " + encoded)
+            .defaultHeader("Content-Type", "application/json")
+            .build();
+}
+```
+
+타임아웃 값 근거:
+- `connectTimeout=3000ms`: 연결 자체가 3초 이상 걸리면 서버 자체 문제이므로 빠르게 포기.
+- `readTimeout=10000ms`: 토스 응답 p99가 수초 수준임을 감안해 여유 있게 설정.
+  실제 운영에서는 부하 테스트 결과 기반으로 조정해야 한다.
+
+---
+
+### Step 3 — 멱등키 + 예외 분류 (`TossPaymentGateway`)
+
+#### 멱등키
+
+`confirm(PaymentConfirmation confirmation)` 호출부에 헤더 추가:
+
+```java
+TossPaymentResponse response = restClient.post()
+        .uri(CONFIRM_PATH)
+        .header("Idempotency-Key", confirmation.orderId())  // 추가
+        .body(request)
+        .retrieve()
+        .onStatus(...)
+        .body(TossPaymentResponse.class);
+```
+
+`orderId`는 이미 주문 생성 시 UUID로 고정 발급되어 있으므로,
+재시도 시에도 같은 `orderId`가 전달된다 → 멱등성 보장.
+
+#### 예외 분류
+
+`ResourceAccessException`의 root cause로 상황을 구분한다.
+
+```java
+try {
+    TossPaymentResponse response = restClient.post()
+            ...
+            .body(TossPaymentResponse.class);
+    ...
+} catch (ResourceAccessException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof SocketTimeoutException ste && ste.getMessage().contains("Read")) {
+        throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
+    }
+    throw new CustomException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
+}
+```
+
+| 상황 | 예외 | root cause | ErrorCode |
+|------|------|-----------|-----------|
+| connect timeout / 연결 거부 | `ResourceAccessException` | `ConnectException` / `SocketTimeoutException`(connect) | `PAYMENT_CONNECTION_TIMEOUT` |
+| read timeout (응답 지연) | `ResourceAccessException` | `SocketTimeoutException`("Read timed out") | `PAYMENT_READ_TIMEOUT` |
+| Toss 비즈니스 거절 | `CustomException` (이미 처리됨) | — | 기존 코드 유지 |
+
+**핵심**: `PAYMENT_READ_TIMEOUT`은 "실패"가 아니라 "불확실"이다.
+`PaymentService`에서 이 예외를 잡아 UNCERTAIN 상태로 저장해야 한다.
+
+---
+
+### Step 4 — PaymentStatus 추가
+
+#### `PaymentStatus.java` (신규)
+
+```java
+public enum PaymentStatus {
+    CONFIRMED,   // 정상 승인
+    UNCERTAIN    // read timeout - 승인됐는지 모름
+}
+```
+
+#### `Payment.java` 변경
+
+`status` 필드 추가. 기존 생성자는 `CONFIRMED`를 기본값으로 유지해 하위 호환을 깨지 않는다.
+
+```java
+private final PaymentStatus status;
+
+// 기존 생성자: status = CONFIRMED
+// 신규 생성자: status 명시 가능
+```
+
+#### DB schema 변경
+
+`src/main/resources/schema.sql`에 `payment` 테이블 컬럼 추가:
+```sql
+ALTER TABLE payment ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'CONFIRMED';
+```
+또는 CREATE TABLE 문에 `status VARCHAR(20) NOT NULL DEFAULT 'CONFIRMED'` 컬럼 추가.
+
+#### `JdbcPaymentRepository` 변경
+
+`save()` 시 `status` 컬럼 포함, `rowMapper`에 `status` 매핑 추가.
+
+---
+
+### Step 5 — uncertain 분기 처리 (`PaymentService`)
+
+`confirmPayment()`에서 `PAYMENT_READ_TIMEOUT` 발생 시 예약을 PENDING 유지한 채 UNCERTAIN Payment를 저장한다.
+
+```java
+@Transactional
+public Payment confirmPayment(PaymentConfirmation confirmation) {
+    Reservation reservation = reservationRepository.findByOrderId(confirmation.orderId())
+            .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+    if (!confirmation.amount().equals(reservation.getAmount())) {
+        throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+    }
+
+    try {
+        PaymentResult result = paymentGateway.confirm(confirmation);
+        Payment payment = paymentRepository.save(
+                new Payment(reservation.getId(), result.paymentKey(), result.orderId(), result.amount(), PaymentStatus.CONFIRMED)
+        );
+        reservation.confirm();
+        reservationRepository.updateStatus(reservation);
+        // ThemeSlot update 유지
+        ...
+        return payment;
+
+    } catch (CustomException e) {
+        if (e.getErrorCode() == ErrorCode.PAYMENT_READ_TIMEOUT) {
+            // 불확실 상태: 예약은 PENDING 유지, UNCERTAIN 기록만 저장
+            return paymentRepository.save(
+                    new Payment(reservation.getId(), null, confirmation.orderId(), confirmation.amount(), PaymentStatus.UNCERTAIN)
+            );
+        }
+        throw e;
+    }
+}
+```
+
+**왜 예약을 PENDING으로 유지하는가?**
+read timeout 시 토스가 이미 승인을 처리했을 수 있다.
+예약을 CANCELLED로 바꾸면 실제로 결제는 됐는데 예약이 취소되는 더 큰 문제가 생긴다.
+사용자가 내역 페이지에서 확인하고 안전하게 재시도(같은 멱등키로)할 수 있도록 놔둔다.
+
+---
+
+### Step 6 — 내역 조회 API
+
+요구사항: "로그인한 사용자의 주문(예약) 목록에 예약 정보 + 결제 상태 표시"
+
+#### 엔드포인트
+
+`GET /payment/history` (또는 `/reservations/mine` 패턴에 통합)
+
+로그인 사용자의 `name`(또는 memberId)으로 Reservation을 조회하고,
+각 Reservation에 연결된 Payment를 JOIN 또는 개별 조회해서 내려준다.
+
+#### 응답 DTO
+
+```java
+public record ReservationPaymentResponse(
+    Long reservationId,
+    String themeName,
+    LocalDate date,
+    String timeValue,
+    String reservationStatus,
+    String orderId,
+    String paymentKey,       // UNCERTAIN이면 null
+    Long amount,
+    String paymentStatus     // "CONFIRMED" | "UNCERTAIN" | "PENDING(결제 전)"
+) {}
+```
+
+#### 구현 위치
+
+- `PaymentService.getPaymentHistory(String memberName)` 또는 `ReservationService` 통합
+- `PaymentController.GET /payment/history`
+
+---
+
+## 변경 파일 목록 요약
+
+| 파일 | 변경 유형 | 내용 |
+|------|----------|------|
+| `application.properties` | 추가 | `toss.connect-timeout`, `toss.read-timeout` |
+| `ErrorCode.java` | 추가 | `PAYMENT_CONNECTION_TIMEOUT`, `PAYMENT_READ_TIMEOUT` |
+| `PaymentStatus.java` | 신규 | `CONFIRMED`, `UNCERTAIN` |
+| `Payment.java` | 수정 | `status` 필드 추가 |
+| `TossPaymentConfig.java` | 수정 | `SimpleClientHttpRequestFactory` + timeout |
+| `TossPaymentGateway.java` | 수정 | `Idempotency-Key` 헤더, timeout 예외 분류 |
+| `PaymentService.java` | 수정 | uncertain 분기 처리, 내역 조회 메서드 |
+| `JdbcPaymentRepository.java` | 수정 | `status` 컬럼 CRUD |
+| `schema.sql` | 수정 | `payment.status` 컬럼 |
+| `PaymentController.java` | 수정 | `GET /payment/history` 추가 |
+
+---
+
+## 테스트 전략
+
+### TossPaymentGateway — MockWebServer 슬라이스 테스트
+
+```java
+// connect timeout: 블랙홀 IP(10.255.255.1)는 테스트 환경에서 쓰기 어려우므로
+// MockWebServer에서 응답을 보내기 전에 소켓을 close해서 거부 상황 재현
+server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+// read timeout: 응답 지연으로 재현
+server.enqueue(new MockResponse()
+    .setBodyDelay(readTimeout + 500, TimeUnit.MILLISECONDS)
+    .setBody("{}"));
+```
+
+검증 포인트:
+- connect 실패 → `CustomException(PAYMENT_CONNECTION_TIMEOUT)`
+- read timeout → `CustomException(PAYMENT_READ_TIMEOUT)`
+- 멱등키 헤더 → `RecordedRequest.getHeader("Idempotency-Key")` == orderId
+
+### PaymentService — 단위 테스트
+
+- `paymentGateway.confirm()` Mock이 `PAYMENT_READ_TIMEOUT` 던질 때
+  → UNCERTAIN Payment 저장, 예약 상태 PENDING 유지
+  → `reservation.confirm()` 호출되지 않음
+
+---
+
+## 추가 고민할 것
+
+1. `UNCERTAIN` 상태를 어떻게 `CONFIRMED`로 수렴시킬 것인가?
+   - 결제 조회 API(`GET /v1/payments/{orderId}`)로 실제 상태를 폴링하는 배치나 스케줄러가 필요하다.
+   - 이번 단계에서는 "사용자가 내역에서 확인 후 재시도"로 처리한다.
+
+2. `Idempotency-Key` 유효기간(15일) 이후 재시도는?
+   - orderId를 새로 발급해야 한다. → 현재는 미지원 범위.
+
+3. `PaymentController.confirm()`의 파라미터가 `@RequestParam`인데
+   Toss 리다이렉트는 query string으로 내려오므로 맞다.
+   단, `amount`가 `Long`이어서 Toss가 문자열 `"50000"`을 보낼 때 자동 변환되는지 확인 필요.

--- a/docs/01-feature/external_API/step2/04-spring-retry-implementation.md
+++ b/docs/01-feature/external_API/step2/04-spring-retry-implementation.md
@@ -1,0 +1,192 @@
+# Spring Retry 구현 — TossPaymentGateway 재시도 전략
+
+---
+
+## 결론 먼저
+
+> `@Retryable`은 AOP 프록시 기반이라 예외 타입으로 재시도 여부를 분류한다.
+> 재시도 가능 / 불가 예외를 **타입으로 분리**하고,
+> 멱등키는 호출 전에 고정해야 안전하게 재시도할 수 있다.
+
+---
+
+## 왜 직접 루프 대신 Spring Retry인가
+
+직접 루프로 재시도를 구현하면 서비스 로직에 재시도 정책이 섞인다.
+
+```java
+// 직접 루프 — 재시도 정책이 비즈니스 로직에 섞임
+for (int i = 0; i < 3; i++) {
+    try {
+        return paymentGateway.confirm(confirmation);
+    } catch (ResourceAccessException e) {
+        if (i == 2) throw e;
+        Thread.sleep(1000 * (i + 1));
+    }
+}
+```
+
+`@Retryable`을 쓰면 재시도 정책을 어노테이션으로 선언하고, 실제 로직에는 단순한 메서드 호출만 남는다.
+
+---
+
+## 설정
+
+### 의존성 (`build.gradle`)
+
+```groovy
+implementation 'org.springframework.retry:spring-retry'
+implementation 'org.springframework:spring-aspects'  // AOP 프록시 필요
+```
+
+### 활성화
+
+```java
+@EnableRetry
+@Configuration
+public class TossPaymentConfig { ... }
+```
+
+---
+
+## 예외 분리 전략
+
+`@Retryable`은 **예외 타입**으로 재시도 여부를 구분한다.
+`retryFor`와 `noRetryFor`에 같은 타입을 쓸 수 없으므로,
+재시도 가능 여부에 따라 예외 타입 자체를 나눠야 한다.
+
+### 재시도 가능 예외 (신규 정의)
+
+```java
+// gateway 레이어 전용 — 일시적 실패, 결과 불확실
+public class RetryablePaymentException extends RuntimeException {
+    public RetryablePaymentException(String message) {
+        super(message);
+    }
+}
+```
+
+### 재시도 불가 예외 (기존 `CustomException` 그대로)
+
+비즈니스 거절(카드 한도 초과, 인증 키 오류 등)은 재시도해도 결과가 같으므로 `CustomException`을 그대로 던져 즉시 실패시킨다.
+
+---
+
+## `TossPaymentGateway` 적용
+
+### 예외 분류 지점 변경
+
+```java
+} catch (ResourceAccessException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof SocketTimeoutException && cause.getMessage().contains("Read")) {
+        // read timeout: 서버가 처리했을 수도 있음 → 재시도 가능
+        throw new RetryablePaymentException("read timeout");
+    }
+    // connect 실패: 연결조차 안 됨 → 재시도 가능 (서버 미처리 확정)
+    throw new RetryablePaymentException("connection failed");
+}
+// Toss 비즈니스 거절: onStatus()에서 CustomException → 재시도 없이 즉시 실패
+```
+
+### `@Retryable` 선언
+
+```java
+@Retryable(
+    retryFor  = { RetryablePaymentException.class },  // 재시도 O
+    noRetryFor = { CustomException.class },           // 재시도 X
+    maxAttempts = 3,
+    backoff = @Backoff(
+        delay      = 1000,   // 첫 재시도 대기: 1초
+        multiplier = 2.0,    // 지수 백오프: 1s → 2s → 4s
+        random     = true    // 지터: thundering herd 방지
+    )
+)
+@Override
+public PaymentResult confirm(PaymentConfirmation confirmation) { ... }
+```
+
+### `@Recover` — 3회 모두 실패 시
+
+```java
+@Recover
+public PaymentResult recoverConfirm(RetryablePaymentException e, PaymentConfirmation confirmation) {
+    // 재시도를 모두 소진했을 때 → PaymentService에서 UNCERTAIN으로 처리
+    throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
+}
+```
+
+---
+
+## 전체 호출 흐름
+
+```
+PaymentService.confirmPayment()
+    └─ TossPaymentGateway.confirm()  ← @Retryable 적용
+
+        ┌─ 성공 ────────────────────────────────────────► PaymentResult 반환
+        │
+        ├─ RetryablePaymentException (1회)
+        │       ↓ 1초 + jitter 대기
+        ├─ RetryablePaymentException (2회)
+        │       ↓ 2초 + jitter 대기
+        ├─ RetryablePaymentException (3회)
+        │       ↓ @Recover 호출
+        │   CustomException(PAYMENT_READ_TIMEOUT)
+        │       ↓
+        │   PaymentService → UNCERTAIN Payment 저장, 예약 PENDING 유지
+        │
+        └─ CustomException (비즈니스 거절)
+                ↓ 즉시 실패 (noRetryFor)
+            PaymentService → 예외 전파
+```
+
+---
+
+## 멱등키와 재시도의 관계
+
+`@Retryable`이 재시도할 때 **같은 `confirmation` 객체를 그대로 재사용**한다.
+`confirmation.orderId()`가 이미 주문 생성 시 고정된 UUID이므로,
+재시도 3회 모두 동일한 `Idempotency-Key`가 헤더에 붙는다.
+토스 서버는 같은 키를 받으면 첫 응답을 그대로 돌려주므로 이중 승인이 발생하지 않는다.
+
+```
+재시도 1회: Idempotency-Key: order-uuid-abc → 토스 처리 중
+재시도 2회: Idempotency-Key: order-uuid-abc → 첫 응답 캐시 반환 (멱등)
+재시도 3회: Idempotency-Key: order-uuid-abc → 첫 응답 캐시 반환 (멱등)
+```
+
+---
+
+## 주의사항
+
+### AOP 프록시 한계
+
+`@Retryable`은 스프링 빈을 통한 호출에만 동작한다.
+같은 클래스 내에서 `this.confirm()`을 직접 호출하면 프록시를 우회하여 재시도가 동작하지 않는다.
+
+```java
+// 동작 안 함 — 프록시 우회
+public void someMethod() {
+    this.confirm(confirmation);  // @Retryable 무시
+}
+
+// 동작함 — 빈 주입을 통한 호출
+public void someMethod(TossPaymentGateway gateway) {
+    gateway.confirm(confirmation);  // @Retryable 적용
+}
+```
+
+### 현재 코드에 바로 적용하기 전 고려할 것
+
+현재 `PaymentService`는 `PAYMENT_READ_TIMEOUT`을 받으면 UNCERTAIN Payment를 저장한다.
+여기에 Gateway 레벨 재시도까지 추가하면, **하나의 `confirmPayment()` 호출이 토스에 최대 3번 요청**을 보낼 수 있다.
+
+| 상황 | 재시도 없음 | 재시도 있음 |
+|------|------------|------------|
+| 토스 일시 불안정 | 즉시 UNCERTAIN 저장 | 자동 복구 가능, 성공 확률↑ |
+| 사용자 대기 시간 | 짧음 (타임아웃 1회) | 최대 1+2+4 = 7초 |
+| 토스 요청 횟수 | 1회 | 최대 3회 |
+
+결제처럼 민감한 작업은 재시도 횟수를 보수적으로(2~3회) 잡고,
+전체 데드라인(예: 10초)을 넘지 않도록 backoff 값을 설계해야 한다.

--- a/src/main/java/roomescape/controller/PaymentController.java
+++ b/src/main/java/roomescape/controller/PaymentController.java
@@ -1,6 +1,8 @@
 package roomescape.controller;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,10 +10,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.controller.dto.PaymentConfirmResponse;
 import roomescape.controller.dto.PaymentFailResponse;
+import roomescape.controller.dto.ReservationPaymentResponse;
 import roomescape.domain.payment.Payment;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.service.PaymentService;
 
+import java.util.List;
+
+@Validated
 @RestController
 @RequestMapping("/payment")
 public class PaymentController {
@@ -41,5 +47,10 @@ public class PaymentController {
     ) {
         paymentService.handlePaymentFail(orderId);
         return ResponseEntity.ok(new PaymentFailResponse(code, message));
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<List<ReservationPaymentResponse>> getHistory(@NotBlank @RequestParam String name) {
+        return ResponseEntity.ok(paymentService.getPaymentHistory(name));
     }
 }

--- a/src/main/java/roomescape/controller/dto/ReservationPaymentResponse.java
+++ b/src/main/java/roomescape/controller/dto/ReservationPaymentResponse.java
@@ -1,0 +1,46 @@
+package roomescape.controller.dto;
+
+import roomescape.domain.Reservation;
+import roomescape.domain.payment.Payment;
+
+import java.time.LocalDate;
+
+public record ReservationPaymentResponse(
+        Long reservationId,
+        String themeName,
+        LocalDate date,
+        String timeValue,
+        String reservationStatus,
+        String orderId,
+        String paymentKey,
+        Long amount,
+        String paymentStatus
+) {
+    public static ReservationPaymentResponse of(Reservation reservation, Payment payment) {
+        return new ReservationPaymentResponse(
+                reservation.getId(),
+                reservation.getTheme().getName(),
+                reservation.getDate(),
+                reservation.getTime().getStartAt().toString(),
+                reservation.getReservationStatusName(),
+                reservation.getOrderId(),
+                payment.getPaymentKey(),
+                payment.getAmount(),
+                payment.getStatus().name()
+        );
+    }
+
+    public static ReservationPaymentResponse withoutPayment(Reservation reservation) {
+        return new ReservationPaymentResponse(
+                reservation.getId(),
+                reservation.getTheme().getName(),
+                reservation.getDate(),
+                reservation.getTime().getStartAt().toString(),
+                reservation.getReservationStatusName(),
+                reservation.getOrderId(),
+                null,
+                reservation.getAmount(),
+                null
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/payment/Payment.java
+++ b/src/main/java/roomescape/domain/payment/Payment.java
@@ -7,21 +7,27 @@ public class Payment {
     private final String paymentKey;
     private final String orderId;
     private final Long amount;
+    private final PaymentStatus status;
 
     public Payment(Long reservationId, String paymentKey, String orderId, Long amount) {
-        this.id = null;
-        this.reservationId = reservationId;
-        this.paymentKey = paymentKey;
-        this.orderId = orderId;
-        this.amount = amount;
+        this(null, reservationId, paymentKey, orderId, amount, PaymentStatus.CONFIRMED);
+    }
+
+    public Payment(Long reservationId, String paymentKey, String orderId, Long amount, PaymentStatus status) {
+        this(null, reservationId, paymentKey, orderId, amount, status);
     }
 
     public Payment(Long id, Long reservationId, String paymentKey, String orderId, Long amount) {
+        this(id, reservationId, paymentKey, orderId, amount, PaymentStatus.CONFIRMED);
+    }
+
+    public Payment(Long id, Long reservationId, String paymentKey, String orderId, Long amount, PaymentStatus status) {
         this.id = id;
         this.reservationId = reservationId;
         this.paymentKey = paymentKey;
         this.orderId = orderId;
         this.amount = amount;
+        this.status = status;
     }
 
     public Long getId() {
@@ -42,5 +48,9 @@ public class Payment {
 
     public Long getAmount() {
         return amount;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
     }
 }

--- a/src/main/java/roomescape/domain/payment/PaymentStatus.java
+++ b/src/main/java/roomescape/domain/payment/PaymentStatus.java
@@ -1,0 +1,6 @@
+package roomescape.domain.payment;
+
+public enum PaymentStatus {
+    CONFIRMED,
+    UNCERTAIN
+}

--- a/src/main/java/roomescape/global/config/TossPaymentConfig.java
+++ b/src/main/java/roomescape/global/config/TossPaymentConfig.java
@@ -3,6 +3,7 @@ package roomescape.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 import java.util.Base64;
@@ -13,10 +14,21 @@ public class TossPaymentConfig {
     @Value("${toss.secret-key}")
     private String secretKey;
 
+    @Value("${toss.connect-timeout}")
+    private int connectTimeout;
+
+    @Value("${toss.read-timeout}")
+    private int readTimeout;
+
     @Bean
     public RestClient tossRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
+
         String encoded = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
         return RestClient.builder()
+                .requestFactory(factory)
                 .baseUrl("https://api.tosspayments.com")
                 .defaultHeader("Authorization", "Basic " + encoded)
                 .defaultHeader("Content-Type", "application/json")

--- a/src/main/java/roomescape/global/config/TossPaymentConfig.java
+++ b/src/main/java/roomescape/global/config/TossPaymentConfig.java
@@ -4,10 +4,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestClient;
 
 import java.util.Base64;
 
+@EnableRetry
 @Configuration
 public class TossPaymentConfig {
 

--- a/src/main/java/roomescape/global/exception/ErrorCode.java
+++ b/src/main/java/roomescape/global/exception/ErrorCode.java
@@ -42,7 +42,9 @@ public enum ErrorCode {
     PAYMENT_UNAUTHORIZED_KEY(HttpStatus.UNAUTHORIZED, "결제 인증 키가 유효하지 않습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
     PAYMENT_TOSS_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "결제 서버 내부 오류입니다. 잠시 후 재시도해 주세요."),
-    PAYMENT_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 알 수 없는 오류가 발생했습니다.");
+    PAYMENT_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 알 수 없는 오류가 발생했습니다."),
+    PAYMENT_CONNECTION_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+    PAYMENT_READ_TIMEOUT(HttpStatus.ACCEPTED, "결제 요청을 전송했으나 응답이 없습니다. 결제 내역에서 상태를 확인해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/roomescape/global/exception/ErrorCode.java
+++ b/src/main/java/roomescape/global/exception/ErrorCode.java
@@ -44,7 +44,8 @@ public enum ErrorCode {
     PAYMENT_TOSS_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "결제 서버 내부 오류입니다. 잠시 후 재시도해 주세요."),
     PAYMENT_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 알 수 없는 오류가 발생했습니다."),
     PAYMENT_CONNECTION_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요."),
-    PAYMENT_READ_TIMEOUT(HttpStatus.ACCEPTED, "결제 요청을 전송했으나 응답이 없습니다. 결제 내역에서 상태를 확인해 주세요.");
+    PAYMENT_READ_TIMEOUT(HttpStatus.ACCEPTED, "결제 요청을 전송했으나 응답이 없습니다. 결제 내역에서 상태를 확인해 주세요."),
+    PAYMENT_SLOT_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 다른 사용자가 해당 슬롯을 결제 완료했습니다. 대기 순서에 따라 자동 승격됩니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/roomescape/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -63,6 +64,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e, HttpServletRequest httpServletRequest
+    ) {
+        ErrorResponse errorResponse = new ErrorResponseBuilder()
+                .httpStatus(HttpStatus.BAD_REQUEST)
+                .errorMessage("요청값이 잘못됐습니다.")
+                .apiUrl(httpServletRequest.getRequestURI())
+                .timeStamp(LocalDateTime.now())
+                .traceId(MDC.get("traceId"))
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolationException(

--- a/src/main/java/roomescape/infra/JdbcPaymentRepository.java
+++ b/src/main/java/roomescape/infra/JdbcPaymentRepository.java
@@ -43,13 +43,27 @@ public class JdbcPaymentRepository implements PaymentRepository {
                 FROM payment
                 WHERE order_id = ?
                 """;
-        return jdbcTemplate.query(sql, (rs, rowNum) -> new Payment(
+        return jdbcTemplate.query(sql, paymentRowMapper(), orderId).stream().findFirst();
+    }
+
+    @Override
+    public Optional<Payment> findByReservationId(Long reservationId) {
+        String sql = """
+                SELECT id, reservation_id, payment_key, order_id, amount, status
+                FROM payment
+                WHERE reservation_id = ?
+                """;
+        return jdbcTemplate.query(sql, paymentRowMapper(), reservationId).stream().findFirst();
+    }
+
+    private org.springframework.jdbc.core.RowMapper<Payment> paymentRowMapper() {
+        return (rs, rowNum) -> new Payment(
                 rs.getLong("id"),
                 rs.getLong("reservation_id"),
                 rs.getString("payment_key"),
                 rs.getString("order_id"),
                 rs.getLong("amount"),
                 PaymentStatus.valueOf(rs.getString("status"))
-        ), orderId).stream().findFirst();
+        );
     }
 }

--- a/src/main/java/roomescape/infra/JdbcPaymentRepository.java
+++ b/src/main/java/roomescape/infra/JdbcPaymentRepository.java
@@ -4,6 +4,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.payment.Payment;
+import roomescape.domain.payment.PaymentStatus;
 import roomescape.repository.PaymentRepository;
 
 import java.util.HashMap;
@@ -30,14 +31,15 @@ public class JdbcPaymentRepository implements PaymentRepository {
         params.put("payment_key", payment.getPaymentKey());
         params.put("order_id", payment.getOrderId());
         params.put("amount", payment.getAmount());
+        params.put("status", payment.getStatus().name());
         long id = simpleJdbcInsert.executeAndReturnKey(params).longValue();
-        return new Payment(id, payment.getReservationId(), payment.getPaymentKey(), payment.getOrderId(), payment.getAmount());
+        return new Payment(id, payment.getReservationId(), payment.getPaymentKey(), payment.getOrderId(), payment.getAmount(), payment.getStatus());
     }
 
     @Override
     public Optional<Payment> findByOrderId(String orderId) {
         String sql = """
-                SELECT id, reservation_id, payment_key, order_id, amount
+                SELECT id, reservation_id, payment_key, order_id, amount, status
                 FROM payment
                 WHERE order_id = ?
                 """;
@@ -46,7 +48,8 @@ public class JdbcPaymentRepository implements PaymentRepository {
                 rs.getLong("reservation_id"),
                 rs.getString("payment_key"),
                 rs.getString("order_id"),
-                rs.getLong("amount")
+                rs.getLong("amount"),
+                PaymentStatus.valueOf(rs.getString("status"))
         ), orderId).stream().findFirst();
     }
 }

--- a/src/main/java/roomescape/infra/toss/RetryablePaymentException.java
+++ b/src/main/java/roomescape/infra/toss/RetryablePaymentException.java
@@ -1,0 +1,17 @@
+package roomescape.infra.toss;
+
+import roomescape.global.exception.ErrorCode;
+
+public class RetryablePaymentException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public RetryablePaymentException(ErrorCode errorCode) {
+        super(errorCode.name());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
+++ b/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
@@ -3,6 +3,7 @@ package roomescape.infra.toss;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
@@ -12,6 +13,8 @@ import roomescape.global.exception.ErrorCode;
 import roomescape.infra.toss.dto.TossErrorResponse;
 import roomescape.infra.toss.dto.TossPaymentRequest;
 import roomescape.infra.toss.dto.TossPaymentResponse;
+
+import java.net.SocketTimeoutException;
 
 @Component
 public class TossPaymentGateway implements PaymentGateway {
@@ -34,22 +37,33 @@ public class TossPaymentGateway implements PaymentGateway {
                 confirmation.amount()
         );
 
-        TossPaymentResponse response = restClient.post()
-                .uri(CONFIRM_PATH)
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (statusCode, clientResponse) -> {
-                    TossErrorResponse error = objectMapper.readValue(
-                            clientResponse.getBody(), TossErrorResponse.class
-                    );
-                    throw new CustomException(mapToErrorCode(error));
-                })
-                .body(TossPaymentResponse.class);
+        try {
+            TossPaymentResponse response = restClient.post()
+                    .uri(CONFIRM_PATH)
+                    .header("Idempotency-Key", confirmation.orderId())
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (statusCode, clientResponse) -> {
+                        TossErrorResponse error = objectMapper.readValue(
+                                clientResponse.getBody(), TossErrorResponse.class
+                        );
+                        throw new CustomException(mapToErrorCode(error));
+                    })
+                    .body(TossPaymentResponse.class);
 
-        if (response == null) {
-            throw new CustomException(ErrorCode.PAYMENT_UNKNOWN_ERROR);
+            if (response == null) {
+                throw new CustomException(ErrorCode.PAYMENT_UNKNOWN_ERROR);
+            }
+            return new PaymentResult(response.paymentKey(), response.orderId(), response.totalAmount());
+
+        } catch (ResourceAccessException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof SocketTimeoutException && cause.getMessage() != null
+                    && cause.getMessage().contains("Read")) {
+                throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
+            }
+            throw new CustomException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
         }
-        return new PaymentResult(response.paymentKey(), response.orderId(), response.totalAmount());
     }
 
     private ErrorCode mapToErrorCode(TossErrorResponse error) {

--- a/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
+++ b/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
@@ -2,6 +2,9 @@ package roomescape.infra.toss;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
@@ -29,6 +32,12 @@ public class TossPaymentGateway implements PaymentGateway {
         this.objectMapper = objectMapper;
     }
 
+    @Retryable(
+            retryFor = { RetryablePaymentException.class },
+            noRetryFor = { CustomException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2.0, random = true)
+    )
     @Override
     public PaymentResult confirm(PaymentConfirmation confirmation) {
         TossPaymentRequest request = new TossPaymentRequest(
@@ -60,10 +69,15 @@ public class TossPaymentGateway implements PaymentGateway {
             Throwable cause = e.getCause();
             if (cause instanceof SocketTimeoutException && cause.getMessage() != null
                     && cause.getMessage().contains("Read")) {
-                throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
+                throw new RetryablePaymentException(ErrorCode.PAYMENT_READ_TIMEOUT);
             }
-            throw new CustomException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
+            throw new RetryablePaymentException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
         }
+    }
+
+    @Recover
+    public PaymentResult recoverConfirm(RetryablePaymentException e, PaymentConfirmation confirmation) {
+        throw new CustomException(e.getErrorCode());
     }
 
     private ErrorCode mapToErrorCode(TossErrorResponse error) {

--- a/src/main/java/roomescape/repository/PaymentRepository.java
+++ b/src/main/java/roomescape/repository/PaymentRepository.java
@@ -9,4 +9,6 @@ public interface PaymentRepository {
     Payment save(Payment payment);
 
     Optional<Payment> findByOrderId(String orderId);
+
+    Optional<Payment> findByReservationId(Long reservationId);
 }

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -59,6 +59,13 @@ public class PaymentService {
             throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
+        ThemeSlot themeSlot = themeSlotRepository.findById(reservation.getThemeSlotId())
+                .orElseThrow(() -> new CustomException(ErrorCode.THEME_SLOT_NOT_FOUND));
+
+        if (themeSlot.isReserved()) {
+            throw new CustomException(ErrorCode.PAYMENT_SLOT_ALREADY_CONFIRMED);
+        }
+
         try {
             PaymentResult result = paymentGateway.confirm(confirmation);
 

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -8,6 +8,7 @@ import roomescape.domain.payment.Payment;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
 import roomescape.domain.payment.PaymentResult;
+import roomescape.domain.payment.PaymentStatus;
 import roomescape.global.exception.CustomException;
 import roomescape.global.exception.ErrorCode;
 import roomescape.repository.PaymentRepository;
@@ -54,20 +55,30 @@ public class PaymentService {
             throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
-        PaymentResult result = paymentGateway.confirm(confirmation);
+        try {
+            PaymentResult result = paymentGateway.confirm(confirmation);
 
-        Payment payment = paymentRepository.save(
-                new Payment(reservation.getId(), result.paymentKey(), result.orderId(), result.amount())
-        );
+            Payment payment = paymentRepository.save(
+                    new Payment(reservation.getId(), result.paymentKey(), result.orderId(), result.amount(), PaymentStatus.CONFIRMED)
+            );
 
-        reservation.confirm();
-        reservationRepository.updateStatus(reservation);
+            reservation.confirm();
+            reservationRepository.updateStatus(reservation);
 
-        ThemeSlot reservedSlot = new ThemeSlot(
-                reservation.getTheme(), reservation.getDate(), reservation.getTime(), true
-        );
-        themeSlotRepository.update(reservedSlot);
+            ThemeSlot reservedSlot = new ThemeSlot(
+                    reservation.getTheme(), reservation.getDate(), reservation.getTime(), true
+            );
+            themeSlotRepository.update(reservedSlot);
 
-        return payment;
+            return payment;
+
+        } catch (CustomException e) {
+            if (e.getErrorCode() == ErrorCode.PAYMENT_READ_TIMEOUT) {
+                return paymentRepository.save(
+                        new Payment(reservation.getId(), null, confirmation.orderId(), confirmation.amount(), PaymentStatus.UNCERTAIN)
+                );
+            }
+            throw e;
+        }
     }
 }

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -2,6 +2,7 @@ package roomescape.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.controller.dto.ReservationPaymentResponse;
 import roomescape.domain.Reservation;
 import roomescape.domain.ThemeSlot;
 import roomescape.domain.payment.Payment;
@@ -14,6 +15,9 @@ import roomescape.global.exception.ErrorCode;
 import roomescape.repository.PaymentRepository;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ThemeSlotRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class PaymentService {
@@ -80,5 +84,17 @@ public class PaymentService {
             }
             throw e;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReservationPaymentResponse> getPaymentHistory(String name) {
+        return reservationRepository.findByName(name).stream()
+                .map(reservation -> {
+                    Optional<Payment> payment = paymentRepository.findByReservationId(reservation.getId());
+                    return payment
+                            .map(p -> ReservationPaymentResponse.of(reservation, p))
+                            .orElseGet(() -> ReservationPaymentResponse.withoutPayment(reservation));
+                })
+                .toList();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
 
 toss.secret-key=test_sk_placeholder
+toss.connect-timeout=3000
+toss.read-timeout=10000

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -50,9 +50,10 @@ CREATE TABLE IF NOT EXISTS payment
 (
     id             BIGINT       NOT NULL AUTO_INCREMENT,
     reservation_id BIGINT       NOT NULL,
-    payment_key    VARCHAR(200) NOT NULL,
+    payment_key    VARCHAR(200) NULL,
     order_id       VARCHAR(64)  NOT NULL,
     amount         BIGINT       NOT NULL,
+    status         VARCHAR(20)  NOT NULL DEFAULT 'CONFIRMED',
     PRIMARY KEY (id),
     FOREIGN KEY (reservation_id) REFERENCES reservation (id)
 );

--- a/src/test/java/roomescape/controller/PaymentControllerTest.java
+++ b/src/test/java/roomescape/controller/PaymentControllerTest.java
@@ -1,0 +1,37 @@
+package roomescape.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import roomescape.service.PaymentService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentController.class)
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PaymentService paymentService;
+
+    @Test
+    @DisplayName("내역 조회 시 name이 빈 문자열이면 400을 반환한다.")
+    void getHistory_blankName_returns400() throws Exception {
+        mockMvc.perform(get("/payment/history")
+                        .param("name", ""))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내역 조회 시 name 파라미터가 없으면 400을 반환한다.")
+    void getHistory_missingName_returns400() throws Exception {
+        mockMvc.perform(get("/payment/history"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/roomescape/infra/toss/TossPaymentGatewayTest.java
+++ b/src/test/java/roomescape/infra/toss/TossPaymentGatewayTest.java
@@ -21,6 +21,9 @@ import roomescape.domain.payment.PaymentResult;
 import roomescape.global.exception.CustomException;
 import roomescape.global.exception.ErrorCode;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+
 class TossPaymentGatewayTest {
 
     private static final String BASE_URL = "https://api.tosspayments.com";
@@ -131,5 +134,33 @@ class TossPaymentGatewayTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(ErrorCode.PAYMENT_UNKNOWN_ERROR);
+    }
+
+    @Test
+    @DisplayName("read timeout 발생 시 PAYMENT_READ_TIMEOUT ErrorCode를 가진 RetryablePaymentException이 던져진다.")
+    void confirm_readTimeout_throwsRetryableWithReadTimeoutCode() {
+        mockServer.expect(requestTo(CONFIRM_URL))
+                .andRespond(request -> {
+                    throw new SocketTimeoutException("Read timed out");
+                });
+
+        assertThatThrownBy(() -> gateway.confirm(new PaymentConfirmation("pay-key", "order-123", 10000L)))
+                .isInstanceOf(RetryablePaymentException.class)
+                .extracting(e -> ((RetryablePaymentException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_READ_TIMEOUT);
+    }
+
+    @Test
+    @DisplayName("connect 실패 발생 시 PAYMENT_CONNECTION_TIMEOUT ErrorCode를 가진 RetryablePaymentException이 던져진다.")
+    void confirm_connectFailure_throwsRetryableWithConnectionTimeoutCode() {
+        mockServer.expect(requestTo(CONFIRM_URL))
+                .andRespond(request -> {
+                    throw new ConnectException("Connection refused");
+                });
+
+        assertThatThrownBy(() -> gateway.confirm(new PaymentConfirmation("pay-key", "order-123", 10000L)))
+                .isInstanceOf(RetryablePaymentException.class)
+                .extracting(e -> ((RetryablePaymentException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
     }
 }

--- a/src/test/java/roomescape/repository/FakePaymentRepository.java
+++ b/src/test/java/roomescape/repository/FakePaymentRepository.java
@@ -27,4 +27,11 @@ public class FakePaymentRepository implements PaymentRepository {
                 .filter(p -> Objects.equals(p.getOrderId(), orderId))
                 .findFirst();
     }
+
+    @Override
+    public Optional<Payment> findByReservationId(Long reservationId) {
+        return storage.values().stream()
+                .filter(p -> Objects.equals(p.getReservationId(), reservationId))
+                .findFirst();
+    }
 }

--- a/src/test/java/roomescape/repository/FakePaymentRepository.java
+++ b/src/test/java/roomescape/repository/FakePaymentRepository.java
@@ -16,7 +16,7 @@ public class FakePaymentRepository implements PaymentRepository {
     @Override
     public Payment save(Payment payment) {
         long id = sequence.getAndIncrement();
-        Payment saved = new Payment(id, payment.getReservationId(), payment.getPaymentKey(), payment.getOrderId(), payment.getAmount());
+        Payment saved = new Payment(id, payment.getReservationId(), payment.getPaymentKey(), payment.getOrderId(), payment.getAmount(), payment.getStatus());
         storage.put(id, saved);
         return saved;
     }

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -14,11 +14,13 @@ import roomescape.domain.Reservation;
 import roomescape.domain.Theme;
 import roomescape.domain.ThemeSlot;
 import roomescape.domain.Time;
+import roomescape.controller.dto.ReservationPaymentResponse;
 import roomescape.domain.payment.Payment;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
 import roomescape.domain.payment.PaymentResult;
 import roomescape.domain.payment.PaymentStatus;
+import roomescape.domain.reservationStatus.ConfirmedStatus;
 import roomescape.domain.reservationStatus.PendingStatus;
 import roomescape.global.exception.CustomException;
 import roomescape.global.exception.ErrorCode;
@@ -50,9 +52,19 @@ class PaymentServiceTest {
         fakeThemeSlotRepository.save(new ThemeSlot(THEME, DATE, TIME, false));
     }
 
-    private Reservation pendingReservation(String orderId, Long amount) {
+    private Reservation pendingReservation(String name, String orderId, Long amount) {
         return fakeReservationRepository.save(
-                new Reservation(null, "브라운", 1L, DATE, TIME, THEME, PendingStatus.getInstance(), orderId, amount)
+                new Reservation(null, name, 1L, DATE, TIME, THEME, PendingStatus.getInstance(), orderId, amount)
+        );
+    }
+
+    private Reservation pendingReservation(String orderId, Long amount) {
+        return pendingReservation("브라운", orderId, amount);
+    }
+
+    private Reservation confirmedReservation(String name, String orderId, Long amount) {
+        return fakeReservationRepository.save(
+                new Reservation(null, name, 1L, DATE, TIME, THEME, ConfirmedStatus.getInstance(), orderId, amount)
         );
     }
 
@@ -163,5 +175,72 @@ class PaymentServiceTest {
     void handlePaymentFail_withUnknownOrderId_doesNothing() {
         paymentService.handlePaymentFail("nonexistent-order");
         // 예외 없이 정상 종료
+    }
+
+    // ── getPaymentHistory ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("CONFIRMED payment가 있는 예약은 paymentStatus CONFIRMED와 paymentKey를 포함해 반환한다.")
+    void getPaymentHistory_confirmedPayment_returnsConfirmedStatus() {
+        Reservation reservation = confirmedReservation("브라운", "order-123", 10000L);
+        fakePaymentRepository.save(new Payment(reservation.getId(), "pay-key", "order-123", 10000L, PaymentStatus.CONFIRMED));
+
+        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
+
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).paymentStatus()).isEqualTo("CONFIRMED");
+        assertThat(history.get(0).paymentKey()).isEqualTo("pay-key");
+        assertThat(history.get(0).orderId()).isEqualTo("order-123");
+    }
+
+    @Test
+    @DisplayName("UNCERTAIN payment가 있는 예약은 paymentStatus UNCERTAIN이고 paymentKey는 null이다.")
+    void getPaymentHistory_uncertainPayment_returnsUncertainStatus() {
+        Reservation reservation = pendingReservation("브라운", "order-123", 10000L);
+        fakePaymentRepository.save(new Payment(reservation.getId(), null, "order-123", 10000L, PaymentStatus.UNCERTAIN));
+
+        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
+
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).paymentStatus()).isEqualTo("UNCERTAIN");
+        assertThat(history.get(0).paymentKey()).isNull();
+    }
+
+    @Test
+    @DisplayName("payment 기록이 없는 예약은 paymentStatus와 paymentKey가 null이다.")
+    void getPaymentHistory_noPayment_returnsNullPaymentStatus() {
+        pendingReservation("브라운", "order-123", 10000L);
+
+        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
+
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).paymentStatus()).isNull();
+        assertThat(history.get(0).paymentKey()).isNull();
+    }
+
+    @Test
+    @DisplayName("CONFIRMED/UNCERTAIN/결제없음 예약이 섞여 있어도 전체 목록을 반환한다.")
+    void getPaymentHistory_mixedStatuses_returnsAll() {
+        Reservation confirmed = confirmedReservation("브라운", "order-1", 10000L);
+        fakePaymentRepository.save(new Payment(confirmed.getId(), "pay-key", "order-1", 10000L, PaymentStatus.CONFIRMED));
+
+        Reservation uncertain = pendingReservation("브라운", "order-2", 10000L);
+        fakePaymentRepository.save(new Payment(uncertain.getId(), null, "order-2", 10000L, PaymentStatus.UNCERTAIN));
+
+        pendingReservation("브라운", "order-3", 10000L);
+
+        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
+
+        assertThat(history).hasSize(3);
+        assertThat(history).extracting(ReservationPaymentResponse::paymentStatus)
+                .containsExactlyInAnyOrder("CONFIRMED", "UNCERTAIN", null);
+    }
+
+    @Test
+    @DisplayName("해당 이름의 예약이 없으면 빈 리스트를 반환한다.")
+    void getPaymentHistory_noReservation_returnsEmptyList() {
+        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("없는사람");
+
+        assertThat(history).isEmpty();
     }
 }

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -18,8 +18,10 @@ import roomescape.domain.payment.Payment;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
 import roomescape.domain.payment.PaymentResult;
+import roomescape.domain.payment.PaymentStatus;
 import roomescape.domain.reservationStatus.PendingStatus;
 import roomescape.global.exception.CustomException;
+import roomescape.global.exception.ErrorCode;
 import roomescape.repository.FakePaymentRepository;
 import roomescape.repository.FakeReservationRepository;
 import roomescape.repository.FakeThemeSlotRepository;
@@ -103,6 +105,40 @@ class PaymentServiceTest {
         assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("예약이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("read timeout 발생 시 예약은 PENDING을 유지하고 UNCERTAIN Payment가 저장된다.")
+    void confirmPayment_readTimeout_savesUncertainPaymentAndKeepsPending() {
+        PaymentGateway timeoutGateway = confirmation -> {
+            throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
+        };
+        paymentService = new PaymentService(timeoutGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
+
+        Reservation reservation = pendingReservation("order-123", 10000L);
+        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
+
+        Payment payment = paymentService.confirmPayment(confirmation);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.UNCERTAIN);
+        assertThat(payment.getPaymentKey()).isNull();
+        assertThat(fakeReservationRepository.findById(reservation.getId()).get().isConfirmed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("read timeout 이외의 결제 예외는 그대로 전파된다.")
+    void confirmPayment_connectionTimeout_propagatesException() {
+        PaymentGateway connectionFailGateway = confirmation -> {
+            throw new CustomException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
+        };
+        paymentService = new PaymentService(connectionFailGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
+
+        pendingReservation("order-123", 10000L);
+        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
+
+        assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.PAYMENT_CONNECTION_TIMEOUT.getMessage());
     }
 
     @Test

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -120,6 +120,38 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("슬롯이 이미 다른 사용자에 의해 결제 완료된 경우 PAYMENT_SLOT_ALREADY_CONFIRMED 예외가 발생한다.")
+    void confirmPayment_slotAlreadyReserved_throwsException() {
+        // 슬롯을 is_reserved=true 상태로 갱신
+        fakeThemeSlotRepository.update(new ThemeSlot(THEME, DATE, TIME, true));
+        pendingReservation("브라운", "order-123", 10000L);
+        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
+
+        assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PAYMENT_SLOT_ALREADY_CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("슬롯이 이미 선점된 경우 토스 결제 승인 API는 호출되지 않는다.")
+    void confirmPayment_slotAlreadyReserved_gatewayNotCalled() {
+        List<PaymentConfirmation> called = new ArrayList<>();
+        PaymentGateway trackingGateway = confirmation -> {
+            called.add(confirmation);
+            return new PaymentResult(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount());
+        };
+        paymentService = new PaymentService(trackingGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
+
+        fakeThemeSlotRepository.update(new ThemeSlot(THEME, DATE, TIME, true));
+        pendingReservation("브라운", "order-123", 10000L);
+
+        assertThatThrownBy(() -> paymentService.confirmPayment(new PaymentConfirmation("pay-key", "order-123", 10000L)))
+                .isInstanceOf(CustomException.class);
+        assertThat(called).isEmpty();
+    }
+
+    @Test
     @DisplayName("read timeout 발생 시 예약은 PENDING을 유지하고 UNCERTAIN Payment가 저장된다.")
     void confirmPayment_readTimeout_savesUncertainPaymentAndKeepsPending() {
         PaymentGateway timeoutGateway = confirmation -> {


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [ ] 미션의 필수 요구사항을 모두 구현했나요?
- [ ] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [ ] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

## 구현 내용

외부 결제 API(Toss Payments) 연동에서 발생할 수 있는 네트워크 불확실성을 안전하게 처리합니다.
타임아웃 설정, 예외 분류, 멱등키, UNCERTAIN 상태, 재시도 정책, 결제 내역 조회를 구현했습니다.

---

## 1. 타임아웃 설정

`jdk` 기반 HTTP 팩토리는 응답 바디 읽기 지연을 감지하지 못합니다.
`SimpleClientHttpRequestFactory`를 명시적으로 사용해 connect/read 타임아웃을 모두 제어합니다.

```properties
toss.connect-timeout=3000   # 연결 타임아웃 (ms)
toss.read-timeout=10000     # 읽기 타임아웃 (ms)
```

---

## 2. 타임아웃 예외 분류

`ResourceAccessException`의 원인 예외를 분석해 두 케이스를 다르게 처리합니다.

| 예외 | 의미 | 처리 |
|------|------|------|
| `SocketTimeoutException("Read…")` | 토스가 처리했을 수도 있음 (불확실) | UNCERTAIN Payment 저장, 예약 PENDING 유지 |
| `ConnectException` | 연결 자체가 안 됨 (미처리 확정) | 503 에러 반환 |

---

## 3. 멱등키 (Idempotency-Key)

재시도 시 이중 승인을 방지하기 위해 토스 요청에 `Idempotency-Key: {orderId}` 헤더를 추가합니다.
`orderId`는 예약 생성 시 발급된 UUID로 고정되므로, 재시도 횟수와 관계없이 토스는 첫 처리 결과를 동일하게 반환합니다.

---

## 4. PaymentStatus — UNCERTAIN 상태

read timeout 발생 시 결제가 됐는지 모르는 상태이므로, 섣불리 취소하지 않습니다.

```java
public enum PaymentStatus {
    CONFIRMED,   // 정상 승인
    UNCERTAIN    // read timeout — 결과 불명확
}
```

- 예약은 PENDING 유지 (CANCELLED로 바꾸면 결제된 사용자 피해)
- Payment 레코드는 `status = UNCERTAIN`, `payment_key = NULL`로 저장
- 사용자에게 202 응답과 함께 "결제 내역 확인" 안내

---

## 5. 슬롯 이중 confirm 방지

자동 confirm 제거 이후, 동일 슬롯에 여러 PENDING 예약이 존재할 수 있습니다.
두 사용자가 순차적으로 결제하면 슬롯에 CONFIRMED가 두 개 생기는 버그를 방지합니다.

`confirmPayment()` 내 토스 API 호출 전에 슬롯 선점 여부를 검증합니다.

```
슬롯 isReserved == true → PAYMENT_SLOT_ALREADY_CONFIRMED (409)
→ PaymentGateway.confirm() 미호출 (실제 결제 발생 X)
```

> 동시에 두 요청이 진입하는 레이스 컨디션은 DB 수준 락(`SELECT FOR UPDATE`)이 필요하며, 동시성 제어 단계에서 다룰 예정입니다.

---

## 6. 결제 내역 조회 API

```
GET /payment/history?name={사용자이름}
```

예약 목록과 각 예약에 연결된 결제 상태를 함께 반환합니다.
결제 기록이 없는 예약(결제 전 상태)도 포함되며, `paymentStatus / paymentKey`는 null로 반환됩니다.

---

## 7. Spring Retry — 자동 재시도

일시적인 네트워크 실패 시 자동으로 재시도합니다.

### 예외 타입 분리

`@Retryable`은 예외 타입으로 재시도 여부를 구분하므로 타입 자체를 나눕니다.

```
RetryablePaymentException (재시도 O)  ← read timeout, connect timeout
CustomException           (재시도 X)  ← 카드 거절, 인증 오류 등 비즈니스 거절
```

### 재시도 정책

- 최대 3회, 지수 백오프: 1초 → 2초 → 4초 + random jitter
- 3회 소진 시 `@Recover`에서 `CustomException`으로 변환 → `PaymentService`가 에러 코드 타입에 따라 UNCERTAIN 저장 또는 에러 전파

```
confirm()  ← @Retryable
    ├─ 성공 ────────────────────────────────► PaymentResult 반환
    │
    ├─ RetryablePaymentException (1회) ↓ 1초
    ├─ RetryablePaymentException (2회) ↓ 2초
    ├─ RetryablePaymentException (3회) → @Recover
    │       read timeout  → CustomException(PAYMENT_READ_TIMEOUT)        → UNCERTAIN 저장
    │       connect 실패  → CustomException(PAYMENT_CONNECTION_TIMEOUT)  → 503 에러
    │
    └─ CustomException (비즈니스 거절) → noRetryFor → 즉시 실패
```

---

## 테스트

### PaymentService 단위 테스트

- read timeout → UNCERTAIN Payment 저장, 예약 PENDING 유지
- connection timeout → 예외 전파
- 슬롯 이미 선점 → `PAYMENT_SLOT_ALREADY_CONFIRMED`, 게이트웨이 미호출 확인
- `getPaymentHistory` → CONFIRMED / UNCERTAIN / 결제없음 혼합 목록 반환

### TossPaymentGateway 슬라이스 테스트

- read timeout → `RetryablePaymentException(PAYMENT_READ_TIMEOUT)`
- connect 실패 → `RetryablePaymentException(PAYMENT_CONNECTION_TIMEOUT)`

### PaymentController 입력 검증 테스트

- `name` 빈 문자열 → 400
- `name` 파라미터 누락 → 400 (`MissingServletRequestParameterException` 핸들러 추가)

---

## 고민한 점

**read timeout을 즉시 실패가 아닌 UNCERTAIN으로 처리하는 이유**

토스 서버가 처리를 완료한 뒤 응답을 보내는 도중 타임아웃이 날 수 있습니다.
이 상태에서 예약을 취소하면 "결제는 됐지만 예약이 없는" 상황이 발생합니다.
UNCERTAIN으로 남겨 사용자가 결제 내역 페이지에서 직접 확인할 수 있도록 했습니다.

**`@Retryable`에서 예외 타입을 나눈 이유**

Spring Retry의 `retryFor`와 `noRetryFor`에 같은 타입을 동시에 지정할 수 없습니다.
비즈니스 거절은 재시도해도 결과가 같으므로 즉시 실패해야 하고,
네트워크 실패는 재시도할 가치가 있습니다.
두 경우를 타입 자체로 구분(`RetryablePaymentException` vs `CustomException`)해 정책을 선언적으로 관리합니다.
