### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 라텔(김규빈) 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ out/
 .claude/
 .omc/
 CLAUDE.md
+**/AGENTS.md
 
 ### Local secrets ###
 application-local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:spring-mock-mvc'
     testImplementation 'io.rest-assured:rest-assured'
+    // 응답 지연(setHeadersDelay)을 주입해 read timeout 을 결정적으로 재현하는 스텁 서버
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 test {

--- a/src/main/java/roomescape/client/TossClientConfig.java
+++ b/src/main/java/roomescape/client/TossClientConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -14,11 +15,19 @@ public class TossClientConfig {
     @Bean
     public RestClient tossRestClient(
             @Value("${toss.base-url}") String baseUrl,
-            @Value("${toss.secret-key}") String secretKey
+            @Value("${toss.secret-key}") String secretKey,
+            @Value("${toss.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${toss.read-timeout-ms}") int readTimeoutMs
     ) {
         var basic = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        SimpleClientHttpRequestFactory clientRequestFactory = new SimpleClientHttpRequestFactory();
+        clientRequestFactory.setReadTimeout(readTimeoutMs);
+        clientRequestFactory.setConnectTimeout(connectTimeoutMs);
+
         return RestClient.builder()
+                .requestFactory(clientRequestFactory)
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basic)
                 .build();

--- a/src/main/java/roomescape/client/TossConfirmResultUnknownException.java
+++ b/src/main/java/roomescape/client/TossConfirmResultUnknownException.java
@@ -1,0 +1,12 @@
+package roomescape.client;
+
+/**
+ * 응답을 읽는 단계(read)에서 실패한 경우. 요청은 토스에 전달되었으나 응답을 받지 못해 승인 여부를 알 수 없다.
+ * 실패로 단정해서는 안 되며, 결과 확인·재시도가 가능하도록 안내해야 한다.
+ */
+public class TossConfirmResultUnknownException extends RuntimeException {
+
+    public TossConfirmResultUnknownException(Throwable cause) {
+        super("결제 승인 결과를 확인하지 못했습니다. 결제가 완료되었을 수 있으니 예약 내역을 확인해주세요.", cause);
+    }
+}

--- a/src/main/java/roomescape/client/TossConnectionException.java
+++ b/src/main/java/roomescape/client/TossConnectionException.java
@@ -1,0 +1,11 @@
+package roomescape.client;
+
+/**
+ * 연결 단계(connect)에서 실패한 경우. 요청이 토스에 도달하지 못했으므로 결제는 확실히 처리되지 않았다.
+ */
+public class TossConnectionException extends RuntimeException {
+
+    public TossConnectionException(Throwable cause) {
+        super("결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.", cause);
+    }
+}

--- a/src/main/java/roomescape/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/client/TossPaymentGateway.java
@@ -12,10 +12,12 @@ import org.springframework.web.client.RestClientException;
 import roomescape.client.dto.PaymentConfirmation;
 import roomescape.client.dto.TossErrorResponse;
 import roomescape.client.dto.TossPaymentResponse;
+import roomescape.domain.PaymentResult;
+import roomescape.service.PaymentGateway;
 
 @Slf4j
 @Component
-public class TossPaymentGateway {
+public class TossPaymentGateway implements PaymentGateway {
 
     private static final int MAX_CONNECTION_ATTEMPTS = 3;
     private static final long CONNECTION_RETRY_DELAY_MS = 300;
@@ -28,8 +30,10 @@ public class TossPaymentGateway {
         this.objectMapper = objectMapper;
     }
 
-    public TossPaymentResponse confirm(PaymentConfirmation confirmation) {
-        return withConnectionRetry(() -> doConfirm(confirmation));
+    @Override
+    public PaymentResult confirm(PaymentConfirmation confirmation) {
+        TossPaymentResponse response = withConnectionRetry(() -> doConfirm(confirmation));
+        return new PaymentResult(response.orderId(), response.status(), response.approvedAmount(), response.approvedAt());
     }
 
     private TossPaymentResponse doConfirm(PaymentConfirmation confirmation) {

--- a/src/main/java/roomescape/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/client/TossPaymentGateway.java
@@ -1,16 +1,24 @@
 package roomescape.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import roomescape.client.dto.PaymentConfirmation;
 import roomescape.client.dto.TossErrorResponse;
 import roomescape.client.dto.TossPaymentResponse;
 
+@Slf4j
 @Component
 public class TossPaymentGateway {
+
+    private static final int MAX_CONNECTION_ATTEMPTS = 3;
+    private static final long CONNECTION_RETRY_DELAY_MS = 300;
 
     private final RestClient tossRestClient;
     private final ObjectMapper objectMapper;
@@ -21,17 +29,58 @@ public class TossPaymentGateway {
     }
 
     public TossPaymentResponse confirm(PaymentConfirmation confirmation) {
+        return withConnectionRetry(() -> doConfirm(confirmation));
+    }
+
+    private TossPaymentResponse doConfirm(PaymentConfirmation confirmation) {
         record ConfirmRequest(String paymentKey, String orderId, Long amount) {}
 
-        return tossRestClient.post()
-                .uri("/v1/payments/confirm")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(new ConfirmRequest(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount()))
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, resp) -> {
-                    var error = objectMapper.readValue(resp.getBody(), TossErrorResponse.class);
-                    throw TossPaymentException.of(resp.getStatusCode(), error);
-                })
-                .body(TossPaymentResponse.class);
+        try {
+            return tossRestClient.post()
+                    .uri("/v1/payments/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ConfirmRequest(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount()))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, resp) -> {
+                        var error = objectMapper.readValue(resp.getBody(), TossErrorResponse.class);
+                        throw TossPaymentException.of(resp.getStatusCode(), error);
+                    })
+                    .body(TossPaymentResponse.class);
+        } catch (ResourceAccessException e) {
+            // 연결 단계 실패 - withConnectionRetry가 재시도 여부를 판단하도록 그대로 전달한다.
+            throw e;
+        } catch (RestClientException e) {
+            // 응답 읽기 단계 실패(느린 응답 등) - 요청은 보냈으나 승인 여부를 확인하지 못한 상태라 재시도하지 않는다.
+            throw new TossConfirmResultUnknownException(e);
+        }
+    }
+
+    /**
+     * 연결 단계 실패(ResourceAccessException)만 재시도한다 - 요청이 토스에 도달하지 못했으므로 중복 승인 위험이 없다.
+     */
+    private <T> T withConnectionRetry(Supplier<T> action) {
+        ResourceAccessException lastConnectionFailure = null;
+        for (int attempt = 1; attempt <= MAX_CONNECTION_ATTEMPTS; attempt++) {
+            try {
+                return action.get();
+            } catch (ResourceAccessException e) {
+                lastConnectionFailure = e;
+                log.warn("[토스 연결 재시도] attempt={}/{} message={}", attempt, MAX_CONNECTION_ATTEMPTS, e.getMessage());
+                if (attempt < MAX_CONNECTION_ATTEMPTS) {
+                    sleep(CONNECTION_RETRY_DELAY_MS);
+                }
+            }
+        }
+        // 연결 재시도를 모두 소진한 경우 - 확실히 미승인 상태다.
+        throw new TossConnectionException(lastConnectionFailure);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("결제 승인 재시도 중 인터럽트되었습니다.", e);
+        }
     }
 }

--- a/src/main/java/roomescape/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/client/TossPaymentGateway.java
@@ -39,6 +39,7 @@ public class TossPaymentGateway {
             return tossRestClient.post()
                     .uri("/v1/payments/confirm")
                     .contentType(MediaType.APPLICATION_JSON)
+                    .header("Idempotency-Key", confirmation.orderId())
                     .body(new ConfirmRequest(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount()))
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, (req, resp) -> {

--- a/src/main/java/roomescape/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/client/TossPaymentGateway.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import roomescape.client.dto.PaymentConfirmation;
 import roomescape.client.dto.TossErrorResponse;
 import roomescape.client.dto.TossPaymentResponse;
 
@@ -19,12 +20,13 @@ public class TossPaymentGateway {
         this.objectMapper = objectMapper;
     }
 
-    public TossPaymentResponse confirm(String paymentKey, String orderId, Long amount) {
+    public TossPaymentResponse confirm(PaymentConfirmation confirmation) {
         record ConfirmRequest(String paymentKey, String orderId, Long amount) {}
+
         return tossRestClient.post()
                 .uri("/v1/payments/confirm")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(new ConfirmRequest(paymentKey, orderId, amount))
+                .body(new ConfirmRequest(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount()))
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, resp) -> {
                     var error = objectMapper.readValue(resp.getBody(), TossErrorResponse.class);

--- a/src/main/java/roomescape/client/dto/PaymentConfirmation.java
+++ b/src/main/java/roomescape/client/dto/PaymentConfirmation.java
@@ -1,0 +1,8 @@
+package roomescape.client.dto;
+
+public record PaymentConfirmation(
+        String paymentKey,
+        String orderId,
+        Long amount
+) {
+}

--- a/src/main/java/roomescape/controller/client/PaymentController.java
+++ b/src/main/java/roomescape/controller/client/PaymentController.java
@@ -1,13 +1,17 @@
 package roomescape.controller.client;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.controller.client.dto.request.ReservationRequest;
+import roomescape.controller.client.dto.response.OrderHistoryResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.service.PaymentService;
 
@@ -22,5 +26,13 @@ public class PaymentController {
     public ResponseEntity<PreparePaymentResponse> prepare(@RequestBody @Valid ReservationRequest request) {
         PreparePaymentResponse response = paymentService.prepare(request.toCommand());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/orders")
+    public ResponseEntity<List<OrderHistoryResponse>> getOrders(@RequestParam String name) {
+        List<OrderHistoryResponse> responses = paymentService.getOrderHistories(name).stream()
+                .map(OrderHistoryResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/roomescape/controller/client/dto/response/OrderHistoryResponse.java
+++ b/src/main/java/roomescape/controller/client/dto/response/OrderHistoryResponse.java
@@ -1,0 +1,35 @@
+package roomescape.controller.client.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import roomescape.service.result.OrderHistoryResult;
+
+public record OrderHistoryResponse(
+        Long reservationId,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate date,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime time,
+        String themeName,
+        String entryStatus,
+        String orderId,
+        String paymentKey,
+        Long amount,
+        String paymentStatus
+) {
+
+    public static OrderHistoryResponse from(OrderHistoryResult result) {
+        return new OrderHistoryResponse(
+                result.reservationId(),
+                result.date(),
+                result.time(),
+                result.themeName(),
+                result.entryStatus(),
+                result.orderId(),
+                result.paymentKey(),
+                result.amount(),
+                result.paymentStatus()
+        );
+    }
+}

--- a/src/main/java/roomescape/controller/client/web/PageController.java
+++ b/src/main/java/roomescape/controller/client/web/PageController.java
@@ -7,6 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.context.request.WebRequest;
 import roomescape.client.TossConfirmResultUnknownException;
 import roomescape.client.TossConnectionException;
 import roomescape.client.TossPaymentException;
@@ -67,10 +68,8 @@ public class PageController {
     }
 
     @ExceptionHandler(TossPaymentException.AlreadyProcessed.class)
-    public String handleAlreadyProcessed(
-            TossPaymentException.AlreadyProcessed e,
-            @RequestParam String orderId,
-            Model model) {
+    public String handleAlreadyProcessed(TossPaymentException.AlreadyProcessed e, WebRequest request, Model model) {
+        String orderId = request.getParameter("orderId");
         // 이미 승인된 결제에 대한 중복 confirm 호출 - 실패가 아니라 "이미 성공한 결제"이므로 성공 화면과 구분해서 안내한다.
         log.info("[이미 처리된 결제] orderId={} message={}", orderId, e.getMessage());
         model.addAttribute("title", "✅ 이미 처리된 결제예요");
@@ -81,10 +80,8 @@ public class PageController {
     }
 
     @ExceptionHandler(TossConfirmResultUnknownException.class)
-    public String handleResultUnknown(
-            TossConfirmResultUnknownException e,
-            @RequestParam String orderId,
-            Model model) {
+    public String handleResultUnknown(TossConfirmResultUnknownException e, WebRequest request, Model model) {
+        String orderId = request.getParameter("orderId");
         // 응답을 받지 못해 승인 여부를 모르는 상태 - "실패"로 단정하지 않고 확인을 안내한다.
         log.warn("[결제 승인 결과 확인 불가] orderId={} message={}", orderId, e.getMessage());
         model.addAttribute("title", "⏳ 결제 결과를 확인하지 못했어요");
@@ -95,10 +92,8 @@ public class PageController {
     }
 
     @ExceptionHandler(TossConnectionException.class)
-    public String handleConnectionFailed(
-            TossConnectionException e,
-            @RequestParam String orderId,
-            Model model) {
+    public String handleConnectionFailed(TossConnectionException e, WebRequest request, Model model) {
+        String orderId = request.getParameter("orderId");
         // 요청 자체가 토스에 도달하지 못한 경우 - 미승인이 확실하므로 실패로 안내한다.
         log.warn("[결제 서버 연결 실패] orderId={} message={}", orderId, e.getMessage());
         model.addAttribute("code", "CONNECTION_FAILED");
@@ -108,10 +103,8 @@ public class PageController {
     }
 
     @ExceptionHandler(Exception.class)
-    public String handleConfirmFailed(
-            Exception e,
-            @RequestParam String orderId,
-            Model model) {
+    public String handleConfirmFailed(Exception e, WebRequest request, Model model) {
+        String orderId = request.getParameter("orderId");
         model.addAttribute("code", "CONFIRM_FAILED");
         model.addAttribute("message", e.getMessage());
         model.addAttribute("orderId", orderId);

--- a/src/main/java/roomescape/controller/client/web/PageController.java
+++ b/src/main/java/roomescape/controller/client/web/PageController.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import roomescape.client.TossConfirmResultUnknownException;
+import roomescape.client.TossConnectionException;
+import roomescape.client.TossPaymentException;
 import roomescape.service.PaymentService;
 
 @Slf4j
@@ -55,18 +59,63 @@ public class PageController {
             @RequestParam String orderId,
             @RequestParam Long amount,
             Model model) {
-        try {
-            var result = paymentService.confirm(paymentKey, orderId, amount);
-            model.addAttribute("orderId", orderId);
-            model.addAttribute("amount", amount);
-            model.addAttribute("result", result);
-            return "payment/success";
-        } catch (Exception e) {
-            model.addAttribute("code", "CONFIRM_FAILED");
-            model.addAttribute("message", e.getMessage());
-            model.addAttribute("orderId", orderId);
-            return "payment/fail";
-        }
+        var result = paymentService.confirm(paymentKey, orderId, amount);
+        model.addAttribute("orderId", orderId);
+        model.addAttribute("amount", amount);
+        model.addAttribute("result", result);
+        return "payment/success";
+    }
+
+    @ExceptionHandler(TossPaymentException.AlreadyProcessed.class)
+    public String handleAlreadyProcessed(
+            TossPaymentException.AlreadyProcessed e,
+            @RequestParam String orderId,
+            Model model) {
+        // 이미 승인된 결제에 대한 중복 confirm 호출 - 실패가 아니라 "이미 성공한 결제"이므로 성공 화면과 구분해서 안내한다.
+        log.info("[이미 처리된 결제] orderId={} message={}", orderId, e.getMessage());
+        model.addAttribute("title", "✅ 이미 처리된 결제예요");
+        model.addAttribute("code", "ALREADY_PROCESSED");
+        model.addAttribute("message", "이미 정상적으로 처리된 결제입니다. 중복 결제가 아니니 안심하고 예약 내역을 확인해주세요.");
+        model.addAttribute("orderId", orderId);
+        return "payment/fail";
+    }
+
+    @ExceptionHandler(TossConfirmResultUnknownException.class)
+    public String handleResultUnknown(
+            TossConfirmResultUnknownException e,
+            @RequestParam String orderId,
+            Model model) {
+        // 응답을 받지 못해 승인 여부를 모르는 상태 - "실패"로 단정하지 않고 확인을 안내한다.
+        log.warn("[결제 승인 결과 확인 불가] orderId={} message={}", orderId, e.getMessage());
+        model.addAttribute("title", "⏳ 결제 결과를 확인하지 못했어요");
+        model.addAttribute("code", "CONFIRM_RESULT_UNKNOWN");
+        model.addAttribute("message", e.getMessage());
+        model.addAttribute("orderId", orderId);
+        return "payment/fail";
+    }
+
+    @ExceptionHandler(TossConnectionException.class)
+    public String handleConnectionFailed(
+            TossConnectionException e,
+            @RequestParam String orderId,
+            Model model) {
+        // 요청 자체가 토스에 도달하지 못한 경우 - 미승인이 확실하므로 실패로 안내한다.
+        log.warn("[결제 서버 연결 실패] orderId={} message={}", orderId, e.getMessage());
+        model.addAttribute("code", "CONNECTION_FAILED");
+        model.addAttribute("message", e.getMessage());
+        model.addAttribute("orderId", orderId);
+        return "payment/fail";
+    }
+
+    @ExceptionHandler(Exception.class)
+    public String handleConfirmFailed(
+            Exception e,
+            @RequestParam String orderId,
+            Model model) {
+        model.addAttribute("code", "CONFIRM_FAILED");
+        model.addAttribute("message", e.getMessage());
+        model.addAttribute("orderId", orderId);
+        return "payment/fail";
     }
 
     @GetMapping("/payments/fail")

--- a/src/main/java/roomescape/controller/client/web/PageController.java
+++ b/src/main/java/roomescape/controller/client/web/PageController.java
@@ -40,6 +40,11 @@ public class PageController {
         return "forward:/search.html";
     }
 
+    @GetMapping("/orders")
+    public String orders() {
+        return "forward:/orders.html";
+    }
+
     @GetMapping("/payment/checkout")
     public String paymentCheckout(
             @RequestParam String orderId,

--- a/src/main/java/roomescape/domain/PaymentOrder.java
+++ b/src/main/java/roomescape/domain/PaymentOrder.java
@@ -11,24 +11,43 @@ public class PaymentOrder {
     private final Long amount;
     private final Long entryId;
     private final LocalDateTime createdAt;
+    private final String paymentKey;
+    private final PaymentOrderStatus status;
 
-    private PaymentOrder(Long id, String orderId, Long amount, Long entryId, LocalDateTime createdAt) {
+    private PaymentOrder(Long id, String orderId, Long amount, Long entryId, LocalDateTime createdAt,
+                         String paymentKey, PaymentOrderStatus status) {
         this.id = id;
         this.orderId = orderId;
         this.amount = amount;
         this.entryId = entryId;
         this.createdAt = createdAt;
+        this.paymentKey = paymentKey;
+        this.status = status;
     }
 
     public static PaymentOrder create(String orderId, Long amount, Long entryId, LocalDateTime createdAt) {
-        return new PaymentOrder(null, orderId, amount, entryId, createdAt);
+        return new PaymentOrder(null, orderId, amount, entryId, createdAt, null, PaymentOrderStatus.PENDING);
     }
 
-    public static PaymentOrder restore(Long id, String orderId, Long amount, Long entryId, LocalDateTime createdAt) {
-        return new PaymentOrder(id, orderId, amount, entryId, createdAt);
+    public static PaymentOrder restore(Long id, String orderId, Long amount, Long entryId, LocalDateTime createdAt,
+                                       String paymentKey, PaymentOrderStatus status) {
+        return new PaymentOrder(id, orderId, amount, entryId, createdAt, paymentKey, status);
     }
 
     public PaymentOrder withId(Long id) {
-        return new PaymentOrder(id, orderId, amount, entryId, createdAt);
+        return new PaymentOrder(id, orderId, amount, entryId, createdAt, paymentKey, status);
+    }
+
+    public PaymentOrder confirmed(String paymentKey) {
+        return new PaymentOrder(id, orderId, amount, entryId, createdAt, paymentKey, PaymentOrderStatus.CONFIRMED);
+    }
+
+    public PaymentOrder failed() {
+        return new PaymentOrder(id, orderId, amount, entryId, createdAt, paymentKey, PaymentOrderStatus.FAILED);
+    }
+
+    public PaymentOrder resultUnknown() {
+        return new PaymentOrder(id, orderId, amount, entryId, createdAt, paymentKey,
+                PaymentOrderStatus.CONFIRM_RESULT_UNKNOWN);
     }
 }

--- a/src/main/java/roomescape/domain/PaymentOrderStatus.java
+++ b/src/main/java/roomescape/domain/PaymentOrderStatus.java
@@ -1,0 +1,8 @@
+package roomescape.domain;
+
+public enum PaymentOrderStatus {
+    PENDING,
+    CONFIRMED,
+    FAILED,
+    CONFIRM_RESULT_UNKNOWN
+}

--- a/src/main/java/roomescape/domain/PaymentResult.java
+++ b/src/main/java/roomescape/domain/PaymentResult.java
@@ -1,0 +1,9 @@
+package roomescape.domain;
+
+public record PaymentResult(
+        String orderId,
+        String status,
+        Long approvedAmount,
+        String approvedAt
+) {
+}

--- a/src/main/java/roomescape/query/ReservationQueryRepository.java
+++ b/src/main/java/roomescape/query/ReservationQueryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import roomescape.common.Page;
 import roomescape.common.Pageable;
 import roomescape.service.command.ReservationSearchCommand;
+import roomescape.service.result.OrderHistoryResult;
 import roomescape.service.result.ReservationEntryResult;
 import roomescape.service.result.ReservationResult;
 import roomescape.service.result.ReservationSearchResult;
@@ -55,7 +56,43 @@ public class ReservationQueryRepository {
                     rs.getObject("waiting_rank", Integer.class)
             );
 
+    private static final RowMapper<OrderHistoryResult> ORDER_HISTORY_ROW_MAPPER = (rs, rowNum) ->
+            new OrderHistoryResult(
+                    rs.getLong("reservation_id"),
+                    rs.getDate("reservation_date").toLocalDate(),
+                    rs.getTime("time_start_at").toLocalTime(),
+                    rs.getString("theme_name"),
+                    rs.getString("entry_status"),
+                    rs.getString("order_id"),
+                    rs.getString("payment_key"),
+                    rs.getObject("amount", Long.class),
+                    rs.getString("payment_status")
+            );
+
     private final JdbcTemplate jdbcTemplate;
+
+    public List<OrderHistoryResult> getOrderHistories(String name) {
+        String sql = """
+                SELECT
+                    r.id AS reservation_id,
+                    r.date AS reservation_date,
+                    rt.start_at AS time_start_at,
+                    t.name AS theme_name,
+                    re.status AS entry_status,
+                    po.order_id AS order_id,
+                    po.payment_key AS payment_key,
+                    po.amount AS amount,
+                    po.status AS payment_status
+                FROM reservation r
+                JOIN theme t ON r.theme_id = t.id
+                JOIN reservation_time rt ON r.time_id = rt.id
+                JOIN reservation_entry re ON re.reservation_id = r.id
+                LEFT JOIN payment_order po ON po.entry_id = re.id
+                WHERE re.name = ? AND re.status != 'DELETED'
+                ORDER BY r.date DESC, rt.start_at DESC, re.id DESC
+                """;
+        return jdbcTemplate.query(sql, ORDER_HISTORY_ROW_MAPPER, name);
+    }
 
     public List<ReservationResult> getAllReservations() {
         String sql = """

--- a/src/main/java/roomescape/repository/PaymentOrderRepository.java
+++ b/src/main/java/roomescape/repository/PaymentOrderRepository.java
@@ -7,5 +7,7 @@ public interface PaymentOrderRepository {
 
     PaymentOrder save(PaymentOrder paymentOrder);
 
+    void update(PaymentOrder paymentOrder);
+
     Optional<PaymentOrder> findByOrderId(String orderId);
 }

--- a/src/main/java/roomescape/repository/jdbc/JdbcPaymentOrderRepository.java
+++ b/src/main/java/roomescape/repository/jdbc/JdbcPaymentOrderRepository.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.PaymentOrder;
+import roomescape.domain.PaymentOrderStatus;
 import roomescape.repository.PaymentOrderRepository;
 
 @Repository
@@ -37,9 +38,22 @@ public class JdbcPaymentOrderRepository implements PaymentOrderRepository {
     }
 
     @Override
+    public void update(PaymentOrder paymentOrder) {
+        String sql = """
+                UPDATE payment_order
+                SET payment_key = ?, status = ?
+                WHERE id = ?
+                """;
+        jdbcTemplate.update(sql,
+                paymentOrder.getPaymentKey(),
+                paymentOrder.getStatus().name(),
+                paymentOrder.getId());
+    }
+
+    @Override
     public Optional<PaymentOrder> findByOrderId(String orderId) {
         String sql = """
-                SELECT id, order_id, amount, entry_id, created_at
+                SELECT id, order_id, amount, entry_id, created_at, payment_key, status
                 FROM payment_order
                 WHERE order_id = ?
                 """;
@@ -48,7 +62,9 @@ public class JdbcPaymentOrderRepository implements PaymentOrderRepository {
                 rs.getString("order_id"),
                 rs.getLong("amount"),
                 rs.getLong("entry_id"),
-                rs.getTimestamp("created_at").toLocalDateTime()
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getString("payment_key"),
+                PaymentOrderStatus.valueOf(rs.getString("status"))
         ), orderId);
         return result.stream().findFirst();
     }

--- a/src/main/java/roomescape/service/PaymentGateway.java
+++ b/src/main/java/roomescape/service/PaymentGateway.java
@@ -1,0 +1,9 @@
+package roomescape.service;
+
+import roomescape.client.dto.PaymentConfirmation;
+import roomescape.domain.PaymentResult;
+
+public interface PaymentGateway {
+
+    PaymentResult confirm(PaymentConfirmation confirmation);
+}

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -2,12 +2,17 @@ package roomescape.service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.client.TossConfirmResultUnknownException;
+import roomescape.client.TossConnectionException;
 import roomescape.client.TossPaymentGateway;
 import roomescape.client.dto.PaymentConfirmation;
 import roomescape.client.dto.TossPaymentResponse;
@@ -19,11 +24,13 @@ import roomescape.domain.ReservationStatus;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.Theme;
 import roomescape.exception.EntityNotFoundException;
+import roomescape.query.ReservationQueryRepository;
 import roomescape.repository.PaymentOrderRepository;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.service.command.ReservationCommand;
+import roomescape.service.result.OrderHistoryResult;
 import roomescape.service.result.PaymentConfirmResult;
 import roomescape.service.result.ReservationResult;
 
@@ -38,7 +45,14 @@ public class PaymentService {
     private final PaymentOrderRepository paymentOrderRepository;
     private final TossPaymentGateway tossPaymentGateway;
     private final ReservationService reservationService;
+    private final ReservationQueryRepository reservationQueryRepository;
     private final Clock clock;
+
+    // 자기 자신의 트랜잭션 프록시를 통해 persistConfirmedPayment()를 호출하기 위한 self-injection.
+    // (같은 클래스 내부 호출은 @Transactional AOP를 우회하므로 프록시를 거치게 한다.)
+    @Autowired
+    @Lazy
+    private PaymentService self;
 
     @Value("${toss.client-key}")
     private String clientKey;
@@ -53,11 +67,25 @@ public class PaymentService {
         }
 
         log.info("[결제 승인 요청] orderId={} paymentKey={} amount={}", orderId, paymentKey, amount);
-        TossPaymentResponse response = tossPaymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
+        TossPaymentResponse response;
+        try {
+            response = tossPaymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
+        } catch (TossConfirmResultUnknownException e) {
+            // 응답을 받지 못해 승인 여부 불명 - 상태만 기록하고 entry는 PENDING으로 유지(재시도 가능). 예외는 그대로 전파.
+            paymentOrderRepository.update(paymentOrder.resultUnknown());
+            log.warn("[결제 승인 결과 확인 불가] orderId={} message={}", orderId, e.getMessage());
+            throw e;
+        } catch (TossConnectionException e) {
+            // 요청이 토스에 도달하지 못해 미승인이 확실한 경우 - FAILED로 기록. 예외는 그대로 전파.
+            paymentOrderRepository.update(paymentOrder.failed());
+            log.warn("[결제 서버 연결 실패] orderId={} message={}", orderId, e.getMessage());
+            throw e;
+        }
         log.info("[결제 승인 완료] orderId={} status={} approvedAt={}", response.orderId(), response.status(),
                 response.approvedAt());
 
-        ReservationResult reservationResult = reservationService.confirmPendingEntry(paymentOrder.getEntryId());
+        // PaymentOrder 확정 기록과 예약 엔트리 확정을 하나의 트랜잭션으로 묶어 원자적으로 반영한다.
+        ReservationResult reservationResult = self.persistConfirmedPayment(paymentOrder, paymentKey);
 
         log.info("[예약 확정] entryId={} PENDING→RESERVED", paymentOrder.getEntryId());
 
@@ -70,6 +98,16 @@ public class PaymentService {
         );
     }
 
+    public List<OrderHistoryResult> getOrderHistories(String name) {
+        return reservationQueryRepository.getOrderHistories(name);
+    }
+
+    @Transactional
+    public ReservationResult persistConfirmedPayment(PaymentOrder paymentOrder, String paymentKey) {
+        paymentOrderRepository.update(paymentOrder.confirmed(paymentKey));
+        return reservationService.confirmPendingEntry(paymentOrder.getEntryId());
+    }
+
     @Transactional
     public void cancel(String orderId) {
         if (orderId == null) {
@@ -78,8 +116,15 @@ public class PaymentService {
 
         paymentOrderRepository.findByOrderId(orderId).ifPresent(paymentOrder -> {
             Reservation reservation = reservationRepository.getByEntryIdForUpdate(paymentOrder.getEntryId());
+            if (!reservation.findActiveEntry(paymentOrder.getEntryId()).isPending()) {
+                // 이미 confirm()으로 RESERVED까지 확정된 결제 - cancel이 뒤늦게 들어와도 상태를 덮어쓰지 않는다.
+                log.info("[결제 실패 정리 스킵] orderId={} entryId={} 이미 PENDING이 아님", orderId, paymentOrder.getEntryId());
+                return;
+            }
+
             reservation.cancelPendingEntry(paymentOrder.getEntryId());
             reservationRepository.update(reservation);
+            paymentOrderRepository.update(paymentOrder.failed());
             log.info("[결제 실패 정리] orderId={} entryId={} PENDING→DELETED", orderId, paymentOrder.getEntryId());
         });
     }

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -13,11 +13,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.client.TossConfirmResultUnknownException;
 import roomescape.client.TossConnectionException;
-import roomescape.client.TossPaymentGateway;
 import roomescape.client.dto.PaymentConfirmation;
-import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.domain.PaymentOrder;
+import roomescape.domain.PaymentResult;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationEntry;
 import roomescape.domain.ReservationStatus;
@@ -43,7 +42,7 @@ public class PaymentService {
     private final ThemeRepository themeRepository;
     private final ReservationTimeRepository reservationTimeRepository;
     private final PaymentOrderRepository paymentOrderRepository;
-    private final TossPaymentGateway tossPaymentGateway;
+    private final PaymentGateway paymentGateway;
     private final ReservationService reservationService;
     private final ReservationQueryRepository reservationQueryRepository;
     private final Clock clock;
@@ -67,9 +66,9 @@ public class PaymentService {
         }
 
         log.info("[결제 승인 요청] orderId={} paymentKey={} amount={}", orderId, paymentKey, amount);
-        TossPaymentResponse response;
+        PaymentResult response;
         try {
-            response = tossPaymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
+            response = paymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
         } catch (TossConfirmResultUnknownException e) {
             // 응답을 받지 못해 승인 여부 불명 - 상태만 기록하고 entry는 PENDING으로 유지(재시도 가능). 예외는 그대로 전파.
             paymentOrderRepository.update(paymentOrder.resultUnknown());

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -25,10 +25,10 @@ import roomescape.repository.ReservationTimeRepository;
 import roomescape.repository.ThemeRepository;
 import roomescape.service.command.ReservationCommand;
 import roomescape.service.result.PaymentConfirmResult;
+import roomescape.service.result.ReservationResult;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class PaymentService {
 
@@ -37,6 +37,7 @@ public class PaymentService {
     private final ReservationTimeRepository reservationTimeRepository;
     private final PaymentOrderRepository paymentOrderRepository;
     private final TossPaymentGateway tossPaymentGateway;
+    private final ReservationService reservationService;
     private final Clock clock;
 
     @Value("${toss.client-key}")
@@ -56,21 +57,20 @@ public class PaymentService {
         log.info("[결제 승인 완료] orderId={} status={} approvedAt={}", response.orderId(), response.status(),
                 response.approvedAt());
 
-        Reservation reservation = reservationRepository.getByEntryIdForUpdate(paymentOrder.getEntryId());
-        reservation.confirmPendingEntry(paymentOrder.getEntryId());
-        reservationRepository.update(reservation);
+        ReservationResult reservationResult = reservationService.confirmPendingEntry(paymentOrder.getEntryId());
 
         log.info("[예약 확정] entryId={} PENDING→RESERVED", paymentOrder.getEntryId());
 
         return new PaymentConfirmResult(
                 response,
-                reservation.getTheme().getName(),
-                reservation.getTheme().getThumbnailImageUrl(),
-                reservation.getDate(),
-                reservation.getTime().getStartAt()
+                reservationResult.theme().name(),
+                reservationResult.theme().thumbnailImageUrl(),
+                reservationResult.date(),
+                reservationResult.time().startAt()
         );
     }
 
+    @Transactional
     public void cancel(String orderId) {
         if (orderId == null) {
             return;
@@ -84,6 +84,7 @@ public class PaymentService {
         });
     }
 
+    @Transactional
     public PreparePaymentResponse prepare(ReservationCommand command) {
         Reservation reservation = findOrCreateSlotForUpdate(command);
         reservation.addPendingEntry(command.name(), command.amount(), LocalDateTime.now(clock));

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.client.TossPaymentGateway;
+import roomescape.client.dto.PaymentConfirmation;
 import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.domain.PaymentOrder;
@@ -51,15 +52,16 @@ public class PaymentService {
         }
 
         log.info("[결제 승인 요청] orderId={} paymentKey={} amount={}", orderId, paymentKey, amount);
-        TossPaymentResponse response = tossPaymentGateway.confirm(paymentKey, orderId, amount);
-        log.info("[결제 승인 완료] orderId={} status={} approvedAt={}", response.orderId(), response.status(), response.approvedAt());
+        TossPaymentResponse response = tossPaymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
+        log.info("[결제 승인 완료] orderId={} status={} approvedAt={}", response.orderId(), response.status(),
+                response.approvedAt());
 
         Reservation reservation = reservationRepository.getByEntryIdForUpdate(paymentOrder.getEntryId());
         reservation.confirmPendingEntry(paymentOrder.getEntryId());
         reservationRepository.update(reservation);
 
         log.info("[예약 확정] entryId={} PENDING→RESERVED", paymentOrder.getEntryId());
-        
+
         return new PaymentConfirmResult(
                 response,
                 reservation.getTheme().getName(),

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -90,6 +90,14 @@ public class ReservationService {
         reservationRepository.save(reservation);
     }
 
+    @Transactional
+    public ReservationResult confirmPendingEntry(long entryId) {
+        Reservation reservation = reservationRepository.getByEntryIdForUpdate(entryId);
+        reservation.confirmPendingEntry(entryId);
+        reservationRepository.update(reservation);
+        return ReservationResult.from(reservation, reservation.findActiveEntry(entryId));
+    }
+
     public ReservationResult getActiveReservationEntry(long entryId) {
         Reservation reservation = reservationRepository.getByEntryId(entryId);
         ReservationEntry reservationEntry = reservation.findActiveEntry(entryId);

--- a/src/main/java/roomescape/service/result/OrderHistoryResult.java
+++ b/src/main/java/roomescape/service/result/OrderHistoryResult.java
@@ -1,0 +1,17 @@
+package roomescape.service.result;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record OrderHistoryResult(
+        Long reservationId,
+        LocalDate date,
+        LocalTime time,
+        String themeName,
+        String entryStatus,
+        String orderId,
+        String paymentKey,
+        Long amount,
+        String paymentStatus
+) {
+}

--- a/src/main/java/roomescape/service/result/PaymentConfirmResult.java
+++ b/src/main/java/roomescape/service/result/PaymentConfirmResult.java
@@ -2,10 +2,10 @@ package roomescape.service.result;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import roomescape.client.dto.TossPaymentResponse;
+import roomescape.domain.PaymentResult;
 
 public record PaymentConfirmResult(
-        TossPaymentResponse response,
+        PaymentResult response,
         String themeName,
         String themeThumbnailUrl,
         LocalDate reservationDate,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,8 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:local}
 toss.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 toss.base-url=https://api.tosspayments.com
 toss.secret-key=${TOSS_SECRET_KEY}
+toss.connect-timeout-ms = 1000
+toss.read-timeout-ms = 65000
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -44,11 +44,13 @@ CREATE TABLE reservation_entry
 
 CREATE TABLE payment_order
 (
-    id         BIGINT      NOT NULL AUTO_INCREMENT,
-    order_id   VARCHAR(50) NOT NULL,
-    amount     BIGINT      NOT NULL,
-    entry_id   BIGINT      NOT NULL,
-    created_at TIMESTAMP   NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    order_id    VARCHAR(50)  NOT NULL,
+    amount      BIGINT       NOT NULL,
+    entry_id    BIGINT       NOT NULL,
+    created_at  TIMESTAMP    NOT NULL,
+    payment_key VARCHAR(200) NULL,
+    status      VARCHAR(30)  NOT NULL DEFAULT 'PENDING',
     PRIMARY KEY (id),
     CONSTRAINT uk_payment_order_order_id UNIQUE (order_id),
     FOREIGN KEY (entry_id) REFERENCES reservation_entry (id)

--- a/src/main/resources/static/admin.html
+++ b/src/main/resources/static/admin.html
@@ -19,6 +19,7 @@
             <a href="/">홈</a>
             <a href="/reserve">예약하기</a>
             <a href="/search">예약확인</a>
+            <a href="/orders">주문내역</a>
             <a class="active" href="/admin">관리자</a>
         </div>
     </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -19,6 +19,7 @@
             <a class="active" href="/">홈</a>
             <a href="/reserve">예약하기</a>
             <a href="/search">예약확인</a>
+            <a href="/orders">주문내역</a>
             <a href="/admin">관리자</a>
         </div>
     </div>

--- a/src/main/resources/static/js/orders/Controller.js
+++ b/src/main/resources/static/js/orders/Controller.js
@@ -1,0 +1,36 @@
+export default class Controller {
+    constructor(store, views) {
+        this.store = store;
+        this.views = views;
+
+        this.subscribeViewEvents();
+    }
+
+    subscribeViewEvents() {
+        this.views.formView.on("@search", async (event) => {
+            try {
+                await this.store.search(event.detail.name);
+
+                if (!this.store.orders || !this.store.orders.length) {
+                    this.views.toastView.show("주문/결제 내역이 없습니다.");
+                }
+
+                this.render();
+            } catch (error) {
+                this.views.toastView.show(error.message);
+            }
+        });
+    }
+
+    initialize() {
+        this.render();
+    }
+
+    render() {
+        this.views.formView.sync({
+            name: this.store.name
+        });
+
+        this.views.resultView.render(this.store.orders);
+    }
+}

--- a/src/main/resources/static/js/orders/Store.js
+++ b/src/main/resources/static/js/orders/Store.js
@@ -1,0 +1,13 @@
+import {fetchOrders} from "./api.js";
+
+export default class Store {
+    constructor() {
+        this.name = "";
+        this.orders = null;
+    }
+
+    async search(name) {
+        this.name = name;
+        this.orders = await fetchOrders(name);
+    }
+}

--- a/src/main/resources/static/js/orders/api.js
+++ b/src/main/resources/static/js/orders/api.js
@@ -1,0 +1,7 @@
+import {requestJson} from "../common/http.js";
+
+export function fetchOrders(name) {
+    return requestJson(
+        `/api/payments/orders?name=${encodeURIComponent(name)}`
+    );
+}

--- a/src/main/resources/static/js/orders/main.js
+++ b/src/main/resources/static/js/orders/main.js
@@ -1,0 +1,20 @@
+import {qs} from "../common/helpers.js";
+
+import Store from "./Store.js";
+import Controller from "./Controller.js";
+
+import OrdersFormView from "./views/OrdersFormView.js";
+import OrdersResultView from "./views/OrdersResultView.js";
+import ToastView from "./views/ToastView.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+    const store = new Store();
+
+    const views = {
+        formView: new OrdersFormView(qs('[data-role="orders-form"]')),
+        resultView: new OrdersResultView(qs('[data-role="orders-results"]')),
+        toastView: new ToastView(qs('[data-role="toast"]'))
+    };
+
+    new Controller(store, views).initialize();
+});

--- a/src/main/resources/static/js/orders/views/OrdersFormView.js
+++ b/src/main/resources/static/js/orders/views/OrdersFormView.js
@@ -1,0 +1,21 @@
+import View from "../../common/View.js";
+import {on, qs} from "../../common/helpers.js";
+
+export default class OrdersFormView extends View {
+    constructor(element) {
+        super(element);
+        this.nameInput = qs('[name="name"]', element);
+        this.bindEvents();
+    }
+
+    bindEvents() {
+        on(this.element, "submit", (event) => {
+            event.preventDefault();
+            this.emit("@search", {name: this.nameInput.value.trim()});
+        });
+    }
+
+    sync({name}) {
+        this.nameInput.value = name || "";
+    }
+}

--- a/src/main/resources/static/js/orders/views/OrdersResultView.js
+++ b/src/main/resources/static/js/orders/views/OrdersResultView.js
@@ -1,0 +1,126 @@
+import View from "../../common/View.js";
+import {clearElement, createElement} from "../../common/helpers.js";
+
+export default class OrdersResultView extends View {
+    constructor(element) {
+        super(element);
+    }
+
+    render(orders) {
+        clearElement(this.element);
+
+        if (!orders || !orders.length) {
+            this.element.innerHTML = `
+                <div class="empty-state">주문/결제 내역을 검색하세요</div>
+            `;
+            return;
+        }
+
+        orders.forEach((order) => {
+            const item = createElement("div", "reservation-item order-item");
+            const badge = this.resolveBadge(order);
+
+            item.dataset.reservationId = order.reservationId;
+
+            item.innerHTML = `
+                <div class="order-main">
+                    <div class="res-title-row">
+                        <div class="res-theme">${escapeHtml(order.themeName)}</div>
+                        <span class="res-status ${badge.className}">${badge.label}</span>
+                    </div>
+
+                    <div class="res-details">
+                        ${order.date}
+                        ·
+                        ${formatTime(order.time)}
+                    </div>
+
+                    ${this.renderPaymentDetail(order, badge)}
+                </div>
+            `;
+
+            this.element.appendChild(item);
+        });
+    }
+
+    renderPaymentDetail(order, badge) {
+        if (badge.kind === "UNKNOWN") {
+            const link = buildRetryLink(order);
+            return `
+                <div class="order-notice unknown">
+                    확인 필요 — 잠시 후 다시 확인해주세요
+                </div>
+                ${link ? `<a class="order-retry-btn" href="${link}">다시 확인하기</a>` : ""}
+            `;
+        }
+
+        if (badge.kind === "CONFIRMED") {
+            return `
+                <div class="order-payment">
+                    <div class="order-amount">${formatAmount(order.amount)}</div>
+                    <div class="order-meta">주문번호 ${escapeHtml(order.orderId)}</div>
+                    <div class="order-meta">결제키 ${escapeHtml(order.paymentKey)}</div>
+                </div>
+            `;
+        }
+
+        return "";
+    }
+
+    resolveBadge(order) {
+        if (order.entryStatus === "WAITING" || order.paymentStatus === null || order.paymentStatus === undefined) {
+            return {kind: "WAITING", className: "status-muted", label: "대기중"};
+        }
+
+        switch (order.paymentStatus) {
+            case "CONFIRMED":
+                return {kind: "CONFIRMED", className: "status-confirmed", label: "확정"};
+            case "FAILED":
+                return {kind: "FAILED", className: "status-failed", label: "결제 실패"};
+            case "CONFIRM_RESULT_UNKNOWN":
+                return {kind: "UNKNOWN", className: "status-unknown", label: "⏳ 확인 필요"};
+            case "PENDING":
+            default:
+                return {kind: "PENDING", className: "status-muted", label: "결제 대기"};
+        }
+    }
+}
+
+function buildRetryLink(order) {
+    if (order.paymentKey === null || order.orderId === null || order.amount === null
+        || order.paymentKey === undefined || order.orderId === undefined || order.amount === undefined) {
+        return null;
+    }
+
+    const paymentKey = encodeURIComponent(order.paymentKey);
+    const orderId = encodeURIComponent(order.orderId);
+    const amount = encodeURIComponent(order.amount);
+
+    return `/payments/success?paymentKey=${paymentKey}&orderId=${orderId}&amount=${amount}`;
+}
+
+function formatTime(time) {
+    if (!time) {
+        return "";
+    }
+    return time.slice(0, 5);
+}
+
+function formatAmount(amount) {
+    if (amount === null || amount === undefined) {
+        return "";
+    }
+    return `${Number(amount).toLocaleString("ko-KR")}원`;
+}
+
+function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return "";
+    }
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}

--- a/src/main/resources/static/js/orders/views/ToastView.js
+++ b/src/main/resources/static/js/orders/views/ToastView.js
@@ -1,0 +1,13 @@
+import View from "../../common/View.js";
+
+export default class ToastView extends View {
+    show(message, type = "") {
+        this.element.textContent = message;
+        this.element.className = `toast show${type ? ` ${type}` : ""}`;
+
+        window.clearTimeout(this.timeoutId);
+        this.timeoutId = window.setTimeout(() => {
+            this.element.className = "toast";
+        }, 3000);
+    }
+}

--- a/src/main/resources/static/orders.html
+++ b/src/main/resources/static/orders.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title>주문/결제 내역</title>
+    <link href="/styles/common.css" rel="stylesheet"/>
+    <link href="/styles/search.css" rel="stylesheet"/>
+    <link href="/styles/orders.css" rel="stylesheet"/>
+</head>
+<body>
+<nav class="top-nav">
+    <div class="nav-inner">
+        <a class="nav-logo" href="/">RoomEscape</a>
+        <div class="nav-links">
+            <a href="/">홈</a>
+            <a href="/reserve">예약하기</a>
+            <a href="/search">예약확인</a>
+            <a class="active" href="/orders">주문내역</a>
+            <a href="/admin">관리자</a>
+        </div>
+    </div>
+</nav>
+<main class="search-page">
+    <h1 class="page-title">주문/결제 내역</h1>
+
+    <section class="search-card">
+        <form data-role="orders-form">
+            <label>예약자 이름</label>
+
+            <div class="search-row">
+                <input
+                        class="search-input"
+                        name="name"
+                        placeholder="이름을 입력하세요"
+                        required
+                />
+                <button class="search-btn">조회</button>
+            </div>
+        </form>
+    </section>
+
+    <section
+            class="result-card"
+            data-role="orders-results"
+    ></section>
+
+    <div data-role="toast"></div>
+</main>
+
+<script src="/js/orders/main.js" type="module"></script>
+</body>
+</html>

--- a/src/main/resources/static/reservation.html
+++ b/src/main/resources/static/reservation.html
@@ -19,6 +19,7 @@
             <a href="/">홈</a>
             <a class="active" href="/reserve">예약하기</a>
             <a href="/search">예약확인</a>
+            <a href="/orders">주문내역</a>
             <a href="/admin">관리자</a>
         </div>
     </div>

--- a/src/main/resources/static/search.html
+++ b/src/main/resources/static/search.html
@@ -14,6 +14,7 @@
             <a href="/">홈</a>
             <a href="/reserve">예약하기</a>
             <a class="active" href="/search">예약확인</a>
+            <a href="/orders">주문내역</a>
             <a href="/admin">관리자</a>
         </div>
     </div>

--- a/src/main/resources/static/styles/orders.css
+++ b/src/main/resources/static/styles/orders.css
@@ -1,0 +1,72 @@
+.order-item {
+    align-items: flex-start;
+}
+
+.order-main {
+    width: 100%;
+}
+
+.res-status.status-muted {
+    background: #f2f4f6;
+    color: #8b95a1;
+}
+
+.res-status.status-confirmed {
+    background: #e6f4ea;
+    color: #1f9254;
+}
+
+.res-status.status-failed {
+    background: #fdecea;
+    color: #d92d20;
+}
+
+.res-status.status-unknown {
+    background: #fff4e5;
+    color: #b54708;
+}
+
+.order-payment {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed #f2f4f6;
+}
+
+.order-amount {
+    font-size: 15px;
+    font-weight: 700;
+    color: #191f28;
+}
+
+.order-meta {
+    margin-top: 2px;
+    font-size: 11px;
+    color: #b0b8c1;
+    word-break: break-all;
+}
+
+.order-notice.unknown {
+    margin-top: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #b54708;
+}
+
+.order-retry-btn {
+    display: inline-flex;
+    align-items: center;
+    height: 34px;
+    margin-top: 8px;
+    padding: 0 14px;
+    border-radius: 10px;
+    background: #fff4e5;
+    color: #b54708;
+    font-size: 12px;
+    font-weight: 700;
+    text-decoration: none;
+    border: 1px solid #fcd9a8;
+}
+
+.order-retry-btn:hover {
+    background: #ffe9cc;
+}

--- a/src/main/resources/templates/payment/fail.html
+++ b/src/main/resources/templates/payment/fail.html
@@ -40,7 +40,7 @@
 </head>
 <body>
 <div class="card">
-  <h1>❌ 결제를 실패했어요</h1>
+  <h1 th:text="${title} ?: '❌ 결제를 실패했어요'">❌ 결제를 실패했어요</h1>
 
   <div class="row"><span class="label">에러코드</span>
     <span class="val" th:text="${code}">REJECT_CARD_PAYMENT</span></div>

--- a/src/test/java/roomescape/client/TossClientExceptionsTest.java
+++ b/src/test/java/roomescape/client/TossClientExceptionsTest.java
@@ -1,0 +1,28 @@
+package roomescape.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TossClientExceptionsTest {
+
+    @Test
+    void TossConnectionException은_원인을_보존하고_안내_메시지를_노출한다() {
+        RuntimeException cause = new RuntimeException("connect timed out");
+
+        TossConnectionException exception = new TossConnectionException(cause);
+
+        assertThat(exception.getCause()).isSameAs(cause);
+        assertThat(exception.getMessage()).isEqualTo("결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.");
+    }
+
+    @Test
+    void TossConfirmResultUnknownException은_원인을_보존하고_안내_메시지를_노출한다() {
+        RuntimeException cause = new RuntimeException("read timed out");
+
+        TossConfirmResultUnknownException exception = new TossConfirmResultUnknownException(cause);
+
+        assertThat(exception.getCause()).isSameAs(cause);
+        assertThat(exception.getMessage()).isEqualTo("결제 승인 결과를 확인하지 못했습니다. 결제가 완료되었을 수 있으니 예약 내역을 확인해주세요.");
+    }
+}

--- a/src/test/java/roomescape/client/TossClientTimeoutTest.java
+++ b/src/test/java/roomescape/client/TossClientTimeoutTest.java
@@ -18,8 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestClientException;
 import roomescape.client.dto.PaymentConfirmation;
 
 
@@ -74,7 +72,7 @@ class TossClientTimeoutTest {
 
         var start = System.nanoTime();
         assertThatThrownBy(() -> tossPaymentGateway.confirm(confirmation()))
-                .isInstanceOf(RestClientException.class)
+                .isInstanceOf(TossConfirmResultUnknownException.class)
                 .hasRootCauseInstanceOf(SocketTimeoutException.class);
         var elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
@@ -103,7 +101,7 @@ class TossClientTimeoutTest {
             try {
                 tossPaymentGateway.confirm(confirmation());
                 succeeded++;
-            } catch (RestClientException e) {
+            } catch (TossConfirmResultUnknownException e) {
                 // 타임아웃으로 일찍 포기한 호출 — 성공 TPS 에 세지 않는다.
             }
         }
@@ -117,22 +115,22 @@ class TossClientTimeoutTest {
     }
 
     @Test
-    @Timeout(value = 3, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+    @Timeout(value = 5, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
     void 라우팅불가_IP면_connectTimeout만큼_기다렸다가_SocketTimeout으로_실패한다() {
         // 학생이 채운 tossRestClient 의 connect timeout 을 그대로 검증한다.
-        // 설정 전(initial)엔 타임아웃이 없어 블랙홀 연결이 매달리므로 @Timeout(3초)이 끊어 실패시킨다.
+        // 설정 전(initial)엔 타임아웃이 없어 블랙홀 연결이 매달리므로 @Timeout(5초)이 끊어 실패시킨다.
         var gateway = new TossPaymentGateway(
                 new TossClientConfig().tossRestClient(BLACKHOLE_URL, "test_gsk_dummy", 500, 500),
                 new ObjectMapper());
 
         var start = System.nanoTime();
         assertThatThrownBy(() -> gateway.confirm(confirmation()))
-                .isInstanceOf(ResourceAccessException.class)
-                .hasCauseInstanceOf(SocketTimeoutException.class);
+                .isInstanceOf(TossConnectionException.class)
+                .hasRootCauseInstanceOf(SocketTimeoutException.class);
         var elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
-        // connect timeout(500ms)만큼 기다렸다가 끊긴다.
-        assertThat(elapsedMs).isBetween(300L, 2500L);
+        // connect timeout(500ms) 3회 재시도 + 재시도 간격(300ms) 2회 ≈ 2100ms. JVM/Spring 오버헤드 여유를 두고 4000ms로 상한을 잡는다.
+        assertThat(elapsedMs).isBetween(300L, 4000L);
     }
 
 }

--- a/src/test/java/roomescape/client/TossClientTimeoutTest.java
+++ b/src/test/java/roomescape/client/TossClientTimeoutTest.java
@@ -63,6 +63,19 @@ class TossClientTimeoutTest {
     }
 
     @Test
+    void confirm_호출시_Idempotency_Key_헤더에_orderId가_그대로_전달된다() throws InterruptedException {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(SUCCESS_BODY));
+
+        tossPaymentGateway.confirm(confirmation());
+
+        var recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getHeader("Idempotency-Key")).isEqualTo("order-1");
+    }
+
+    @Test
     void 읽기타임아웃이면_readTimeout만큼만_기다렸다가_RestClient예외로_실패한다() {
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(200)

--- a/src/test/java/roomescape/client/TossPaymentGatewayTest.java
+++ b/src/test/java/roomescape/client/TossPaymentGatewayTest.java
@@ -1,0 +1,138 @@
+package roomescape.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import roomescape.client.dto.PaymentConfirmation;
+
+
+@SpringBootTest
+class TossClientTimeoutTest {
+
+    // 응답 없는(SYN 무응답) IP → connect 가 매달려 connect timeout 을 유발한다.
+    private static final String BLACKHOLE_URL = "http://10.255.255.1:81";
+
+    static MockWebServer mockWebServer;
+
+    static {
+        mockWebServer = new MockWebServer();
+        try {
+            mockWebServer.start();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static final String SUCCESS_BODY = """
+            {"paymentKey": "test_pk_1", "orderId": "order-1", "status": "DONE", "totalAmount": 10000}
+            """;
+
+    @Autowired
+    private TossPaymentGateway tossPaymentGateway;
+
+    @DynamicPropertySource
+    static void tossProperties(DynamicPropertyRegistry registry) {
+        registry.add("toss.base-url", () -> mockWebServer.url("/").toString());
+        registry.add("toss.secret-key", () -> "test_gsk_dummy");
+        registry.add("toss.connect-timeout-ms", () -> "500");
+        registry.add("toss.read-timeout-ms", () -> "500");
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    private PaymentConfirmation confirmation() {
+        return new PaymentConfirmation("test_pk_1", "order-1", 10000L);
+    }
+
+    @Test
+    void 읽기타임아웃이면_readTimeout만큼만_기다렸다가_RestClient예외로_실패한다() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(SUCCESS_BODY)
+                .setHeadersDelay(2, TimeUnit.SECONDS));
+
+        var start = System.nanoTime();
+        assertThatThrownBy(() -> tossPaymentGateway.confirm(confirmation()))
+                .isInstanceOf(RestClientException.class)
+                .hasRootCauseInstanceOf(SocketTimeoutException.class);
+        var elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // 서버는 2초를 끌지만 read timeout(500ms)이 먼저 끊는다.
+        assertThat(elapsedMs).isLessThan(1500);
+    }
+
+    @Test
+    void 느린_호출이_섞여도_타임아웃이_있으면_성공_TPS가_유지된다() {
+        // 느린 응답(2초)과 정상 응답이 번갈아 온다 — 느린 의존성에 일부 호출만 물리는 상황.
+        for (var i = 0; i < 3; i++) {
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(SUCCESS_BODY)
+                    .setHeadersDelay(2, TimeUnit.SECONDS));
+            mockWebServer.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(SUCCESS_BODY));
+        }
+
+        var succeeded = 0;
+        var start = System.nanoTime();
+        for (var i = 0; i < 6; i++) {
+            try {
+                tossPaymentGateway.confirm(confirmation());
+                succeeded++;
+            } catch (RestClientException e) {
+                // 타임아웃으로 일찍 포기한 호출 — 성공 TPS 에 세지 않는다.
+            }
+        }
+        var elapsedSeconds = (System.nanoTime() - start) / 1_000_000_000.0;
+        var tps = succeeded / elapsedSeconds;
+
+        // 성공 TPS = 성공 건수 ÷ 경과 초.
+        // read timeout(500ms)이 있으면 느린 3건을 일찍 포기한 덕에 정상 3건이 제때 처리된다 → ~1.8.
+        // 없으면 느린 호출이 스레드를 2초씩 붙잡아, 6건 전부 성공하고도 1.0 을 넘지 못한다.
+        assertThat(tps).isGreaterThan(1.1);
+    }
+
+    @Test
+    @Timeout(value = 3, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+    void 라우팅불가_IP면_connectTimeout만큼_기다렸다가_SocketTimeout으로_실패한다() {
+        // 학생이 채운 tossRestClient 의 connect timeout 을 그대로 검증한다.
+        // 설정 전(initial)엔 타임아웃이 없어 블랙홀 연결이 매달리므로 @Timeout(3초)이 끊어 실패시킨다.
+        var gateway = new TossPaymentGateway(
+                new TossClientConfig().tossRestClient(BLACKHOLE_URL, "test_gsk_dummy", 500, 500),
+                new ObjectMapper());
+
+        var start = System.nanoTime();
+        assertThatThrownBy(() -> gateway.confirm(confirmation()))
+                .isInstanceOf(ResourceAccessException.class)
+                .hasCauseInstanceOf(SocketTimeoutException.class);
+        var elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // connect timeout(500ms)만큼 기다렸다가 끊긴다.
+        assertThat(elapsedMs).isBetween(300L, 2500L);
+    }
+
+}

--- a/src/test/java/roomescape/controller/client/PaymentControllerTest.java
+++ b/src/test/java/roomescape/controller/client/PaymentControllerTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.when;
 
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,10 +20,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.context.WebApplicationContext;
 import roomescape.controller.BaseControllerUnitTest;
 import roomescape.controller.client.dto.request.ReservationRequest;
+import roomescape.controller.client.dto.response.OrderHistoryResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.controller.client.fixture.ReservationApiRequestFixture;
 import roomescape.service.PaymentService;
 import roomescape.service.command.ReservationCommand;
+import roomescape.service.result.OrderHistoryResult;
 
 @WebMvcTest(PaymentController.class)
 class PaymentControllerTest extends BaseControllerUnitTest {
@@ -51,6 +56,34 @@ class PaymentControllerTest extends BaseControllerUnitTest {
                 .extract().as(new TypeRef<>() {});
 
         assertThat(response).isEqualTo(serviceResponse);
+    }
+
+    @Test
+    void 주문_내역_조회에_성공하면_200_OK와_계약_형태의_응답이_반환된다() {
+        // given
+        OrderHistoryResult confirmed = new OrderHistoryResult(
+                1L, LocalDate.of(2025, 1, 2), LocalTime.of(10, 0), "공포테마",
+                "RESERVED", "order-1", "payment-key-1", 30000L, "CONFIRMED");
+        OrderHistoryResult waiting = new OrderHistoryResult(
+                2L, LocalDate.of(2025, 1, 3), LocalTime.of(12, 0), "추리테마",
+                "WAITING", null, null, null, (String) null);
+        when(paymentService.getOrderHistories("이프")).thenReturn(List.of(confirmed, waiting));
+
+        // when & then
+        List<OrderHistoryResponse> response = RestAssuredMockMvc.given().spec(defaultSpec()).log().all()
+                .param("name", "이프")
+                .when().get("/api/payments/orders")
+                .then().log().all()
+                .status(HttpStatus.OK)
+                .extract().as(new TypeRef<>() {});
+
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0))
+                .isEqualTo(new OrderHistoryResponse(1L, LocalDate.of(2025, 1, 2), LocalTime.of(10, 0),
+                        "공포테마", "RESERVED", "order-1", "payment-key-1", 30000L, "CONFIRMED"));
+        assertThat(response.get(1).orderId()).isNull();
+        assertThat(response.get(1).paymentStatus()).isNull();
+        assertThat(response.get(1).amount()).isNull();
     }
 
     @ParameterizedTest(name = "요청 정보가 {0} 일 때, 예외 메세지 \"{1}\"가 발생한다.")

--- a/src/test/java/roomescape/controller/client/web/PageControllerTest.java
+++ b/src/test/java/roomescape/controller/client/web/PageControllerTest.java
@@ -16,8 +16,8 @@ import org.springframework.web.context.WebApplicationContext;
 import roomescape.client.TossConfirmResultUnknownException;
 import roomescape.client.TossConnectionException;
 import roomescape.client.TossPaymentException;
-import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.BaseControllerUnitTest;
+import roomescape.domain.PaymentResult;
 import roomescape.service.PaymentService;
 import roomescape.service.result.PaymentConfirmResult;
 
@@ -34,8 +34,7 @@ class PageControllerTest extends BaseControllerUnitTest {
 
     @Test
     void 결제_승인에_성공하면_성공_화면에_예약_정보가_노출된다() {
-        TossPaymentResponse response = new TossPaymentResponse(
-                "payment-key-1", "order-1", "주문명", "DONE", 30000L, "카드", "2024-01-01T00:00:00");
+        PaymentResult response = new PaymentResult("order-1", "DONE", 30000L, "2024-01-01T00:00:00");
         PaymentConfirmResult result = new PaymentConfirmResult(
                 response, "공포테마", "https://image.com/image.png", LocalDate.of(2024, 1, 2), LocalTime.of(10, 0));
         when(paymentService.confirm(any(), any(), any())).thenReturn(result);

--- a/src/test/java/roomescape/controller/client/web/PageControllerTest.java
+++ b/src/test/java/roomescape/controller/client/web/PageControllerTest.java
@@ -1,0 +1,115 @@
+package roomescape.controller.client.web;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.context.WebApplicationContext;
+import roomescape.client.TossConfirmResultUnknownException;
+import roomescape.client.TossConnectionException;
+import roomescape.client.TossPaymentException;
+import roomescape.client.dto.TossPaymentResponse;
+import roomescape.controller.BaseControllerUnitTest;
+import roomescape.service.PaymentService;
+import roomescape.service.result.PaymentConfirmResult;
+
+@WebMvcTest(PageController.class)
+class PageControllerTest extends BaseControllerUnitTest {
+
+    @MockitoBean
+    private PaymentService paymentService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        mockMvcSetting(webApplicationContext);
+    }
+
+    @Test
+    void 결제_승인에_성공하면_성공_화면에_예약_정보가_노출된다() {
+        TossPaymentResponse response = new TossPaymentResponse(
+                "payment-key-1", "order-1", "주문명", "DONE", 30000L, "카드", "2024-01-01T00:00:00");
+        PaymentConfirmResult result = new PaymentConfirmResult(
+                response, "공포테마", "https://image.com/image.png", LocalDate.of(2024, 1, 2), LocalTime.of(10, 0));
+        when(paymentService.confirm(any(), any(), any())).thenReturn(result);
+
+        RestAssuredMockMvc.given().spec(defaultSpec())
+                .queryParam("paymentKey", "payment-key-1")
+                .queryParam("orderId", "order-1")
+                .queryParam("amount", 30000L)
+                .when().get("/payments/success")
+                .then()
+                .status(HttpStatus.OK)
+                .body(containsString("공포테마"));
+    }
+
+    @Test
+    void 이미_처리된_결제이면_성공이_아닌_안내_화면으로_이동한다() {
+        when(paymentService.confirm(any(), any(), any()))
+                .thenThrow(new TossPaymentException.AlreadyProcessed("이미 처리된 결제입니다."));
+
+        RestAssuredMockMvc.given().spec(defaultSpec())
+                .queryParam("paymentKey", "payment-key-1")
+                .queryParam("orderId", "order-1")
+                .queryParam("amount", 30000L)
+                .when().get("/payments/success")
+                .then()
+                .status(HttpStatus.OK)
+                .body(containsString("이미 처리된 결제예요"))
+                .body(containsString("ALREADY_PROCESSED"));
+    }
+
+    @Test
+    void 결제_승인_결과를_확인할_수_없으면_확인_불가_안내_화면으로_이동한다() {
+        when(paymentService.confirm(any(), any(), any()))
+                .thenThrow(new TossConfirmResultUnknownException(new RuntimeException("read timeout")));
+
+        RestAssuredMockMvc.given().spec(defaultSpec())
+                .queryParam("paymentKey", "payment-key-1")
+                .queryParam("orderId", "order-1")
+                .queryParam("amount", 30000L)
+                .when().get("/payments/success")
+                .then()
+                .status(HttpStatus.OK)
+                .body(containsString("결제 결과를 확인하지 못했어요"))
+                .body(containsString("CONFIRM_RESULT_UNKNOWN"));
+    }
+
+    @Test
+    void 토스_서버에_연결할_수_없으면_연결_실패_안내가_노출된다() {
+        when(paymentService.confirm(any(), any(), any()))
+                .thenThrow(new TossConnectionException(new RuntimeException("connect timeout")));
+
+        RestAssuredMockMvc.given().spec(defaultSpec())
+                .queryParam("paymentKey", "payment-key-1")
+                .queryParam("orderId", "order-1")
+                .queryParam("amount", 30000L)
+                .when().get("/payments/success")
+                .then()
+                .status(HttpStatus.OK)
+                .body(containsString("CONNECTION_FAILED"));
+    }
+
+    @Test
+    void 예상하지_못한_예외는_일반_결제_실패_화면으로_이동한다() {
+        when(paymentService.confirm(any(), any(), any()))
+                .thenThrow(new IllegalStateException("알 수 없는 오류"));
+
+        RestAssuredMockMvc.given().spec(defaultSpec())
+                .queryParam("paymentKey", "payment-key-1")
+                .queryParam("orderId", "order-1")
+                .queryParam("amount", 30000L)
+                .when().get("/payments/success")
+                .then()
+                .status(HttpStatus.OK)
+                .body(containsString("CONFIRM_FAILED"))
+                .body(containsString("알 수 없는 오류"));
+    }
+}

--- a/src/test/java/roomescape/query/OrderHistoryQueryIntegrationTest.java
+++ b/src/test/java/roomescape/query/OrderHistoryQueryIntegrationTest.java
@@ -1,0 +1,74 @@
+package roomescape.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import roomescape.service.result.OrderHistoryResult;
+import roomescape.support.IntegrationTest;
+
+@IntegrationTest
+@Sql("/integration-fixture.sql")
+class OrderHistoryQueryIntegrationTest {
+
+    @Autowired
+    private ReservationQueryRepository reservationQueryRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("INSERT INTO reservation (id, date, theme_id, time_id) VALUES (1, '2025-01-02', 1, 1)");
+        jdbcTemplate.update("INSERT INTO reservation (id, date, theme_id, time_id) VALUES (2, '2025-01-03', 1, 2)");
+
+        // RESERVED 엔트리 + 결제 완료된 주문
+        jdbcTemplate.update(
+                "INSERT INTO reservation_entry (id, name, reservation_id, status, created_at) "
+                        + "VALUES (1, '이프', 1, 'RESERVED', CURRENT_TIMESTAMP)");
+        jdbcTemplate.update(
+                "INSERT INTO payment_order (order_id, amount, entry_id, created_at, payment_key, status) "
+                        + "VALUES ('order-1', 30000, 1, CURRENT_TIMESTAMP, 'pk-1', 'CONFIRMED')");
+
+        // WAITING 엔트리 - 연결된 주문 없음
+        jdbcTemplate.update(
+                "INSERT INTO reservation_entry (id, name, reservation_id, status, created_at) "
+                        + "VALUES (2, '이프', 2, 'WAITING', CURRENT_TIMESTAMP)");
+
+        // 다른 사람의 엔트리 - 조회되면 안 됨
+        jdbcTemplate.update(
+                "INSERT INTO reservation_entry (id, name, reservation_id, status, created_at) "
+                        + "VALUES (3, '두둠', 1, 'WAITING', CURRENT_TIMESTAMP)");
+    }
+
+    @Test
+    void 이름으로_주문_내역을_결제_상태와_함께_조회하며_주문이_없는_엔트리는_결제정보가_null이다() {
+        // when
+        List<OrderHistoryResult> result = reservationQueryRepository.getOrderHistories("이프");
+
+        // then
+        assertThat(result).hasSize(2);
+
+        OrderHistoryResult confirmed = result.stream()
+                .filter(r -> "RESERVED".equals(r.entryStatus()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(confirmed.orderId()).isEqualTo("order-1");
+        assertThat(confirmed.paymentKey()).isEqualTo("pk-1");
+        assertThat(confirmed.amount()).isEqualTo(30000L);
+        assertThat(confirmed.paymentStatus()).isEqualTo("CONFIRMED");
+        assertThat(confirmed.themeName()).isEqualTo("공포");
+
+        OrderHistoryResult waiting = result.stream()
+                .filter(r -> "WAITING".equals(r.entryStatus()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(waiting.orderId()).isNull();
+        assertThat(waiting.paymentKey()).isNull();
+        assertThat(waiting.amount()).isNull();
+        assertThat(waiting.paymentStatus()).isNull();
+    }
+}

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -14,11 +14,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import roomescape.client.TossConfirmResultUnknownException;
 import roomescape.client.TossConnectionException;
 import roomescape.client.TossPaymentException;
-import roomescape.client.TossPaymentGateway;
-import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.domain.PaymentOrder;
 import roomescape.domain.PaymentOrderStatus;
+import roomescape.domain.PaymentResult;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationEntry;
 import roomescape.domain.ReservationStatus;
@@ -49,7 +48,7 @@ class PaymentServiceTest {
     private ReservationTimeRepository reservationTimeRepository;
     private FakeThemeRepository themeRepository;
     private FakePaymentOrderRepository paymentOrderRepository;
-    private TossPaymentGateway tossPaymentGateway;
+    private PaymentGateway paymentGateway;
     private PaymentService paymentService;
 
     @BeforeEach
@@ -58,7 +57,7 @@ class PaymentServiceTest {
         this.reservationTimeRepository = new FakeReservationTimeRepository();
         this.themeRepository = new FakeThemeRepository();
         this.paymentOrderRepository = new FakePaymentOrderRepository();
-        this.tossPaymentGateway = Mockito.mock(TossPaymentGateway.class);
+        this.paymentGateway = Mockito.mock(PaymentGateway.class);
         ReservationQueryRepository reservationQueryRepository = Mockito.mock(ReservationQueryRepository.class);
         ReservationService reservationService = new ReservationService(
                 reservationRepository,
@@ -72,7 +71,7 @@ class PaymentServiceTest {
                 themeRepository,
                 reservationTimeRepository,
                 paymentOrderRepository,
-                tossPaymentGateway,
+                paymentGateway,
                 reservationService,
                 reservationQueryRepository,
                 TestDateTimes.fixedClock()
@@ -216,9 +215,8 @@ class PaymentServiceTest {
         // given
         Long amount = ThemeFixture.DEFAULT_PRICE;
         long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        TossPaymentResponse response = new TossPaymentResponse(
-                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
-        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+        PaymentResult response = new PaymentResult("order-1", "DONE", amount, "2024-01-01T00:00:00");
+        when(paymentGateway.confirm(any())).thenReturn(response);
 
         // when
         var result = paymentService.confirm("payment-key-1", "order-1", amount);
@@ -236,9 +234,8 @@ class PaymentServiceTest {
         // given
         Long amount = ThemeFixture.DEFAULT_PRICE;
         preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        TossPaymentResponse response = new TossPaymentResponse(
-                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
-        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+        PaymentResult response = new PaymentResult("order-1", "DONE", amount, "2024-01-01T00:00:00");
+        when(paymentGateway.confirm(any())).thenReturn(response);
 
         // when
         paymentService.confirm("payment-key-1", "order-1", amount);
@@ -254,7 +251,7 @@ class PaymentServiceTest {
         // given
         Long amount = ThemeFixture.DEFAULT_PRICE;
         long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        when(tossPaymentGateway.confirm(any()))
+        when(paymentGateway.confirm(any()))
                 .thenThrow(new TossConfirmResultUnknownException(new RuntimeException("read timeout")));
 
         // when & then
@@ -287,9 +284,8 @@ class PaymentServiceTest {
         // given: confirm()까지 성공해 RESERVED + CONFIRMED 상태
         Long amount = ThemeFixture.DEFAULT_PRICE;
         long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        TossPaymentResponse response = new TossPaymentResponse(
-                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
-        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+        PaymentResult response = new PaymentResult("order-1", "DONE", amount, "2024-01-01T00:00:00");
+        when(paymentGateway.confirm(any())).thenReturn(response);
         paymentService.confirm("payment-key-1", "order-1", amount);
 
         // when: 브라우저 뒤로가기 등으로 cancel이 뒤늦게 호출됨
@@ -308,7 +304,7 @@ class PaymentServiceTest {
         // given
         Long amount = ThemeFixture.DEFAULT_PRICE;
         long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        when(tossPaymentGateway.confirm(any()))
+        when(paymentGateway.confirm(any()))
                 .thenThrow(new TossConnectionException(new RuntimeException("connect timeout")));
 
         // when & then
@@ -346,7 +342,7 @@ class PaymentServiceTest {
         // given
         Long amount = ThemeFixture.DEFAULT_PRICE;
         long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
-        when(tossPaymentGateway.confirm(any()))
+        when(paymentGateway.confirm(any()))
                 .thenThrow(new TossPaymentException.AlreadyProcessed("이미 처리된 결제입니다."));
 
         // when & then

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -2,13 +2,20 @@ package roomescape.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static roomescape.support.TestDateTimes.FIXED;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
+import roomescape.client.TossPaymentException;
+import roomescape.client.TossPaymentGateway;
+import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
+import roomescape.domain.PaymentOrder;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationEntry;
 import roomescape.domain.ReservationStatus;
@@ -19,6 +26,8 @@ import roomescape.domain.fixture.ThemeFixture;
 import roomescape.exception.DuplicateEntityException;
 import roomescape.exception.EntityNotFoundException;
 import roomescape.exception.RoomEscapeException;
+import roomescape.query.ReservationQueryRepository;
+import roomescape.repository.PaymentOrderRepository;
 import roomescape.repository.ReservationRepository;
 import roomescape.repository.ReservationTimeRepository;
 import roomescape.service.command.ReservationCommand;
@@ -37,6 +46,7 @@ class PaymentServiceTest {
     private ReservationTimeRepository reservationTimeRepository;
     private FakeThemeRepository themeRepository;
     private FakePaymentOrderRepository paymentOrderRepository;
+    private TossPaymentGateway tossPaymentGateway;
     private PaymentService paymentService;
 
     @BeforeEach
@@ -45,16 +55,37 @@ class PaymentServiceTest {
         this.reservationTimeRepository = new FakeReservationTimeRepository();
         this.themeRepository = new FakeThemeRepository();
         this.paymentOrderRepository = new FakePaymentOrderRepository();
+        this.tossPaymentGateway = Mockito.mock(TossPaymentGateway.class);
+        ReservationService reservationService = new ReservationService(
+                reservationRepository,
+                reservationTimeRepository,
+                themeRepository,
+                Mockito.mock(ReservationQueryRepository.class),
+                TestDateTimes.fixedClock()
+        );
         this.paymentService = new PaymentService(
                 reservationRepository,
                 themeRepository,
                 reservationTimeRepository,
                 paymentOrderRepository,
-                null, // TossPaymentGateway — prepare() 테스트에서는 사용되지 않음
-                null, // ReservationService — prepare() 테스트에서는 사용되지 않음
+                tossPaymentGateway,
+                reservationService,
                 TestDateTimes.fixedClock()
         );
         ReflectionTestUtils.setField(paymentService, "clientKey", TEST_CLIENT_KEY);
+    }
+
+    private long preparePendingEntry(String name, PaymentOrderRepository paymentOrderRepositoryToSave, String orderId, Long amount) {
+        ReservationTime time = reservationTimeRepository.save(ReservationTimeFixture.createDefault());
+        Theme theme = themeRepository.save(ThemeFixture.createDefaultTheme());
+        Reservation slot = Reservation.createSlot(FIXED.plusDays(1).toLocalDate(), theme, time);
+        slot.addPendingEntry(name, amount, FIXED);
+        Reservation saved = reservationRepository.save(slot);
+        long entryId = saved.findEntryByNameAndStatus(name, ReservationStatus.PENDING).getId();
+
+        PaymentOrder paymentOrder = PaymentOrder.create(orderId, amount, entryId, FIXED);
+        paymentOrderRepositoryToSave.save(paymentOrder);
+        return entryId;
     }
 
     @Test
@@ -171,5 +202,60 @@ class PaymentServiceTest {
         assertThatThrownBy(() -> paymentService.prepare(secondCommand))
                 .isInstanceOf(DuplicateEntityException.class)
                 .hasMessageContaining("이미 예약 또는 결제 중인 날짜입니다.");
+    }
+
+    @Test
+    void 결제_승인에_성공하면_엔트리가_RESERVED로_확정되고_결과에_예약정보가_채워진다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        TossPaymentResponse response = new TossPaymentResponse(
+                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
+        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+
+        // when
+        var result = paymentService.confirm("payment-key-1", "order-1", amount);
+
+        // then
+        assertThat(result.response()).isEqualTo(response);
+        assertThat(result.themeName()).isEqualTo(ThemeFixture.createDefaultTheme().getName());
+
+        Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
+        assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.RESERVED);
+    }
+
+    @Test
+    void 존재하지_않는_orderId로_결제_승인하면_예외가_발생한다() {
+        assertThatThrownBy(() -> paymentService.confirm("payment-key-1", "no-such-order", 30000L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("결제 정보를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 저장된_금액과_요청_금액이_다르면_결제_승인이_거부된다() {
+        // given
+        Long savedAmount = ThemeFixture.DEFAULT_PRICE;
+        preparePendingEntry("이프", paymentOrderRepository, "order-1", savedAmount);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirm("payment-key-1", "order-1", savedAmount + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제 금액이 일치하지 않습니다.");
+    }
+
+    @Test
+    void 토스_승인이_실패하면_엔트리는_PENDING으로_남고_예외가_전파된다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        when(tossPaymentGateway.confirm(any()))
+                .thenThrow(new TossPaymentException.AlreadyProcessed("이미 처리된 결제입니다."));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirm("payment-key-1", "order-1", amount))
+                .isInstanceOf(TossPaymentException.AlreadyProcessed.class);
+
+        Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
+        assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.PENDING);
     }
 }

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -51,6 +51,7 @@ class PaymentServiceTest {
                 reservationTimeRepository,
                 paymentOrderRepository,
                 null, // TossPaymentGateway — prepare() 테스트에서는 사용되지 않음
+                null, // ReservationService — prepare() 테스트에서는 사용되지 않음
                 TestDateTimes.fixedClock()
         );
         ReflectionTestUtils.setField(paymentService, "clientKey", TEST_CLIENT_KEY);

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
+import roomescape.client.TossConfirmResultUnknownException;
+import roomescape.client.TossConnectionException;
 import roomescape.client.TossPaymentException;
 import roomescape.client.TossPaymentGateway;
 import roomescape.client.dto.TossPaymentResponse;
 import roomescape.controller.client.dto.response.PreparePaymentResponse;
 import roomescape.domain.PaymentOrder;
+import roomescape.domain.PaymentOrderStatus;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationEntry;
 import roomescape.domain.ReservationStatus;
@@ -56,11 +59,12 @@ class PaymentServiceTest {
         this.themeRepository = new FakeThemeRepository();
         this.paymentOrderRepository = new FakePaymentOrderRepository();
         this.tossPaymentGateway = Mockito.mock(TossPaymentGateway.class);
+        ReservationQueryRepository reservationQueryRepository = Mockito.mock(ReservationQueryRepository.class);
         ReservationService reservationService = new ReservationService(
                 reservationRepository,
                 reservationTimeRepository,
                 themeRepository,
-                Mockito.mock(ReservationQueryRepository.class),
+                reservationQueryRepository,
                 TestDateTimes.fixedClock()
         );
         this.paymentService = new PaymentService(
@@ -70,9 +74,12 @@ class PaymentServiceTest {
                 paymentOrderRepository,
                 tossPaymentGateway,
                 reservationService,
+                reservationQueryRepository,
                 TestDateTimes.fixedClock()
         );
         ReflectionTestUtils.setField(paymentService, "clientKey", TEST_CLIENT_KEY);
+        // 운영 환경에서는 Spring이 self(트랜잭션 프록시)를 주입하지만, 여기서는 직접 생성하므로 자기 참조로 채운다.
+        ReflectionTestUtils.setField(paymentService, "self", paymentService);
     }
 
     private long preparePendingEntry(String name, PaymentOrderRepository paymentOrderRepositoryToSave, String orderId, Long amount) {
@@ -222,6 +229,97 @@ class PaymentServiceTest {
 
         Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
         assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.RESERVED);
+    }
+
+    @Test
+    void 결제_승인에_성공하면_PaymentOrder가_CONFIRMED와_paymentKey로_영속화된다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        TossPaymentResponse response = new TossPaymentResponse(
+                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
+        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+
+        // when
+        paymentService.confirm("payment-key-1", "order-1", amount);
+
+        // then
+        PaymentOrder saved = paymentOrderRepository.findByOrderId("order-1").orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(PaymentOrderStatus.CONFIRMED);
+        assertThat(saved.getPaymentKey()).isEqualTo("payment-key-1");
+    }
+
+    @Test
+    void 토스_승인_결과가_불명이면_PaymentOrder는_CONFIRM_RESULT_UNKNOWN으로_저장되고_엔트리는_PENDING으로_남으며_예외가_전파된다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        when(tossPaymentGateway.confirm(any()))
+                .thenThrow(new TossConfirmResultUnknownException(new RuntimeException("read timeout")));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirm("payment-key-1", "order-1", amount))
+                .isInstanceOf(TossConfirmResultUnknownException.class);
+
+        PaymentOrder saved = paymentOrderRepository.findByOrderId("order-1").orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(PaymentOrderStatus.CONFIRM_RESULT_UNKNOWN);
+
+        Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
+        assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.PENDING);
+    }
+
+    @Test
+    void 결제_실패_정리_시_PaymentOrder가_FAILED로_저장된다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+
+        // when
+        paymentService.cancel("order-1");
+
+        // then
+        PaymentOrder saved = paymentOrderRepository.findByOrderId("order-1").orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(PaymentOrderStatus.FAILED);
+    }
+
+    @Test
+    void 이미_확정된_결제는_뒤늦은_cancel_호출에도_FAILED로_덮어써지지_않는다() {
+        // given: confirm()까지 성공해 RESERVED + CONFIRMED 상태
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        TossPaymentResponse response = new TossPaymentResponse(
+                "payment-key-1", "order-1", "주문명", "DONE", amount, "카드", "2024-01-01T00:00:00");
+        when(tossPaymentGateway.confirm(any())).thenReturn(response);
+        paymentService.confirm("payment-key-1", "order-1", amount);
+
+        // when: 브라우저 뒤로가기 등으로 cancel이 뒤늦게 호출됨
+        paymentService.cancel("order-1");
+
+        // then: 결제/예약 상태가 그대로 유지된다
+        PaymentOrder saved = paymentOrderRepository.findByOrderId("order-1").orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(PaymentOrderStatus.CONFIRMED);
+
+        Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
+        assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.RESERVED);
+    }
+
+    @Test
+    void 토스_연결이_실패하면_PaymentOrder는_FAILED로_저장되고_엔트리는_PENDING으로_남으며_예외가_전파된다() {
+        // given
+        Long amount = ThemeFixture.DEFAULT_PRICE;
+        long entryId = preparePendingEntry("이프", paymentOrderRepository, "order-1", amount);
+        when(tossPaymentGateway.confirm(any()))
+                .thenThrow(new TossConnectionException(new RuntimeException("connect timeout")));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirm("payment-key-1", "order-1", amount))
+                .isInstanceOf(TossConnectionException.class);
+
+        PaymentOrder saved = paymentOrderRepository.findByOrderId("order-1").orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(PaymentOrderStatus.FAILED);
+
+        Reservation reservation = reservationRepository.findByEntryId(entryId).orElseThrow();
+        assertThat(reservation.findActiveEntry(entryId).getStatus()).isEqualTo(ReservationStatus.PENDING);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -306,6 +306,39 @@ class ReservationServiceTest {
                 .isEqualTo(ReservationStatus.DELETED);
     }
 
+    @Test
+    void PENDING_엔트리를_확정하면_RESERVED로_바뀌고_예약_결과가_반환된다() {
+        // given: PENDING 상태의 엔트리가 저장되어 있음
+        saveDefaultThemeAndTime();
+        ReservationTime time = ReservationTimeFixture.createDefault();
+        Theme theme = ThemeFixture.createThemeWithId();
+        LocalDate date = FIXED.toLocalDate().plusDays(1);
+        Reservation slot = Reservation.createSlot(date, theme, time);
+        slot.addPendingEntry("이프", ThemeFixture.DEFAULT_PRICE, FIXED);
+        Reservation saved = reservationRepository.save(slot);
+        long entryId = saved.findEntryByNameAndStatus("이프", ReservationStatus.PENDING).getId();
+
+        // when
+        ReservationResult result = reservationService.confirmPendingEntry(entryId);
+
+        // then
+        assertThat(result.entry().status()).isEqualTo("RESERVED");
+        assertThat(reservationRepository.findByEntryId(entryId).orElseThrow().findActiveEntry(entryId).getStatus())
+                .isEqualTo(ReservationStatus.RESERVED);
+    }
+
+    @Test
+    void PENDING_상태가_아닌_엔트리를_확정하려하면_예외가_발생한다() {
+        // given: 이미 RESERVED 상태인 엔트리
+        Reservation saved = reservationRepository.save(createDefaultReservationWithName("웨지"));
+        long entryId = reservedEntryId(saved);
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.confirmPendingEntry(entryId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("결제 중인 예약 정보를 찾을 수 없습니다.");
+    }
+
     private void saveDefaultThemeAndTime() {
         themeRepository.save(ThemeFixture.createDefaultTheme());
         reservationTimeRepository.save(ReservationTimeFixture.createDefault());

--- a/src/test/java/roomescape/service/fake/FakePaymentOrderRepository.java
+++ b/src/test/java/roomescape/service/fake/FakePaymentOrderRepository.java
@@ -23,6 +23,12 @@ public class FakePaymentOrderRepository implements PaymentOrderRepository {
     }
 
     @Override
+    public void update(PaymentOrder paymentOrder) {
+        storage.put(paymentOrder.getId(), paymentOrder);
+        orderIdIndex.put(paymentOrder.getOrderId(), paymentOrder);
+    }
+
+    @Override
     public Optional<PaymentOrder> findByOrderId(String orderId) {
         return Optional.ofNullable(orderIdIndex.get(orderId));
     }


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?


## 리뷰 포인트 
  1. 필드 손실 (paymentKey, orderName, method) — PaymentResult에는 이 3개 필드가 없음. 확인 결과 paymentKey는 이미 confirm() 호출 파라미터/PaymentOrder로 별도 관리되고 있어 손실이 아니지만, method(결제수단, 예: "카드")는 현재 코드베이스 어디에도 쓰이지 않아 누락돼도 컴파일/동작엔 문제 없음. 다만 향후 "결제 수단 표시" 같은 기능이 생기면 이 도메인 객체에 필드를 다시 추가해야 함 — 의도적 축소인지 확인 필요.
  2. PaymentConfirmResult.response 필드명 — 타입이 TossPaymentResponse에서 PaymentResult로 바뀌었는데 필드명은 그대로 response. 더 이상 "토스 응답"이 아니라 도메인 결과 객체이므로 이름이 약간 오해를 줄 수 있음 (paymentResult 등으로 리네이밍 고려 여지).
  3. PaymentGateway 인터페이스의 구현체가 현재 1개뿐 — 테스트 더블(Mockito mock) 외에 실제 구현은 TossPaymentGateway 하나라, 인터페이스 분리의 실익이 "테스트 용이성" 외에 당장은 크지 않음. 멀티 PG사 지원 계획이 없다면 과한 추상화로 보일 수도 있어 의도 공유 필요.
  4. 테스트는 기존 로직 검증을 모킹 대상만 교체했을 뿐, PaymentGateway 인터페이스 자체의 계약(예: TossPaymentGateway.confirm이 응답을 PaymentResult로 올바르게 매핑하는지)을 검증하는 단위 테스트는 없음 — 매핑 로직 자체에 대한 별도 테스트 추가 여부 검토 권장.
