### PR TITLE
[🚀 방탈출 예약 외부 API 연동 3단계] 마이찬(나의찬) 미션 제출합니다.

### DIFF
--- a/docs/01-feature/external_API/step2/05-pr-description.md
+++ b/docs/01-feature/external_API/step2/05-pr-description.md
@@ -1,0 +1,151 @@
+# PR Description — 타임아웃 / 멱등성 / 재시도 / 결제 내역
+
+## 구현 내용
+
+외부 결제 API(Toss Payments) 연동에서 발생할 수 있는 네트워크 불확실성을 안전하게 처리합니다.
+타임아웃 설정, 예외 분류, 멱등키, UNCERTAIN 상태, 재시도 정책, 결제 내역 조회를 구현했습니다.
+
+---
+
+## 1. 타임아웃 설정
+
+`jdk` 기반 HTTP 팩토리는 응답 바디 읽기 지연을 감지하지 못합니다.
+`SimpleClientHttpRequestFactory`를 명시적으로 사용해 connect/read 타임아웃을 모두 제어합니다.
+
+```properties
+toss.connect-timeout=3000   # 연결 타임아웃 (ms)
+toss.read-timeout=10000     # 읽기 타임아웃 (ms)
+```
+
+---
+
+## 2. 타임아웃 예외 분류
+
+`ResourceAccessException`의 원인 예외를 분석해 두 케이스를 다르게 처리합니다.
+
+| 예외 | 의미 | 처리 |
+|------|------|------|
+| `SocketTimeoutException("Read…")` | 토스가 처리했을 수도 있음 (불확실) | UNCERTAIN Payment 저장, 예약 PENDING 유지 |
+| `ConnectException` | 연결 자체가 안 됨 (미처리 확정) | 503 에러 반환 |
+
+---
+
+## 3. 멱등키 (Idempotency-Key)
+
+재시도 시 이중 승인을 방지하기 위해 토스 요청에 `Idempotency-Key: {orderId}` 헤더를 추가합니다.
+`orderId`는 예약 생성 시 발급된 UUID로 고정되므로, 재시도 횟수와 관계없이 토스는 첫 처리 결과를 동일하게 반환합니다.
+
+---
+
+## 4. PaymentStatus — UNCERTAIN 상태
+
+read timeout 발생 시 결제가 됐는지 모르는 상태이므로, 섣불리 취소하지 않습니다.
+
+```java
+public enum PaymentStatus {
+    CONFIRMED,   // 정상 승인
+    UNCERTAIN    // read timeout — 결과 불명확
+}
+```
+
+- 예약은 PENDING 유지 (CANCELLED로 바꾸면 결제된 사용자 피해)
+- Payment 레코드는 `status = UNCERTAIN`, `payment_key = NULL`로 저장
+- 사용자에게 202 응답과 함께 "결제 내역 확인" 안내
+
+---
+
+## 5. 슬롯 이중 confirm 방지
+
+자동 confirm 제거 이후, 동일 슬롯에 여러 PENDING 예약이 존재할 수 있습니다.
+두 사용자가 순차적으로 결제하면 슬롯에 CONFIRMED가 두 개 생기는 버그를 방지합니다.
+
+`confirmPayment()` 내 토스 API 호출 전에 슬롯 선점 여부를 검증합니다.
+
+```
+슬롯 isReserved == true → PAYMENT_SLOT_ALREADY_CONFIRMED (409)
+→ PaymentGateway.confirm() 미호출 (실제 결제 발생 X)
+```
+
+> 동시에 두 요청이 진입하는 레이스 컨디션은 DB 수준 락(`SELECT FOR UPDATE`)이 필요하며, 동시성 제어 단계에서 다룰 예정입니다.
+
+---
+
+## 6. 결제 내역 조회 API
+
+```
+GET /payment/history?name={사용자이름}
+```
+
+예약 목록과 각 예약에 연결된 결제 상태를 함께 반환합니다.
+결제 기록이 없는 예약(결제 전 상태)도 포함되며, `paymentStatus / paymentKey`는 null로 반환됩니다.
+
+---
+
+## 7. Spring Retry — 자동 재시도
+
+일시적인 네트워크 실패 시 자동으로 재시도합니다.
+
+### 예외 타입 분리
+
+`@Retryable`은 예외 타입으로 재시도 여부를 구분하므로 타입 자체를 나눕니다.
+
+```
+RetryablePaymentException (재시도 O)  ← read timeout, connect timeout
+CustomException           (재시도 X)  ← 카드 거절, 인증 오류 등 비즈니스 거절
+```
+
+### 재시도 정책
+
+- 최대 3회, 지수 백오프: 1초 → 2초 → 4초 + random jitter
+- 3회 소진 시 `@Recover`에서 `CustomException`으로 변환 → `PaymentService`가 에러 코드 타입에 따라 UNCERTAIN 저장 또는 에러 전파
+
+```
+confirm()  ← @Retryable
+    ├─ 성공 ────────────────────────────────► PaymentResult 반환
+    │
+    ├─ RetryablePaymentException (1회) ↓ 1초
+    ├─ RetryablePaymentException (2회) ↓ 2초
+    ├─ RetryablePaymentException (3회) → @Recover
+    │       read timeout  → CustomException(PAYMENT_READ_TIMEOUT)        → UNCERTAIN 저장
+    │       connect 실패  → CustomException(PAYMENT_CONNECTION_TIMEOUT)  → 503 에러
+    │
+    └─ CustomException (비즈니스 거절) → noRetryFor → 즉시 실패
+```
+
+---
+
+## 테스트
+
+### PaymentService 단위 테스트
+
+- read timeout → UNCERTAIN Payment 저장, 예약 PENDING 유지
+- connection timeout → 예외 전파
+- 슬롯 이미 선점 → `PAYMENT_SLOT_ALREADY_CONFIRMED`, 게이트웨이 미호출 확인
+- `getPaymentHistory` → CONFIRMED / UNCERTAIN / 결제없음 혼합 목록 반환
+
+### TossPaymentGateway 슬라이스 테스트
+
+- read timeout → `RetryablePaymentException(PAYMENT_READ_TIMEOUT)`
+- connect 실패 → `RetryablePaymentException(PAYMENT_CONNECTION_TIMEOUT)`
+
+### PaymentController 입력 검증 테스트
+
+- `name` 빈 문자열 → 400
+- `name` 파라미터 누락 → 400 (`MissingServletRequestParameterException` 핸들러 추가)
+
+---
+
+## 고민한 점
+
+**read timeout을 즉시 실패가 아닌 UNCERTAIN으로 처리하는 이유**
+
+토스 서버가 처리를 완료한 뒤 응답을 보내는 도중 타임아웃이 날 수 있습니다.
+이 상태에서 예약을 취소하면 "결제는 됐지만 예약이 없는" 상황이 발생합니다.
+UNCERTAIN으로 남겨 사용자가 결제 내역 페이지에서 직접 확인할 수 있도록 했습니다.
+
+**`@Retryable`에서 예외 타입을 나눈 이유**
+
+Spring Retry의 `retryFor`와 `noRetryFor`에 같은 타입을 동시에 지정할 수 없습니다.
+비즈니스 거절은 재시도해도 결과가 같으므로 즉시 실패해야 하고,
+네트워크 실패는 재시도할 가치가 있습니다.
+두 경우를 타입 자체로 구분(`RetryablePaymentException` vs `CustomException`)해 정책을 선언적으로 관리합니다.

--- a/docs/01-feature/external_API/step3/01-requirements.md
+++ b/docs/01-feature/external_API/step3/01-requirements.md
@@ -1,0 +1,51 @@
+미션 배경
+2단계에서 타임아웃과 멱등키로 느린 호출과 중복 승인을 막았다. 이번엔 호출량 상한(Rate Limit) 을 다룬다. 우리 서버는 같은 Rate Limit을 양쪽 방향에서 마주한다. 들어오는 요청이 몰리면 초과분을 429로 거부하고(서버 입장), 우리가 토스를 호출할 땐 상대 한도를 넘지 않도록 우리 호출량을 스스로 조절한다(클라이언트 입장). 그래도 429가 오면 Retry-After를 존중해 백오프 재시도한다. 알고리즘은 하나(토큰 버킷), 경계는 둘이다.
+
+TPS(Transactions Per Second): 초당 처리 트랜잭션 수 — 측정값. Rate Limit: "초당 N건까지" — 정책. 타임아웃이 성공 TPS를 지키는 것은2 단계 학습 테스트에서 측정으로 체감했다 — 이번엔 그 측정값에 정책으로 상한을 건다.
+토큰 버킷: capacity(허용 버스트)만큼 토큰이 차 있고 매초 refillPerSec(평균 TPS 상한)개씩 보충된다. 요청은 토큰 1개를 소비하고, 없으면 거부된다.
+시작 전 학습 테스트 learning-test-3-ratelimit을 먼저 푼다(TokenBucketRateLimiter, RateLimitInterceptor, RetryAfterInterceptor, OutboundRateLimitInterceptor).
+
+목표
+토큰 버킷 기반 Rate Limit을 HandlerInterceptor로 결제·예약 엔드포인트에 적용해, 초과 요청을 컨트롤러 호출 없이 429+Retry-After로 거부한다.
+ClientHttpRequestInterceptor로 토스의 429를 가로채 Retry-After 기반 백오프 재시도를 구현한다.
+같은 토큰 버킷을 나가는 호출(egress)에도 적용해, 한도를 넘는 호출은 외부로 보내지 않는다. 들어오는/나가는 Rate Limit이 같은 알고리즘·다른 방향임을 설명할 수 있다.
+들어오는/나가는 정책(rate-limit.*, outbound-rate-limit.*)을 application.yml로 외부화한다.
+요구사항
+1. 토큰 버킷 구현
+   capacity(허용 버스트)와 refillPerSec(평균 TPS 상한)을 가진 토큰 버킷을 직접 구현한다. 외부 의존성은 쓰지 않는다.
+
+보충은 "마지막 보충 이후 경과 시간 × refillPerSec"로 계산하되 capacity를 넘지 않는다.
+tryConsume(): 토큰 ≥1이면 1개 소비 후 통과(true), 없으면 거부(false).
+retryAfterSeconds(): 1개가 찰 때까지 필요한 초를 올림(Math.ceil) 으로 반환한다.
+시간 의존 로직은 System::nanoTime을 박지 말고 LongSupplier 가짜 시계를 주입해 결정적으로 테스트한다.
+동시 요청에서도 정확히 capacity개만 통과하도록 동시성을 안전하게 처리한다.
+2. 서버(게이트웨이) 관점 — 한도 초과 요청 거부
+   결제·예약 엔드포인트에 토큰 버킷을 HandlerInterceptor로 적용한다. preHandle에서 tryConsume()이 false면 컨트롤러를 호출하지 않고(false 반환), 응답을 429로 세팅하고 Retry-After 헤더에 retryAfterSeconds() 값(초)을 담는다. capacity/refillPerSec는 rate-limit.*로 외부화해 코드 수정 없이 거부 시점을 바꾼다.
+
+3. 클라이언트 관점 — 토스의 429에 백오프 재시도
+   토스 호출 RestClient에 ClientHttpRequestInterceptor를 등록한다. 응답이 429이고 시도 횟수가 maxAttempts 미만이면 Retry-After(초)만큼 대기 후 재시도한다. Retry-After가 없으면 짧은 고정 간격(기본 1초)으로 폴백한다. maxAttempts를 넘어도 429면 도메인 예외로 실패시킨다(무한 재시도 금지). 429는 아직 처리되지 않은 상태라 그냥 다시 보내도 안전하지만, 재시도는 2단계에서 도입한 주문당 고정 멱등키를 유지한 채 보낸다(read timeout처럼 "됐는지 모름"인 경우까지 중복 승인을 막는 전제).
+
+4. 클라이언트 관점 — 나가는 호출에 Rate Limit
+   2번의 토큰 버킷을 방향만 바꿔 나가는 호출에 적용한다. 한도를 넘겨 호출하면 어차피 429로 거부당하니, 보내기 전에 스스로 조절하는 게 낫다.
+
+3번과 같은 게이트웨이 RestClient에 인터셉터를 하나 더 등록한다(나가는 호출 한 곳에 Rate Limit·백오프가 함께 걸린다).
+호출 전 tryConsume()으로 토큰을 소비하고, 없으면 외부로 보내지 않고 OutboundRateLimitException으로 거부한다.
+들어오는 쪽(2번)과 똑같은 TokenBucketRateLimiter를 재사용한다. 나가는 한도는 outbound-rate-limit.*로 들어오는 쪽과 분리해 외부화한다.
+완료 기준
+한도 내 요청은 정상 처리되고, 초과 요청은 429+Retry-After로 거부된다(컨트롤러 미호출). 토큰 버킷은 가짜 시계 주입으로 결정적으로 테스트된다.
+들어오는(rate-limit.*)·나가는(outbound-rate-limit.*) 한도 모두 application.yml 값만 바꿔 코드 수정 없이 거부 시점이 달라진다.
+토스가 429+Retry-After를 주면 그만큼 대기 후 재시도해 최종 200을 받는다.
+Retry-After가 없으면 짧은 고정 간격(기본 1초)으로 폴백해 재시도한다. 재시도가 maxAttempts를 넘으면 도메인 예외로 실패한다.
+나가는 호출이 자체 한도를 넘으면 외부로 나가지 않고 거부되며, 토큰이 보충되면 다시 나간다.
+Q. PR 링크
+
+답변을 입력하세요...
+0/5000자
+
+더 생각해보기
+capacity를 키우면 순간 버스트가, refillPerSec를 키우면 평균 처리량이 어떻게 변하는가?
+들어오는 한도(우리 처리 용량)와 나가는 한도(상대가 우리에게 허용한 몫)를 늘 같은 값으로 두면 안 되는 이유는?
+나가는 쪽은 지금 한도 초과 시 즉시 거부(fail-fast)한다. 거부 대신 토큰이 찰 때까지 대기(블로킹) 시키는 방식과 비교하면 장단점은?(대기는 호출을 매끄럽게 흘리지만 스레드를 잡고 결정적 테스트가 어렵다.)
+read timeout(2단계) 재시도와 429 재시도는 무엇이 다른가("이미 처리됐을 수 있음" vs "아직 처리 안 됨")? 각각 어떤 안전장치가 필요한지 멱등성과 연결해 정리해보자.
+Rate Limit은 호출량(throughput) 을 다룬다. 외부가 연속으로 실패(5xx·타임아웃)할 때는 양과 무관하게 호출을 끊는 서킷 브레이커가 필요할 수 있다. Rate Limit과 무엇이 다르고 어떻게 보완하는가?
+Q

--- a/docs/01-feature/external_API/step3/02-implementation-plan.md
+++ b/docs/01-feature/external_API/step3/02-implementation-plan.md
@@ -1,0 +1,408 @@
+# Step3 구현 계획 — Rate Limit (토큰 버킷)
+
+---
+
+## 결론 먼저
+
+> 변경이 필요한 레이어는 4곳이다.
+> `TokenBucketRateLimiter` (핵심 알고리즘) →
+> `RateLimitInterceptor` (HandlerInterceptor — 들어오는 요청 제한) →
+> `RetryAfterInterceptor` (ClientHttpRequestInterceptor — 토스 429 재시도) →
+> `OutboundRateLimitInterceptor` (ClientHttpRequestInterceptor — 나가는 호출 제한)
+>
+> 알고리즘은 토큰 버킷 하나, 방향은 들어오는/나가는 둘이다.
+
+---
+
+## 현재 코드 상태 파악
+
+### 무엇이 없는가
+
+| 위치 | 없는 것 |
+|------|---------|
+| (신규) `TokenBucketRateLimiter` | 토큰 버킷 핵심 알고리즘 |
+| (신규) `RateLimitInterceptor` | 들어오는 요청 429 거부 HandlerInterceptor |
+| (신규) `RetryAfterInterceptor` | 토스 429 → Retry-After 백오프 재시도 |
+| (신규) `OutboundRateLimitInterceptor` | 나가는 호출 자체 Rate Limit |
+| `TossPaymentConfig` | RestClient에 인터셉터 등록 |
+| `WebMvcConfig` (또는 기존 설정 클래스) | HandlerInterceptor 경로 등록 |
+| `application.yml` | `rate-limit.*`, `outbound-rate-limit.*` 설정 외부화 |
+| `ErrorCode` | `RATE_LIMIT_EXCEEDED`, `OUTBOUND_RATE_LIMIT_EXCEEDED`, `TOSS_RATE_LIMIT_EXCEEDED` |
+
+### 무엇이 이미 있는가
+
+- `TossPaymentConfig` → `RestClient` 빈 설정, `SimpleClientHttpRequestFactory` 타임아웃 설정 완료.
+- step2에서 도입한 `@Retryable` (read timeout 재시도)는 토큰 버킷 재시도와 레이어가 다르므로 충돌하지 않는다.
+- `GlobalExceptionHandler` → `CustomException` 핸들러 완성. `RATE_LIMIT_EXCEEDED`는 자동으로 처리된다.
+
+---
+
+## 구현 순서
+
+### Step 1 — TokenBucketRateLimiter 구현
+
+요구사항의 핵심. 외부 의존성 없이 직접 구현한다.
+
+#### 설계
+
+```java
+public class TokenBucketRateLimiter {
+
+    private final long capacity;        // 최대 보유 가능 토큰 (버스트 허용량)
+    private final double refillPerSec;  // 초당 보충 토큰 수 (평균 TPS 상한)
+    private final LongSupplier clock;   // 가짜 시계 주입용 (System::nanoTime)
+
+    private double tokens;
+    private long lastRefillNanos;
+
+    public synchronized boolean tryConsume() {
+        refill();
+        if (tokens >= 1.0) {
+            tokens -= 1.0;
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized long retryAfterSeconds() {
+        refill();
+        // 1개가 찰 때까지 걸리는 시간 (초, 올림)
+        double secondsNeeded = (1.0 - tokens) / refillPerSec;
+        return (long) Math.ceil(secondsNeeded);
+    }
+
+    private void refill() {
+        long now = clock.getAsLong();
+        double elapsed = (now - lastRefillNanos) / 1_000_000_000.0;
+        tokens = Math.min(capacity, tokens + elapsed * refillPerSec);
+        lastRefillNanos = now;
+    }
+}
+```
+
+#### 핵심 결정사항
+
+**왜 `double tokens`인가?**
+`long`으로 정수 토큰만 관리하면 보충 주기가 1초 미만일 때 매번 0이 되어
+소수점 토큰 손실이 쌓인다. `double`로 분수 토큰을 유지해야 정확하다.
+
+**왜 `synchronized`인가?**
+`tryConsume()`과 `refill()`은 read-modify-write 시퀀스다.
+`AtomicLong`으로는 두 필드(`tokens`, `lastRefillNanos`)의 복합 갱신을 원자적으로 보장하기 어렵다.
+성능보다 정확성이 중요한 상황이므로 `synchronized`가 적합하다.
+
+**가짜 시계(LongSupplier) 주입 이유**
+`System.nanoTime()`을 하드코딩하면 "1초 경과 후 토큰 1개 보충" 같은 시나리오를
+실제로 1초를 기다리지 않고 테스트할 수 없다.
+`LongSupplier`를 생성자로 주입하면 테스트에서 시간을 자유롭게 조작할 수 있다.
+
+```java
+// 프로덕션
+new TokenBucketRateLimiter(capacity, refillPerSec, System::nanoTime);
+
+// 테스트 (가짜 시계)
+long[] now = { 0L };
+TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(5, 2.0, () -> now[0]);
+now[0] += 1_000_000_000L; // 1초 경과
+```
+
+---
+
+### Step 2 — ErrorCode 추가
+
+```java
+// 들어오는 요청 초과 (우리 서버가 429 반환)
+RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
+
+// 나가는 호출 초과 (우리가 스스로 차단)
+OUTBOUND_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "외부 API 호출 한도를 초과했습니다."),
+
+// 토스가 429를 maxAttempts 이상 반환
+TOSS_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "결제 서버의 요청 한도를 초과했습니다. 잠시 후 다시 시도해 주세요."),
+```
+
+---
+
+### Step 3 — 설정 외부화 (application.yml)
+
+`application.properties`에서 `application.yml`로 전환하거나,
+rate limit 설정만 `application.yml`에 추가한다.
+
+```yaml
+rate-limit:
+  capacity: 10         # 최대 버스트 허용량
+  refill-per-sec: 5    # 초당 평균 TPS 상한
+
+outbound-rate-limit:
+  capacity: 5
+  refill-per-sec: 3
+
+toss:
+  retry:
+    max-attempts: 3    # 429 재시도 최대 횟수
+    fallback-wait-seconds: 1  # Retry-After 헤더 없을 때 대기 시간
+```
+
+`@ConfigurationProperties`로 바인딩하면 `@Value`보다 타입 안전하게 관리할 수 있다.
+
+```java
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(long capacity, double refillPerSec) {}
+```
+
+---
+
+### Step 4 — RateLimitInterceptor (HandlerInterceptor)
+
+들어오는 요청을 제한한다. 컨트롤러 호출 없이 `preHandle`에서 즉시 거부한다.
+
+```java
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        if (!rateLimiter.tryConsume()) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setHeader("Retry-After", String.valueOf(rateLimiter.retryAfterSeconds()));
+            response.getWriter().write("요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.");
+            return false;  // 컨트롤러 미호출
+        }
+        return true;
+    }
+}
+```
+
+**WebMvcConfigurer로 경로 등록:**
+
+```java
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/payment/**", "/reservations/**");
+    }
+}
+```
+
+요구사항: "결제·예약 엔드포인트에 적용"
+
+---
+
+### Step 5 — RetryAfterInterceptor (ClientHttpRequestInterceptor)
+
+토스가 429를 반환하면 `Retry-After` 헤더를 파싱해 대기 후 재시도한다.
+
+```java
+public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
+
+    private final int maxAttempts;
+    private final long fallbackWaitSeconds;
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            ClientHttpResponse response = execution.execute(request, body);
+
+            if (response.getStatusCode().value() != 429) {
+                return response;  // 정상 또는 다른 에러 → 상위로 위임
+            }
+
+            if (attempt >= maxAttempts) {
+                throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+            }
+
+            long waitSeconds = parseRetryAfter(response);
+            Thread.sleep(waitSeconds * 1000);
+            response.close();
+        }
+
+        throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+    }
+
+    private long parseRetryAfter(ClientHttpResponse response) {
+        String header = response.getHeaders().getFirst("Retry-After");
+        if (header == null) {
+            return fallbackWaitSeconds;  // 헤더 없으면 기본값(1초)
+        }
+        return Long.parseLong(header);
+    }
+}
+```
+
+**핵심 결정사항**
+
+429는 "아직 처리 안 됨" 확정 상태다.
+read timeout과 달리 재시도해도 이중 결제 위험이 없다.
+그러나 멱등키(`Idempotency-Key: orderId`)는 step2에서 이미 고정 발급되어 있으므로,
+재시도 시에도 동일 키가 유지된다.
+
+---
+
+### Step 6 — OutboundRateLimitInterceptor (ClientHttpRequestInterceptor)
+
+나가는 호출이 한도를 초과하면 외부로 보내지 않고 즉시 거부한다.
+
+```java
+public class OutboundRateLimitInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        if (!rateLimiter.tryConsume()) {
+            throw new CustomException(ErrorCode.OUTBOUND_RATE_LIMIT_EXCEEDED);
+        }
+        return execution.execute(request, body);
+    }
+}
+```
+
+**TossPaymentConfig RestClient에 인터셉터 등록:**
+
+```java
+return RestClient.builder()
+        .requestFactory(factory)
+        .baseUrl("https://api.tosspayments.com")
+        .defaultHeader("Authorization", "Basic " + encoded)
+        .defaultHeader("Content-Type", "application/json")
+        .requestInterceptors(interceptors -> {
+            interceptors.add(outboundRateLimitInterceptor);  // 먼저: 보내기 전 자체 한도 확인
+            interceptors.add(retryAfterInterceptor);          // 다음: 토스의 429 처리
+        })
+        .build();
+```
+
+인터셉터 순서가 중요하다.
+`outbound` → `retryAfter` 순서여야 "자체 한도 초과 시 외부로 나가지 않음"이 보장된다.
+
+---
+
+## 변경 파일 목록 요약
+
+| 파일 | 변경 유형 | 내용 |
+|------|----------|------|
+| `application.yml` | 추가/전환 | `rate-limit.*`, `outbound-rate-limit.*`, `toss.retry.*` |
+| `ErrorCode.java` | 추가 | `RATE_LIMIT_EXCEEDED`, `OUTBOUND_RATE_LIMIT_EXCEEDED`, `TOSS_RATE_LIMIT_EXCEEDED` |
+| `TokenBucketRateLimiter.java` | 신규 | 토큰 버킷 알고리즘 (LongSupplier 시계 주입) |
+| `RateLimitInterceptor.java` | 신규 | HandlerInterceptor — 들어오는 요청 429 거부 |
+| `RetryAfterInterceptor.java` | 신규 | ClientHttpRequestInterceptor — 토스 429 재시도 |
+| `OutboundRateLimitInterceptor.java` | 신규 | ClientHttpRequestInterceptor — 나가는 호출 Rate Limit |
+| `WebConfig.java` (또는 기존 설정) | 수정 | `RateLimitInterceptor` 경로 등록 |
+| `TossPaymentConfig.java` | 수정 | RestClient에 두 인터셉터 등록 |
+
+---
+
+## 테스트 전략
+
+### TokenBucketRateLimiter — 단위 테스트 (가짜 시계)
+
+```java
+long[] now = { 0L };
+LongSupplier clock = () -> now[0];
+TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(3, 2.0, clock);
+
+// capacity만큼만 즉시 통과
+assertThat(limiter.tryConsume()).isTrue();  // 3 → 2
+assertThat(limiter.tryConsume()).isTrue();  // 2 → 1
+assertThat(limiter.tryConsume()).isTrue();  // 1 → 0
+assertThat(limiter.tryConsume()).isFalse(); // 0 → 거부
+
+// 1초 경과 후 2개 보충
+now[0] += 1_000_000_000L;
+assertThat(limiter.tryConsume()).isTrue();  // 2 → 1
+assertThat(limiter.tryConsume()).isTrue();  // 1 → 0
+assertThat(limiter.tryConsume()).isFalse(); // 거부
+```
+
+검증 포인트:
+- `capacity` 개까지만 즉시 소비 가능
+- 시간 경과 후 `refillPerSec * elapsed`만큼 보충 (capacity 초과 불가)
+- `retryAfterSeconds()` → 올림 값 검증
+- 동시 요청에서 정확히 `capacity`개만 통과
+
+### RateLimitInterceptor — MockMvc 테스트
+
+```java
+// capacity = 1로 설정
+// 첫 번째 요청: 200
+// 두 번째 요청: 429 + Retry-After 헤더 확인
+mockMvc.perform(post("/payment/confirm")...)
+    .andExpect(status().isTooManyRequests())
+    .andExpect(header().exists("Retry-After"));
+```
+
+### RetryAfterInterceptor — MockRestServiceServer 테스트
+
+```java
+// 1차: 429 + Retry-After: 1
+// 2차: 200 정상 응답
+mockServer.expect(requestTo(CONFIRM_URL)).andRespond(
+    withStatus(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", "1")
+);
+mockServer.expect(requestTo(CONFIRM_URL)).andRespond(withSuccess(...));
+// → 최종 성공 검증
+
+// maxAttempts 초과 시 TOSS_RATE_LIMIT_EXCEEDED 예외 검증
+```
+
+### OutboundRateLimitInterceptor — 단위 테스트
+
+```java
+// tryConsume() false일 때 execution.execute() 미호출 검증
+// CustomException(OUTBOUND_RATE_LIMIT_EXCEEDED) 발생 검증
+```
+
+---
+
+## 공부해볼 것
+
+### 1. capacity vs refillPerSec 트레이드오프
+
+`capacity`를 키우면 순간 버스트를 더 허용한다 (ex: 짧은 시간에 10개 요청 가능).
+`refillPerSec`을 키우면 지속 처리량(평균 TPS)이 늘어난다.
+**들어오는 한도와 나가는 한도를 같은 값으로 두면 안 되는 이유:**
+우리의 처리 용량(들어오는)과 토스가 우리에게 허용한 몫(나가는)은 다른 자원이다.
+들어오는 요청 하나가 항상 토스 호출 하나로 이어지지 않을 수 있고,
+토스의 Rate Limit은 우리 내부 처리량과 무관하게 토스가 정한다.
+
+### 2. 429 재시도 vs read timeout 재시도의 차이
+
+| 구분 | read timeout (step2) | 429 (step3) |
+|------|---------------------|-------------|
+| 처리 여부 | 모름 (불확실) | 안 됨 (확정) |
+| 안전장치 | 멱등키 (이중 승인 방지) | 없어도 안전, 그래도 멱등키 유지 |
+| 재시도 시기 | 즉시 (backoff 후) | Retry-After 대기 후 |
+
+### 3. fail-fast vs blocking 대기
+
+나가는 Rate Limit이 초과되면 현재 설계는 즉시 거부(fail-fast)한다.
+대안: 토큰이 찰 때까지 `Thread.sleep()`으로 블로킹 대기.
+- 블로킹: 요청이 매끄럽게 흘러가지만 스레드를 잡고 있어 스레드 풀 고갈 위험
+- fail-fast: 스레드를 즉시 반환하지만 호출자가 에러를 직접 처리해야 함
+- Spring의 스레드 모델(tomcat thread per request)에서는 블로킹이 위험하다.
+
+### 4. Rate Limit vs 서킷 브레이커
+
+Rate Limit은 **호출량(throughput)** 을 제어한다 → "초당 N건만 허용".
+서킷 브레이커는 **연속 실패(failure rate)** 를 감지한다 → "실패율이 X%를 넘으면 차단".
+Rate Limit이 있어도 토스가 지속적으로 5xx를 반환하면 무의미한 호출이 계속된다.
+서킷 브레이커(Resilience4j CircuitBreaker)가 이를 보완한다.
+
+### 5. 토큰 버킷 vs 슬라이딩 윈도우 카운터
+
+| 알고리즘 | 버스트 허용 | 구현 복잡도 | 정확도 |
+|---------|------------|------------|--------|
+| 토큰 버킷 | capacity만큼 | 낮음 | 보통 |
+| 고정 윈도우 카운터 | 경계 시점 2배 허용 | 매우 낮음 | 낮음 |
+| 슬라이딩 윈도우 로그 | 없음 | 높음 (메모리 많음) | 높음 |
+| 슬라이딩 윈도우 카운터 | 소량 | 중간 | 높음 |
+
+토큰 버킷은 구현이 단순하고 버스트를 자연스럽게 허용해 API Rate Limit에 가장 많이 쓰인다.

--- a/docs/01-feature/external_API/step3/03-step1-token-bucket.md
+++ b/docs/01-feature/external_API/step3/03-step1-token-bucket.md
@@ -1,0 +1,288 @@
+# Step 1 — TokenBucketRateLimiter 구현 정리
+
+---
+
+## 무엇을 만들었는가
+
+토큰 버킷(Token Bucket) 알고리즘을 직접 구현했다.
+외부 라이브러리 없이, 가짜 시계를 주입받아 결정적으로 테스트 가능한 Rate Limiter다.
+
+```
+src/main/java/roomescape/global/ratelimit/TokenBucketRateLimiter.java
+src/test/java/roomescape/global/ratelimit/TokenBucketRateLimiterTest.java
+```
+
+---
+
+## 토큰 버킷 알고리즘이란
+
+**비유**: 양동이(버킷)에 토큰(동전)이 담겨 있다.
+- 요청이 오면 토큰 1개를 꺼낸다 → 요청 통과
+- 토큰이 없으면 요청을 거부한다
+- 시간이 지나면 토큰이 일정 속도로 다시 채워진다
+
+**두 개의 파라미터가 의미하는 것:**
+
+| 파라미터 | 역할 | 비유 |
+|---------|------|------|
+| `capacity` | 버킷 크기 (최대 보유 토큰 수) | 양동이 크기 → 순간 버스트 허용량 |
+| `refillPerSec` | 초당 보충 속도 | 수도꼭지 속도 → 평균 TPS 상한 |
+
+```
+capacity = 10, refillPerSec = 5 이라면:
+
+초기: 토큰 10개 (버스트: 순간에 10개 요청 가능)
+1초 후: 빈 상태에서 5개 보충 (지속 처리량: 초당 5건)
+2초 후: 5개 → 10개 (capacity 상한)
+```
+
+---
+
+## 코드 구조 설명
+
+```java
+public class TokenBucketRateLimiter {
+
+    private final long capacity;       // 양동이 크기
+    private final double refillPerSec; // 초당 보충 속도
+    private final LongSupplier clock;  // 시계 (나노초 단위)
+
+    private double tokens;             // 현재 토큰 수
+    private long lastRefillNanos;      // 마지막 보충 시각
+```
+
+### tryConsume() — 토큰 소비
+
+```java
+public synchronized boolean tryConsume() {
+    refill();           // 1. 경과 시간만큼 먼저 보충
+    if (tokens >= 1.0) {
+        tokens -= 1.0;  // 2. 토큰 1개 소비
+        return true;    // 3. 통과
+    }
+    return false;       // 4. 토큰 없으면 거부
+}
+```
+
+### refill() — 보충 계산
+
+```java
+private void refill() {
+    long now = clock.getAsLong();
+    double elapsed = (now - lastRefillNanos) / 1_000_000_000.0; // 경과 초
+    tokens = Math.min(capacity, tokens + elapsed * refillPerSec); // 보충 (capacity 초과 불가)
+    lastRefillNanos = now;
+}
+```
+
+경과 시간(초) × 초당 보충 속도 = 보충할 토큰 수
+
+### retryAfterSeconds() — 대기 시간 계산
+
+```java
+public synchronized long retryAfterSeconds() {
+    refill();
+    double secondsNeeded = (1.0 - tokens) / refillPerSec;
+    return (long) Math.ceil(secondsNeeded); // 올림
+}
+```
+
+"1개가 차려면 얼마나 기다려야 하는가"를 초 단위 올림으로 반환한다.
+클라이언트에게 `Retry-After` 헤더로 내려주는 값이다.
+
+---
+
+## 왜 이렇게 설계했는가
+
+### 1. `double tokens` — 왜 정수가 아닌가
+
+`long`으로 정수 토큰만 관리하면 보충 시 소수점이 버려진다.
+
+```
+refillPerSec = 2.0, 0.4초마다 tryConsume() 호출
+
+long 방식:
+  0.4초 경과 → 0.4 * 2.0 = 0.8 → 정수로 버리면 0
+  0.4초 경과 → 또 0.8 → 정수로 버리면 0
+  → 영원히 토큰이 안 생김 (버그!)
+
+double 방식:
+  0.4초 경과 → tokens += 0.8 → 0.8
+  0.2초 경과 → tokens += 0.4 → 1.2 → 통과 가능
+  → 정확하게 동작
+```
+
+### 2. `synchronized` — 왜 AtomicLong이 아닌가
+
+`tokens`와 `lastRefillNanos` 두 필드를 동시에 일관되게 바꿔야 한다.
+
+```
+tryConsume()의 실행 순서:
+  1. refill() → lastRefillNanos 읽기
+  2. tokens 계산
+  3. tokens 수정
+  4. lastRefillNanos 수정
+
+AtomicLong으로는 두 필드의 복합 갱신을 원자적으로 보장할 수 없다.
+스레드 A가 1~2 사이에 끼어들면 잘못된 값으로 계산할 수 있다.
+→ synchronized로 메서드 전체를 임계 구역으로 잠근다.
+```
+
+### 3. `LongSupplier clock` — 왜 System.nanoTime()을 직접 안 쓰는가
+
+`System.nanoTime()`을 하드코딩하면 "1초 경과 후 2개 보충"을 테스트하려면
+실제로 1초를 기다려야 한다. 테스트가 느려지고 불안정해진다.
+
+```java
+// 하드코딩 — 테스트 불가능
+private long lastRefillNanos = System.nanoTime();
+
+// 주입 — 가짜 시계로 테스트 가능
+private final LongSupplier clock;
+private long lastRefillNanos = clock.getAsLong();
+```
+
+테스트에서는 `long[] now = {0L}`으로 가짜 시계를 만들고,
+`now[0] += 1_000_000_000L`으로 1초를 즉시 경과시킨다.
+
+---
+
+## 테스트 설계 포인트
+
+### 가짜 시계 패턴
+
+```java
+long[] now = {0L};                              // 배열로 감싸야 람다 안에서 수정 가능
+TokenBucketRateLimiter limiter =
+    new TokenBucketRateLimiter(5, 2.0, () -> now[0]);
+
+now[0] += 1_000_000_000L; // 1초 경과
+```
+
+**왜 `long[]` 배열인가?**
+Java 람다에서 외부 변수를 캡처하려면 `effectively final`이어야 한다.
+`long now`는 `now++`로 수정할 수 없지만,
+`long[] now`는 배열 자체는 final이고 내부 값(`now[0]`)은 변경 가능하다.
+
+### 동시성 테스트 패턴 — CountDownLatch
+
+```java
+CountDownLatch startLatch = new CountDownLatch(1); // 출발 신호탄
+CountDownLatch doneLatch  = new CountDownLatch(20); // 완료 대기
+
+// 20개 스레드 준비
+executor.submit(() -> {
+    startLatch.await(); // 출발 신호 대기
+    if (limiter.tryConsume()) successCount.incrementAndGet();
+    doneLatch.countDown();
+});
+
+startLatch.countDown(); // 동시 출발
+doneLatch.await();      // 전원 완료 대기
+```
+
+- `CountDownLatch(1)`: 신호탄 역할. `countDown()` 한 번에 대기 중인 스레드 전체 깨움
+- `CountDownLatch(20)`: 완료 카운터. 20개 스레드가 다 끝날 때까지 메인 스레드 대기
+- `AtomicInteger successCount`: 스레드 간 공유 카운터. `++` 연산이 원자적
+
+---
+
+## 공부해볼 개념들
+
+### 1. Rate Limit 알고리즘 비교
+
+| 알고리즘 | 원리 | 버스트 허용 | 구현 난이도 |
+|---------|------|------------|------------|
+| **토큰 버킷** (이번 구현) | 토큰 소비/보충 | O (capacity만큼) | 낮음 |
+| 고정 윈도우 카운터 | N초마다 카운터 리셋 | 경계 시점에 2배 허용 | 매우 낮음 |
+| 슬라이딩 윈도우 로그 | 요청 시각 목록 유지 | X | 높음 (메모리 많음) |
+| 슬라이딩 윈도우 카운터 | 이전 윈도우 비율 반영 | 소량 | 중간 |
+
+토큰 버킷이 API Rate Limit에 가장 많이 쓰이는 이유:
+- 버스트를 자연스럽게 허용 (capacity)
+- 평균 처리량을 보장 (refillPerSec)
+- 구현이 단순
+
+### 2. 동시성 제어 기법
+
+이번에 `synchronized`를 사용했지만, Java에는 다양한 동시성 도구가 있다.
+
+**synchronized 키워드**
+```java
+public synchronized boolean tryConsume() { ... }
+// 이 메서드를 호출하는 스레드는 객체의 모니터 락을 획득
+// 한 번에 한 스레드만 진입 가능
+```
+
+**대안들:**
+- `ReentrantLock`: synchronized보다 유연 (타임아웃, 조건 변수 등)
+- `AtomicLong`: 단일 숫자의 원자적 연산에 적합 (복합 연산엔 부적합)
+- `StampedLock`: 읽기/쓰기 분리가 필요할 때 (읽기가 압도적으로 많은 경우)
+
+**synchronized의 한계:**
+- 스레드가 락을 기다리는 동안 블로킹 (CPU는 놀고 있음)
+- 락 경합이 심할 때 성능 저하
+- 하지만 Rate Limiter처럼 "정확성이 성능보다 중요"한 경우엔 적합
+
+### 3. Java 시간 API
+
+이번 구현에서 `System.nanoTime()`을 사용하는 이유:
+
+| API | 단위 | 용도 |
+|-----|------|------|
+| `System.currentTimeMillis()` | ms | 벽시계 시간 (날짜/시각) |
+| `System.nanoTime()` | ns | 경과 시간 측정 (절대값 의미 없음) |
+| `Instant.now()` | ns | 벽시계 + 나노초 정밀도 |
+
+Rate Limiter는 "몇 시인지"가 아니라 "얼마나 지났는지"가 중요하므로
+`System.nanoTime()`이 적합하다.
+
+`nanoTime()`은 절대값이 의미 없고 두 값의 차이만 의미 있다.
+그래서 `now - lastRefillNanos`로 경과 시간을 계산한다.
+
+### 4. 함수형 인터페이스 — LongSupplier
+
+`LongSupplier`는 Java 표준 함수형 인터페이스다.
+
+```java
+@FunctionalInterface
+public interface LongSupplier {
+    long getAsLong();
+}
+```
+
+`Supplier<Long>`과 비슷하지만 오토박싱(Long ↔ long) 비용이 없다.
+`System::nanoTime`은 `long`을 반환하는 메서드이므로 `LongSupplier`에 딱 맞는다.
+
+```java
+LongSupplier realClock  = System::nanoTime;   // 프로덕션
+LongSupplier fakeClock  = () -> now[0];        // 테스트
+```
+
+### 5. 테스트에서 외부 의존성을 주입하는 패턴
+
+이번에 배운 핵심 패턴: **시간을 주입 가능하게 만들기**
+
+시간, 난수, 외부 API처럼 "테스트에서 제어하기 어려운 것"은
+생성자로 주입받으면 테스트에서 가짜로 교체할 수 있다.
+
+```java
+// 제어 불가능한 코드
+public class RateLimiter {
+    private long lastRefill = System.nanoTime(); // 하드코딩
+}
+
+// 주입으로 제어 가능
+public class RateLimiter {
+    private final LongSupplier clock;
+    private long lastRefill;
+
+    public RateLimiter(LongSupplier clock) {
+        this.clock = clock;
+        this.lastRefill = clock.getAsLong();
+    }
+}
+```
+
+이 패턴은 스프링의 DI(의존성 주입)와 같은 원리다.
+의존하는 것을 외부에서 주입받으면 테스트가 쉬워지고 결합도가 낮아진다.

--- a/docs/01-feature/external_API/step3/04-step2-error-code.md
+++ b/docs/01-feature/external_API/step3/04-step2-error-code.md
@@ -1,0 +1,143 @@
+# Step 2 — ErrorCode 추가 정리
+
+---
+
+## 무엇을 만들었는가
+
+Rate Limit 관련 에러 코드 3개를 `ErrorCode` enum에 추가했다.
+
+```
+src/main/java/roomescape/global/exception/ErrorCode.java
+```
+
+추가된 코드:
+
+```java
+RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
+OUTBOUND_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "외부 API 호출 한도를 초과했습니다."),
+TOSS_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "결제 서버의 요청 한도를 초과했습니다. 잠시 후 다시 시도해 주세요.");
+```
+
+---
+
+## 세 코드가 각각 어떤 상황에서 쓰이는가
+
+| ErrorCode | 방향 | 발생 위치 | 의미 |
+|-----------|------|----------|------|
+| `RATE_LIMIT_EXCEEDED` | 들어오는 요청 | `RateLimitInterceptor` | 우리 서버가 클라이언트 요청을 429로 거부 |
+| `OUTBOUND_RATE_LIMIT_EXCEEDED` | 나가는 호출 | `OutboundRateLimitInterceptor` | 우리가 토스 호출 전에 스스로 차단 |
+| `TOSS_RATE_LIMIT_EXCEEDED` | 나가는 호출 응답 | `RetryAfterInterceptor` | 토스가 우리에게 429 반환, 재시도 소진 |
+
+```
+클라이언트 → [RateLimitInterceptor] → 우리 서버 → [OutboundRateLimitInterceptor] → 토스
+                    ↑                                            ↑                      ↓
+          RATE_LIMIT_EXCEEDED                    OUTBOUND_RATE_LIMIT_EXCEEDED    429 응답
+                                                                          ↓
+                                                              [RetryAfterInterceptor]
+                                                                          ↓ 재시도 소진
+                                                              TOSS_RATE_LIMIT_EXCEEDED
+```
+
+---
+
+## 왜 HTTP 상태 코드 429인가
+
+HTTP 표준(RFC 6585)에서 정의한 "Too Many Requests"다.
+클라이언트가 "요청을 거부당한 게 아니라, 너무 많이 보냈다"는 신호다.
+
+```
+400 Bad Request    — 요청 자체가 잘못됨
+401 Unauthorized   — 인증 없음
+403 Forbidden      — 권한 없음
+404 Not Found      — 리소스 없음
+429 Too Many Requests — 요청 횟수 초과  ← 이번 단계
+503 Service Unavailable — 서버 일시 불가
+```
+
+429와 함께 `Retry-After` 헤더를 보내는 게 관례다.
+"N초 후에 다시 시도해라"는 힌트를 클라이언트에게 준다.
+
+---
+
+## 기존 에러 코드와 비교해서 보는 설계 패턴
+
+```java
+// 같은 HTTP 429지만 ErrorCode를 나눈 이유
+RATE_LIMIT_EXCEEDED          // 우리가 클라이언트에게
+OUTBOUND_RATE_LIMIT_EXCEEDED // 우리가 스스로 차단
+TOSS_RATE_LIMIT_EXCEEDED     // 토스가 우리에게
+```
+
+세 상황 모두 HTTP 상태 코드는 429지만, **발생 원인과 처리 방법이 다르다.**
+
+- `RATE_LIMIT_EXCEEDED` → 클라이언트에게 429 + Retry-After 응답
+- `OUTBOUND_RATE_LIMIT_EXCEEDED` → 우리 서버 내부에서 처리 (GlobalExceptionHandler → 클라이언트에게 503 or 429)
+- `TOSS_RATE_LIMIT_EXCEEDED` → 재시도 소진 후 클라이언트에게 429 응답
+
+에러 코드를 세분화하면:
+1. 로그에서 "왜 실패했는지" 구분할 수 있다
+2. 에러 코드별로 모니터링 알람을 다르게 설정할 수 있다
+3. 클라이언트에게 다른 메시지를 보낼 수 있다
+
+---
+
+## 공부해볼 개념들
+
+### 1. HTTP 상태 코드 체계
+
+| 범위 | 의미 | 예시 |
+|------|------|------|
+| 1xx | 정보 | 100 Continue |
+| 2xx | 성공 | 200 OK, 201 Created, 202 Accepted |
+| 3xx | 리다이렉트 | 301 Moved, 302 Found |
+| 4xx | 클라이언트 오류 | 400 Bad Request, 401, 403, 404, 429 |
+| 5xx | 서버 오류 | 500 Internal Server Error, 503 Service Unavailable |
+
+**429와 503의 차이:**
+- 429: 요청을 너무 많이 보냈다 (클라이언트 책임)
+- 503: 서버가 현재 처리 불가 (서버 책임)
+
+Rate Limit 초과는 클라이언트가 너무 많이 보낸 것이므로 429가 맞다.
+
+### 2. Retry-After 헤더
+
+RFC 7231에서 정의한 표준 HTTP 헤더다.
+429, 503 응답에 함께 내려보내며, 클라이언트에게 언제 재시도할지 알려준다.
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 3          ← 3초 후 재시도
+Content-Type: application/json
+
+{ "message": "요청이 너무 많습니다." }
+```
+
+값 형식:
+- 정수(초): `Retry-After: 30` → 30초 후 재시도
+- 날짜: `Retry-After: Wed, 21 Oct 2025 07:28:00 GMT` → 특정 시각 이후 재시도
+
+### 3. 에러 코드를 enum으로 관리하는 이유
+
+에러 코드를 흩어진 문자열로 관리하면:
+
+```java
+// 나쁜 예: 에러 코드가 흩어짐
+throw new RuntimeException("요청이 너무 많습니다.");
+response.setStatus(429);
+```
+
+문자열이 여러 곳에 복사되면 오타가 생기고, 변경 시 모든 곳을 찾아야 한다.
+
+enum으로 관리하면:
+```java
+// 좋은 예: 한 곳에서 관리
+RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.")
+
+// 사용처
+throw new CustomException(ErrorCode.RATE_LIMIT_EXCEEDED);
+// → HTTP 상태, 메시지, 로그 키 모두 한 곳에서 결정됨
+```
+
+- 컴파일 타임에 오타를 잡을 수 있다
+- HTTP 상태 코드와 메시지를 에러 코드와 함께 선언해 일관성을 보장한다
+- `GlobalExceptionHandler`가 `CustomException` 하나만 처리하면 된다

--- a/docs/01-feature/external_API/step3/05-step3-config-properties.md
+++ b/docs/01-feature/external_API/step3/05-step3-config-properties.md
@@ -1,0 +1,198 @@
+# Step 3 — 설정 외부화 정리
+
+---
+
+## 무엇을 만들었는가
+
+Rate Limit 관련 설정 값을 코드 밖으로 꺼내고,
+`TokenBucketRateLimiter` 빈 두 개(inbound/outbound)를 Spring 컨테이너에 등록했다.
+
+```
+src/main/resources/application.properties         ← 설정값 추가
+src/main/java/.../ratelimit/RateLimitProperties.java
+src/main/java/.../ratelimit/OutboundRateLimitProperties.java
+src/main/java/.../ratelimit/TossRetryProperties.java
+src/main/java/.../config/RateLimitConfig.java
+```
+
+---
+
+## 추가된 설정값
+
+```properties
+# 들어오는 요청 Rate Limit
+rate-limit.capacity=10
+rate-limit.refill-per-sec=5
+
+# 나가는 호출 Rate Limit
+outbound-rate-limit.capacity=5
+outbound-rate-limit.refill-per-sec=3
+
+# 토스 429 재시도
+toss.retry.max-attempts=3
+toss.retry.fallback-wait-seconds=1
+```
+
+코드를 바꾸지 않고 이 값만 바꾸면 Rate Limit 정책이 달라진다.
+
+---
+
+## @ConfigurationProperties vs @Value
+
+기존 코드(`TossPaymentConfig`)는 `@Value`를 사용했다.
+
+```java
+// @Value 방식 (기존)
+@Value("${toss.connect-timeout}")
+private int connectTimeout;
+
+@Value("${toss.read-timeout}")
+private int readTimeout;
+```
+
+이번엔 `@ConfigurationProperties`를 사용했다.
+
+```java
+// @ConfigurationProperties 방식 (이번)
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(long capacity, double refillPerSec) {}
+```
+
+| 구분 | `@Value` | `@ConfigurationProperties` |
+|------|----------|---------------------------|
+| 선언 위치 | 필드마다 | 클래스 하나에 묶음 |
+| 관련 설정 묶음 | 흩어짐 | 한 레코드에 집중 |
+| 타입 변환 | 제한적 | 자동 (kebab-case → camelCase 등) |
+| IDE 지원 | 보통 | 좋음 (annotation processor 추가 시) |
+| 유효성 검증 | 불가 | `@Validated` + `@NotNull` 등 가능 |
+
+설정 항목이 2~3개 이상이고 서로 관련이 있으면 `@ConfigurationProperties`가 낫다.
+
+---
+
+## Relaxed Binding — 프로퍼티 키 형식 자동 변환
+
+Spring Boot는 프로퍼티 키와 필드명 형식이 달라도 자동으로 매핑한다.
+
+```properties
+rate-limit.refill-per-sec=5   ← properties 파일 (kebab-case)
+```
+
+```java
+public record RateLimitProperties(long capacity, double refillPerSec) {}
+//                                                      ↑ camelCase
+```
+
+`refill-per-sec` → `refillPerSec` 자동 변환. 이를 **Relaxed Binding**이라 한다.
+
+지원 형식:
+- `refill-per-sec` (kebab-case) ← 권장
+- `refillPerSec` (camelCase)
+- `REFILL_PER_SEC` (환경변수 형식)
+- `refill_per_sec` (언더스코어)
+
+---
+
+## 왜 빈을 두 개로 나눴는가
+
+`TokenBucketRateLimiter` 빈이 두 개 필요하다.
+들어오는 요청(inbound)과 나가는 호출(outbound)이 **별도의 버킷**으로 관리돼야 하기 때문이다.
+
+```java
+@Bean("inboundRateLimiter")
+public TokenBucketRateLimiter inboundRateLimiter(RateLimitProperties properties) {
+    return new TokenBucketRateLimiter(properties.capacity(), properties.refillPerSec(), System::nanoTime);
+}
+
+@Bean("outboundRateLimiter")
+public TokenBucketRateLimiter outboundRateLimiter(OutboundRateLimitProperties properties) {
+    return new TokenBucketRateLimiter(properties.capacity(), properties.refillPerSec(), System::nanoTime);
+}
+```
+
+같은 타입의 빈이 두 개이므로 이름으로 구분한다.
+나중에 주입할 때는 `@Qualifier`로 어떤 빈인지 지정한다.
+
+```java
+// 예: RateLimitInterceptor에서 inbound 버킷만 주입
+@Component
+public class RateLimitInterceptor {
+    public RateLimitInterceptor(@Qualifier("inboundRateLimiter") TokenBucketRateLimiter rateLimiter) { ... }
+}
+```
+
+---
+
+## 공부해볼 개념들
+
+### 1. @ConfigurationProperties 동작 원리
+
+`@EnableConfigurationProperties(RateLimitProperties.class)` 선언 시:
+1. Spring이 `application.properties`에서 `rate-limit.*` 키를 읽는다
+2. `RateLimitProperties` 레코드를 생성하면서 값을 주입한다
+3. 이 레코드를 스프링 빈으로 등록한다
+
+`@ConfigurationPropertiesScan`을 메인 애플리케이션 클래스에 붙이면
+패키지 전체를 스캔해서 자동으로 등록할 수도 있다.
+
+### 2. record를 설정 객체로 쓰는 이유
+
+```java
+// 클래스 방식
+public class RateLimitProperties {
+    private long capacity;
+    private double refillPerSec;
+    // getter, setter, constructor...
+}
+
+// record 방식
+public record RateLimitProperties(long capacity, double refillPerSec) {}
+```
+
+설정 객체는 한 번 만들어지면 바뀌지 않아야 한다 (불변).
+`record`는 불변이고 생성자·getter·equals·hashCode를 자동으로 만들어준다.
+Spring Boot 2.6부터 `@ConfigurationProperties`를 record에 적용할 수 있다.
+
+### 3. 같은 타입 빈 여러 개 — @Qualifier
+
+Spring에서 같은 타입의 빈이 두 개 이상이면 주입 시 어느 것인지 알 수 없어 오류가 난다.
+
+```
+NoUniqueBeanDefinitionException: expected single matching bean but found 2
+```
+
+해결 방법:
+- `@Qualifier("빈이름")` — 이름으로 특정
+- `@Primary` — 기본값으로 사용할 빈 지정
+- `@Bean("이름")` — 빈에 이름 붙이기
+
+이번에는 두 버킷이 **역할이 다르고** 항상 명시적으로 구분해야 하므로
+`@Qualifier`가 가장 명확하다.
+
+### 4. 외부화 설정의 가치
+
+하드코딩:
+```java
+// 코드 안에 정책이 박혀있음
+TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(10, 5.0, System::nanoTime);
+```
+
+외부화:
+```properties
+rate-limit.capacity=10
+rate-limit.refill-per-sec=5
+```
+
+외부화하면:
+- 코드 수정·재배포 없이 정책 변경 가능
+- 환경별로 다른 값 적용 가능 (개발: 100, 운영: 10)
+- 운영팀이 코드 몰라도 설정 파일만 보고 조정 가능
+
+Spring Boot에서 환경별 설정:
+```
+application.properties         ← 공통 기본값
+application-dev.properties     ← 개발 환경 오버라이드
+application-prod.properties    ← 운영 환경 오버라이드
+```
+
+`spring.profiles.active=prod` 실행 시 prod 파일이 기본값을 덮어쓴다.

--- a/docs/01-feature/external_API/step3/06-step4-rate-limit-interceptor.md
+++ b/docs/01-feature/external_API/step3/06-step4-rate-limit-interceptor.md
@@ -1,0 +1,94 @@
+# Step4 — RateLimitInterceptor (HandlerInterceptor) 구현
+
+---
+
+## 결론 먼저
+
+> `RateLimitInterceptor.preHandle()`에서 inboundRateLimiter를 소비한다.
+> 토큰이 없으면 429 + `Retry-After` 헤더를 직접 써서 응답하고 `false` 반환.
+> `WebConfig.addInterceptors()`로 `/payment/**`, `/reservations/**`에 등록.
+
+---
+
+## 구현
+
+### RateLimitInterceptor
+
+```java
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final TokenBucketRateLimiter inboundRateLimiter;
+
+    public RateLimitInterceptor(@Qualifier("inboundRateLimiter") TokenBucketRateLimiter inboundRateLimiter) {
+        this.inboundRateLimiter = inboundRateLimiter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        if (!inboundRateLimiter.tryConsume()) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+            response.setHeader("Retry-After", String.valueOf(inboundRateLimiter.retryAfterSeconds()));
+            response.getWriter().write("{\"message\":\"요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.\"}");
+            return false;
+        }
+        return true;
+    }
+}
+```
+
+### WebConfig
+
+```java
+@Configuration
+@Import(RateLimitConfig.class)
+public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/payment/**", "/reservations/**");
+    }
+}
+```
+
+---
+
+## 핵심 결정사항
+
+### 왜 CustomException을 던지지 않고 response에 직접 쓰는가?
+
+`preHandle`에서 `CustomException`을 던지면 `GlobalExceptionHandler`가 JSON 본문을 쓰지만,
+`Retry-After` 헤더는 `ResponseEntity`에 포함되지 않는다.
+interceptor 단에서 헤더 + 본문을 함께 제어하려면 `HttpServletResponse`에 직접 쓰는 것이 가장 단순하다.
+
+### 왜 @Import(RateLimitConfig.class)를 WebConfig에 추가했는가?
+
+`@WebMvcTest`는 `WebMvcConfigurer` 구현체를 자동 로드하지만, `@Configuration` 빈(RateLimitConfig)은 로드하지 않는다.
+`WebConfig`가 `RateLimitInterceptor`를 생성자 주입받고, `RateLimitInterceptor`가 `inboundRateLimiter` 빈을 필요로 하기 때문에,
+`@WebMvcTest` 슬라이스 테스트에서 컨텍스트 로드 실패가 발생했다.
+`@Import(RateLimitConfig.class)`를 추가하면 `WebConfig` 로드 시 `RateLimitConfig`도 함께 등록되어 문제가 해결된다.
+
+### 테스트 환경 rate-limit 설정 분리
+
+`src/test/resources/application.properties`에 `rate-limit.capacity=100000`을 설정해
+단위·인수 테스트가 rate limit에 걸리지 않도록 분리한다.
+프로덕션 설정(`rate-limit.capacity=10`)은 `src/main/resources/application.properties`에 유지한다.
+
+---
+
+## 테스트 전략
+
+### MockMvc 테스트 (capacity=1 설정)
+
+```java
+// capacity = 1로 설정
+// 첫 번째 요청: 200 (또는 해당 엔드포인트의 정상 코드)
+// 두 번째 요청: 429 + Retry-After 헤더 확인
+mockMvc.perform(post("/payment/confirm")...)
+    .andExpect(status().isTooManyRequests())
+    .andExpect(header().exists("Retry-After"));
+```

--- a/docs/01-feature/external_API/step3/07-step5-retry-after-interceptor.md
+++ b/docs/01-feature/external_API/step3/07-step5-retry-after-interceptor.md
@@ -1,0 +1,113 @@
+# Step5 — RetryAfterInterceptor 구현 (토스 429 재시도)
+
+---
+
+## 결론 먼저
+
+> `ClientHttpRequestInterceptor`로 RestClient에 등록.
+> 토스가 429를 반환하면 `Retry-After` 헤더를 읽어 대기 후 재시도.
+> `maxAttempts` 초과 시 `TOSS_RATE_LIMIT_EXCEEDED` 예외를 던진다.
+
+---
+
+## 구현
+
+```java
+@Component
+public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TossRetryProperties properties;
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        for (int attempt = 1; attempt <= properties.maxAttempts(); attempt++) {
+            ClientHttpResponse response = execution.execute(request, body);
+
+            if (response.getStatusCode().value() != 429) {
+                return response;
+            }
+
+            if (attempt == properties.maxAttempts()) {
+                response.close();
+                throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+            }
+
+            long waitSeconds = parseRetryAfter(response);
+            response.close();
+            sleep(waitSeconds);
+        }
+
+        throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+    }
+
+    private long parseRetryAfter(ClientHttpResponse response) {
+        String header = response.getHeaders().getFirst("Retry-After");
+        if (header == null) {
+            return properties.fallbackWaitSeconds();
+        }
+        try {
+            return Long.parseLong(header);
+        } catch (NumberFormatException e) {
+            return properties.fallbackWaitSeconds();
+        }
+    }
+
+    private void sleep(long seconds) {
+        try {
+            Thread.sleep(seconds * 1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+        }
+    }
+}
+```
+
+---
+
+## 핵심 결정사항
+
+### 왜 @Retryable(step2)와 별도의 인터셉터를 두는가?
+
+| 구분 | read timeout (@Retryable) | 429 (RetryAfterInterceptor) |
+|------|--------------------------|------------------------------|
+| 처리 여부 | 모름 (불확실) | 안 됨 (확정) |
+| 재시도 즉시성 | backoff 후 즉시 | Retry-After 대기 후 |
+| 멱등키 필요 | 필요 (이중 승인 방지) | 없어도 안전, 이미 등록돼 있음 |
+
+두 메커니즘은 레이어와 트리거가 다르므로 분리해서 관리하는 것이 옳다.
+
+### 왜 loop 안에서 `response.close()`를 하는가?
+
+`ClientHttpResponse`는 기저의 HTTP 연결을 보유한다.
+다음 재시도(`execution.execute`)를 위해 이전 응답의 스트림을 닫아야 연결 풀이 고갈되지 않는다.
+
+### 왜 `fallbackWaitSeconds`가 필요한가?
+
+토스 명세에 따르면 429 응답에 `Retry-After` 헤더가 항상 포함되지 않을 수 있다.
+헤더가 없거나 파싱에 실패할 경우 기본 대기 시간(1초)을 사용한다.
+`@ConfigurationProperties`로 외부화되어 배포 환경마다 조정이 가능하다.
+
+### InterruptedException 처리 이유
+
+`Thread.sleep()`은 `InterruptedException`을 던진다.
+인터럽트가 발생했다는 것은 상위 컨텍스트(서버 종료, 스레드 풀 shutdown)가 이 스레드를 중단하려는 신호다.
+`Thread.currentThread().interrupt()`로 인터럽트 상태를 복원한 뒤 예외를 던져 스레드가 정상 종료될 수 있도록 한다.
+
+---
+
+## 테스트 전략
+
+### MockRestServiceServer 테스트
+
+```java
+// 1차: 429 + Retry-After: 1
+// 2차: 200 정상 응답
+mockServer.expect(requestTo(CONFIRM_URL))
+    .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", "1"));
+mockServer.expect(requestTo(CONFIRM_URL))
+    .andRespond(withSuccess(...));
+// → 최종 성공 검증
+
+// maxAttempts 초과 시 TOSS_RATE_LIMIT_EXCEEDED 예외 검증
+```

--- a/docs/01-feature/external_API/step3/08-step6-outbound-rate-limit.md
+++ b/docs/01-feature/external_API/step3/08-step6-outbound-rate-limit.md
@@ -1,0 +1,120 @@
+# Step6 — OutboundRateLimitInterceptor 구현 및 TossPaymentConfig 등록
+
+---
+
+## 결론 먼저
+
+> `OutboundRateLimitInterceptor`가 나가는 호출을 outboundRateLimiter로 선점한다.
+> 한도 초과 시 `OUTBOUND_RATE_LIMIT_EXCEEDED` 즉시 거부 (fail-fast).
+> `TossPaymentConfig` RestClient에 `outbound → retryAfter` 순으로 등록.
+
+---
+
+## 구현
+
+### OutboundRateLimitInterceptor
+
+```java
+@Component
+public class OutboundRateLimitInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TokenBucketRateLimiter outboundRateLimiter;
+
+    public OutboundRateLimitInterceptor(@Qualifier("outboundRateLimiter") TokenBucketRateLimiter outboundRateLimiter) {
+        this.outboundRateLimiter = outboundRateLimiter;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        if (!outboundRateLimiter.tryConsume()) {
+            throw new CustomException(ErrorCode.OUTBOUND_RATE_LIMIT_EXCEEDED);
+        }
+        return execution.execute(request, body);
+    }
+}
+```
+
+### TossPaymentConfig — 인터셉터 등록
+
+```java
+@Bean
+public RestClient tossRestClient(OutboundRateLimitInterceptor outboundRateLimitInterceptor,
+                                 RetryAfterInterceptor retryAfterInterceptor) {
+    // ...
+    return RestClient.builder()
+            .requestFactory(factory)
+            .baseUrl("https://api.tosspayments.com")
+            .defaultHeader(...)
+            .requestInterceptors(interceptors -> {
+                interceptors.add(outboundRateLimitInterceptor);  // 먼저: 보내기 전 자체 한도 확인
+                interceptors.add(retryAfterInterceptor);          // 다음: 토스의 429 처리
+            })
+            .build();
+}
+```
+
+---
+
+## 핵심 결정사항
+
+### 왜 outbound → retryAfter 순서인가?
+
+인터셉터는 체인 순서대로 실행된다.
+`outboundRateLimitInterceptor`가 먼저 실행되어야 "자체 한도 초과 시 외부로 요청 자체를 보내지 않음"이 보장된다.
+순서가 반대라면 토스에 요청을 보낸 뒤 429를 받고 재시도를 시도할 때, 자체 outbound 한도도 모두 소모되는 비효율이 생긴다.
+
+```
+요청 → [outbound 한도 확인] → [토스 전송] → [429면 Retry-After 대기 후 재시도] → 응답
+```
+
+### fail-fast vs blocking 대기
+
+나가는 Rate Limit이 초과되면 즉시 거부(fail-fast)를 선택했다.
+
+| 전략 | 장점 | 단점 |
+|------|------|------|
+| fail-fast (현재) | 스레드 즉시 반환, 스레드 풀 안전 | 호출자가 에러 직접 처리 |
+| blocking 대기 | 요청 손실 없음 | Tomcat thread per request 모델에서 스레드 고갈 위험 |
+
+Tomcat thread-per-request 모델에서는 blocking 대기가 스레드 풀을 고갈시킬 수 있어 fail-fast가 적합하다.
+
+### inbound vs outbound rate limit을 분리한 이유
+
+들어오는 한도(inbound)와 나가는 한도(outbound)는 서로 다른 자원을 보호한다.
+
+- **inbound**: 우리 서버의 처리 용량 보호
+- **outbound**: 토스가 우리에게 허용한 API 호출량 준수
+
+요청 하나가 항상 토스 호출 하나로 이어지지 않을 수 있고 (내부 캐싱, 실패 등),
+토스의 rate limit은 토스가 정한 별도의 자원이므로 값을 분리해 관리한다.
+
+---
+
+## 변경 파일 요약
+
+| 파일 | 변경 유형 | 내용 |
+|------|----------|------|
+| `RateLimitInterceptor.java` | 신규 | HandlerInterceptor — 들어오는 요청 429 거부 |
+| `WebConfig.java` | 신규 | WebMvcConfigurer — 인터셉터 경로 등록 |
+| `RetryAfterInterceptor.java` | 신규 | ClientHttpRequestInterceptor — 토스 429 재시도 |
+| `OutboundRateLimitInterceptor.java` | 신규 | ClientHttpRequestInterceptor — 나가는 호출 Rate Limit |
+| `TossPaymentConfig.java` | 수정 | RestClient에 두 인터셉터 등록 |
+| `src/test/resources/application.properties` | 신규 | 테스트 환경 rate-limit 무력화 |
+
+---
+
+## 테스트 전략
+
+### OutboundRateLimitInterceptor — 단위 테스트
+
+```java
+// tryConsume() false일 때 execution.execute() 미호출 검증
+// CustomException(OUTBOUND_RATE_LIMIT_EXCEEDED) 발생 검증
+TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(0, 0, System::nanoTime);
+OutboundRateLimitInterceptor interceptor = new OutboundRateLimitInterceptor(limiter);
+
+assertThatThrownBy(() -> interceptor.intercept(request, body, execution))
+    .isInstanceOf(CustomException.class)
+    .extracting(e -> ((CustomException) e).getErrorCode())
+    .isEqualTo(ErrorCode.OUTBOUND_RATE_LIMIT_EXCEEDED);
+```

--- a/src/main/java/roomescape/domain/ThemeSlot.java
+++ b/src/main/java/roomescape/domain/ThemeSlot.java
@@ -45,9 +45,9 @@ public class ThemeSlot {
         return new ThemeSlot(id, themeSlot.getTheme(), themeSlot.getDate(), themeSlot.getTime(), themeSlot.isReserved());
     }
 
-    public Reservation addReservation(String name, String orderId, Long amount) {
+    public Reservation addReservation(String name) {
         reservations.validateDuplicate(name);
-        Reservation reservation = new Reservation(name, this.id, this.date, this.time, this.theme, orderId, amount);
+        Reservation reservation = new Reservation(name, this.id, this.date, this.time, this.theme);
         reservations.add(reservation);
         return reservation;
     }

--- a/src/main/java/roomescape/domain/ThemeSlot.java
+++ b/src/main/java/roomescape/domain/ThemeSlot.java
@@ -45,9 +45,9 @@ public class ThemeSlot {
         return new ThemeSlot(id, themeSlot.getTheme(), themeSlot.getDate(), themeSlot.getTime(), themeSlot.isReserved());
     }
 
-    public Reservation addReservation(String name) {
+    public Reservation addReservation(String name, String orderId, Long amount) {
         reservations.validateDuplicate(name);
-        Reservation reservation = new Reservation(name, this.id, this.date, this.time, this.theme);
+        Reservation reservation = new Reservation(name, this.id, this.date, this.time, this.theme, orderId, amount);
         reservations.add(reservation);
         return reservation;
     }

--- a/src/main/java/roomescape/global/config/RateLimitConfig.java
+++ b/src/main/java/roomescape/global/config/RateLimitConfig.java
@@ -1,0 +1,24 @@
+package roomescape.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import roomescape.global.ratelimit.OutboundRateLimitProperties;
+import roomescape.global.ratelimit.RateLimitProperties;
+import roomescape.global.ratelimit.TossRetryProperties;
+import roomescape.global.ratelimit.TokenBucketRateLimiter;
+
+@Configuration
+@EnableConfigurationProperties({RateLimitProperties.class, OutboundRateLimitProperties.class, TossRetryProperties.class})
+public class RateLimitConfig {
+
+    @Bean("inboundRateLimiter")
+    public TokenBucketRateLimiter inboundRateLimiter(RateLimitProperties properties) {
+        return new TokenBucketRateLimiter(properties.capacity(), properties.refillPerSec(), System::nanoTime);
+    }
+
+    @Bean("outboundRateLimiter")
+    public TokenBucketRateLimiter outboundRateLimiter(OutboundRateLimitProperties properties) {
+        return new TokenBucketRateLimiter(properties.capacity(), properties.refillPerSec(), System::nanoTime);
+    }
+}

--- a/src/main/java/roomescape/global/config/TossPaymentConfig.java
+++ b/src/main/java/roomescape/global/config/TossPaymentConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestClient;
+import roomescape.infra.toss.OutboundRateLimitInterceptor;
+import roomescape.infra.toss.RetryAfterInterceptor;
 
 import java.util.Base64;
 
@@ -23,7 +25,8 @@ public class TossPaymentConfig {
     private int readTimeout;
 
     @Bean
-    public RestClient tossRestClient() {
+    public RestClient tossRestClient(OutboundRateLimitInterceptor outboundRateLimitInterceptor,
+                                     RetryAfterInterceptor retryAfterInterceptor) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(connectTimeout);
         factory.setReadTimeout(readTimeout);
@@ -34,6 +37,10 @@ public class TossPaymentConfig {
                 .baseUrl("https://api.tosspayments.com")
                 .defaultHeader("Authorization", "Basic " + encoded)
                 .defaultHeader("Content-Type", "application/json")
+                .requestInterceptors(interceptors -> {
+                    interceptors.add(outboundRateLimitInterceptor);
+                    interceptors.add(retryAfterInterceptor);
+                })
                 .build();
     }
 }

--- a/src/main/java/roomescape/global/config/WebConfig.java
+++ b/src/main/java/roomescape/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package roomescape.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.global.ratelimit.RateLimitInterceptor;
+
+@Configuration
+@Import(RateLimitConfig.class)
+public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    public WebConfig(RateLimitInterceptor rateLimitInterceptor) {
+        this.rateLimitInterceptor = rateLimitInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/payment/**", "/reservations/**");
+    }
+}

--- a/src/main/java/roomescape/global/exception/ErrorCode.java
+++ b/src/main/java/roomescape/global/exception/ErrorCode.java
@@ -45,7 +45,12 @@ public enum ErrorCode {
     PAYMENT_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 알 수 없는 오류가 발생했습니다."),
     PAYMENT_CONNECTION_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요."),
     PAYMENT_READ_TIMEOUT(HttpStatus.ACCEPTED, "결제 요청을 전송했으나 응답이 없습니다. 결제 내역에서 상태를 확인해 주세요."),
-    PAYMENT_SLOT_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 다른 사용자가 해당 슬롯을 결제 완료했습니다. 대기 순서에 따라 자동 승격됩니다.");
+    PAYMENT_SLOT_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 다른 사용자가 해당 슬롯을 결제 완료했습니다. 대기 순서에 따라 자동 승격됩니다."),
+
+    // rate limit
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
+    OUTBOUND_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "외부 API 호출 한도를 초과했습니다."),
+    TOSS_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "결제 서버의 요청 한도를 초과했습니다. 잠시 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/roomescape/global/ratelimit/OutboundRateLimitProperties.java
+++ b/src/main/java/roomescape/global/ratelimit/OutboundRateLimitProperties.java
@@ -1,0 +1,7 @@
+package roomescape.global.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "outbound-rate-limit")
+public record OutboundRateLimitProperties(long capacity, double refillPerSec) {
+}

--- a/src/main/java/roomescape/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/roomescape/global/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,33 @@
+package roomescape.global.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final TokenBucketRateLimiter inboundRateLimiter;
+
+    public RateLimitInterceptor(@Qualifier("inboundRateLimiter") TokenBucketRateLimiter inboundRateLimiter) {
+        this.inboundRateLimiter = inboundRateLimiter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        if (!inboundRateLimiter.tryConsume()) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+            response.setHeader("Retry-After", String.valueOf(inboundRateLimiter.retryAfterSeconds()));
+            response.getWriter().write("{\"message\":\"요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.\"}");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/roomescape/global/ratelimit/RateLimitProperties.java
+++ b/src/main/java/roomescape/global/ratelimit/RateLimitProperties.java
@@ -1,0 +1,7 @@
+package roomescape.global.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(long capacity, double refillPerSec) {
+}

--- a/src/main/java/roomescape/global/ratelimit/TokenBucketRateLimiter.java
+++ b/src/main/java/roomescape/global/ratelimit/TokenBucketRateLimiter.java
@@ -1,0 +1,43 @@
+package roomescape.global.ratelimit;
+
+import java.util.function.LongSupplier;
+
+public class TokenBucketRateLimiter {
+
+    private final long capacity;
+    private final double refillPerSec;
+    private final LongSupplier clock;
+
+    private double tokens;
+    private long lastRefillNanos;
+
+    public TokenBucketRateLimiter(long capacity, double refillPerSec, LongSupplier clock) {
+        this.capacity = capacity;
+        this.refillPerSec = refillPerSec;
+        this.clock = clock;
+        this.tokens = capacity;
+        this.lastRefillNanos = clock.getAsLong();
+    }
+
+    public synchronized boolean tryConsume() {
+        refill();
+        if (tokens >= 1.0) {
+            tokens -= 1.0;
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized long retryAfterSeconds() {
+        refill();
+        double secondsNeeded = (1.0 - tokens) / refillPerSec;
+        return (long) Math.ceil(secondsNeeded);
+    }
+
+    private void refill() {
+        long now = clock.getAsLong();
+        double elapsed = (now - lastRefillNanos) / 1_000_000_000.0;
+        tokens = Math.min(capacity, tokens + elapsed * refillPerSec);
+        lastRefillNanos = now;
+    }
+}

--- a/src/main/java/roomescape/global/ratelimit/TossRetryProperties.java
+++ b/src/main/java/roomescape/global/ratelimit/TossRetryProperties.java
@@ -1,0 +1,7 @@
+package roomescape.global.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "toss.retry")
+public record TossRetryProperties(int maxAttempts, long fallbackWaitSeconds) {
+}

--- a/src/main/java/roomescape/infra/toss/OutboundRateLimitInterceptor.java
+++ b/src/main/java/roomescape/infra/toss/OutboundRateLimitInterceptor.java
@@ -1,0 +1,31 @@
+package roomescape.infra.toss;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import roomescape.global.exception.CustomException;
+import roomescape.global.exception.ErrorCode;
+import roomescape.global.ratelimit.TokenBucketRateLimiter;
+
+import java.io.IOException;
+
+@Component
+public class OutboundRateLimitInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TokenBucketRateLimiter outboundRateLimiter;
+
+    public OutboundRateLimitInterceptor(@Qualifier("outboundRateLimiter") TokenBucketRateLimiter outboundRateLimiter) {
+        this.outboundRateLimiter = outboundRateLimiter;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        if (!outboundRateLimiter.tryConsume()) {
+            throw new CustomException(ErrorCode.OUTBOUND_RATE_LIMIT_EXCEEDED);
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/roomescape/infra/toss/RetryAfterInterceptor.java
+++ b/src/main/java/roomescape/infra/toss/RetryAfterInterceptor.java
@@ -1,0 +1,65 @@
+package roomescape.infra.toss;
+
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import roomescape.global.exception.CustomException;
+import roomescape.global.exception.ErrorCode;
+import roomescape.global.ratelimit.TossRetryProperties;
+
+import java.io.IOException;
+import org.springframework.http.HttpRequest;
+
+@Component
+public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TossRetryProperties properties;
+
+    public RetryAfterInterceptor(TossRetryProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        for (int attempt = 1; attempt <= properties.maxAttempts(); attempt++) {
+            ClientHttpResponse response = execution.execute(request, body);
+
+            if (response.getStatusCode().value() != 429) {
+                return response;
+            }
+
+            if (attempt == properties.maxAttempts()) {
+                response.close();
+                throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+            }
+
+            long waitSeconds = parseRetryAfter(response);
+            response.close();
+            sleep(waitSeconds);
+        }
+
+        throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+    }
+
+    private long parseRetryAfter(ClientHttpResponse response) {
+        String header = response.getHeaders().getFirst("Retry-After");
+        if (header == null) {
+            return properties.fallbackWaitSeconds();
+        }
+        try {
+            return Long.parseLong(header);
+        } catch (NumberFormatException e) {
+            return properties.fallbackWaitSeconds();
+        }
+    }
+
+    private void sleep(long seconds) {
+        try {
+            Thread.sleep(seconds * 1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.TOSS_RATE_LIMIT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -40,6 +40,17 @@ public class PaymentService {
     }
 
     @Transactional
+    public void handlePaymentFail(String orderId) {
+        if (orderId == null) {
+            return;
+        }
+        reservationRepository.findByOrderId(orderId).ifPresent(reservation -> {
+            reservation.cancel();
+            reservationRepository.updateStatus(reservation);
+        });
+    }
+
+    @Transactional
     public Payment confirmPayment(PaymentConfirmation confirmation) {
         Reservation reservation = reservationRepository.findByOrderId(confirmation.orderId())
                 .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -40,17 +40,6 @@ public class PaymentService {
     }
 
     @Transactional
-    public void handlePaymentFail(String orderId) {
-        if (orderId == null) {
-            return;
-        }
-        reservationRepository.findByOrderId(orderId).ifPresent(reservation -> {
-            reservation.cancel();
-            reservationRepository.updateStatus(reservation);
-        });
-    }
-
-    @Transactional
     public Payment confirmPayment(PaymentConfirmation confirmation) {
         Reservation reservation = reservationRepository.findByOrderId(confirmation.orderId())
                 .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,11 @@ spring.datasource.url=jdbc:h2:mem:database
 toss.secret-key=test_sk_placeholder
 toss.connect-timeout=3000
 toss.read-timeout=10000
+toss.retry.max-attempts=3
+toss.retry.fallback-wait-seconds=1
+
+rate-limit.capacity=10
+rate-limit.refill-per-sec=5
+
+outbound-rate-limit.capacity=5
+outbound-rate-limit.refill-per-sec=3

--- a/src/test/java/roomescape/global/ratelimit/TokenBucketRateLimiterTest.java
+++ b/src/test/java/roomescape/global/ratelimit/TokenBucketRateLimiterTest.java
@@ -1,0 +1,164 @@
+package roomescape.global.ratelimit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenBucketRateLimiterTest {
+
+    private static final long NANOS_PER_SEC = 1_000_000_000L;
+
+    @Test
+    @DisplayName("초기 토큰은 capacity만큼 채워져 있다.")
+    void initialTokens_equalsCapacity() {
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(3, 1.0, () -> now[0]);
+
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isFalse();
+    }
+
+    @Test
+    @DisplayName("토큰이 소진되면 tryConsume()은 false를 반환한다.")
+    void tryConsume_whenExhausted_returnsFalse() {
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(1, 1.0, () -> now[0]);
+
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isFalse();
+    }
+
+    @Test
+    @DisplayName("시간이 경과하면 refillPerSec에 비례해 토큰이 보충된다.")
+    void refill_afterElapsed_addsTokens() {
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(5, 2.0, () -> now[0]);
+
+        // capacity 모두 소비
+        for (int i = 0; i < 5; i++) {
+            limiter.tryConsume();
+        }
+        assertThat(limiter.tryConsume()).isFalse();
+
+        // 1초 경과 → 2개 보충
+        now[0] += NANOS_PER_SEC;
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isFalse();
+    }
+
+    @Test
+    @DisplayName("보충된 토큰은 capacity를 초과하지 않는다.")
+    void refill_doesNotExceedCapacity() {
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(3, 10.0, () -> now[0]);
+
+        // capacity 모두 소비
+        for (int i = 0; i < 3; i++) {
+            limiter.tryConsume();
+        }
+
+        // 10초 경과 → 100개가 보충되려 하지만 capacity(3)에서 멈춤
+        now[0] += 10 * NANOS_PER_SEC;
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isTrue();
+        assertThat(limiter.tryConsume()).isFalse();
+    }
+
+    @Test
+    @DisplayName("retryAfterSeconds()는 1개가 찰 때까지 걸리는 시간을 올림으로 반환한다.")
+    void retryAfterSeconds_returnsRoundedUpWaitTime() {
+        long[] now = {0L};
+        // refillPerSec = 2.0 → 1개 채우는 데 0.5초 → ceil(0.5) = 1
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(1, 2.0, () -> now[0]);
+
+        limiter.tryConsume(); // 소진
+        assertThat(limiter.retryAfterSeconds()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("retryAfterSeconds()는 refillPerSec가 낮을수록 대기 시간이 길다.")
+    void retryAfterSeconds_slowRefill_returnsLongerWait() {
+        long[] now = {0L};
+        // refillPerSec = 0.5 → 1개 채우는 데 2초 → ceil(2.0) = 2
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(1, 0.5, () -> now[0]);
+
+        limiter.tryConsume(); // 소진
+        assertThat(limiter.retryAfterSeconds()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("동시 요청에서 정확히 capacity개만 통과한다.")
+    void tryConsume_concurrentRequests_onlyCapacityPass() throws InterruptedException {
+        int capacity = 5;
+        int threadCount = 20;
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(capacity, 0.0, () -> now[0]);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    if (limiter.tryConsume()) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(capacity);
+    }
+
+    @Test
+    @DisplayName("capacity 0으로 생성하면 모든 요청이 거부된다.")
+    void tryConsume_withZeroCapacity_alwaysReturnsFalse() {
+        long[] now = {0L};
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(0, 0.0, () -> now[0]);
+
+        assertThat(limiter.tryConsume()).isFalse();
+        assertThat(limiter.tryConsume()).isFalse();
+    }
+
+    @Test
+    @DisplayName("소수점 보충이 누적되어 1 이상이 되면 통과한다.")
+    void refill_fractionalAccumulation_eventuallyAllows() {
+        long[] now = {0L};
+        // refillPerSec = 2.0 → 0.5초마다 1개 보충
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(1, 2.0, () -> now[0]);
+
+        limiter.tryConsume(); // 소진
+        assertThat(limiter.tryConsume()).isFalse();
+
+        // 0.4초 경과 → 0.8개 보충 (아직 1개 미만)
+        now[0] += (long) (0.4 * NANOS_PER_SEC);
+        assertThat(limiter.tryConsume()).isFalse();
+
+        // 추가 0.2초 경과 → 누적 0.4 + 0.4 = 0.8 + 0.4 = 1.2개 → 통과
+        now[0] += (long) (0.2 * NANOS_PER_SEC);
+        assertThat(limiter.tryConsume()).isTrue();
+    }
+}

--- a/src/test/java/roomescape/http/reservation/getReservation.http
+++ b/src/test/java/roomescape/http/reservation/getReservation.http
@@ -1,2 +1,2 @@
-GET localhost:8080/reservations?name= HTTP/1.1
+GET localhost:8080/reservations?name=게스트 HTTP/1.1
 Content-Type: application/json

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -104,4 +104,28 @@ class PaymentServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage("예약이 존재하지 않습니다.");
     }
+
+    @Test
+    @DisplayName("결제 실패 처리 시 해당 orderId의 예약이 CANCELLED 상태가 된다.")
+    void handlePaymentFail_withValidOrderId_cancelsReservation() {
+        Reservation reservation = pendingReservation("order-123", 10000L);
+
+        paymentService.handlePaymentFail("order-123");
+
+        assertThat(fakeReservationRepository.findById(reservation.getId()).get().isCancelled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 결제 실패 처리 시 아무것도 하지 않는다.")
+    void handlePaymentFail_withNullOrderId_doesNothing() {
+        paymentService.handlePaymentFail(null);
+        // 예외 없이 정상 종료
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 orderId로 결제 실패 처리 시 조용히 무시된다.")
+    void handlePaymentFail_withUnknownOrderId_doesNothing() {
+        paymentService.handlePaymentFail("nonexistent-order");
+        // 예외 없이 정상 종료
+    }
 }

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -14,16 +14,12 @@ import roomescape.domain.Reservation;
 import roomescape.domain.Theme;
 import roomescape.domain.ThemeSlot;
 import roomescape.domain.Time;
-import roomescape.controller.dto.ReservationPaymentResponse;
 import roomescape.domain.payment.Payment;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
 import roomescape.domain.payment.PaymentResult;
-import roomescape.domain.payment.PaymentStatus;
-import roomescape.domain.reservationStatus.ConfirmedStatus;
 import roomescape.domain.reservationStatus.PendingStatus;
 import roomescape.global.exception.CustomException;
-import roomescape.global.exception.ErrorCode;
 import roomescape.repository.FakePaymentRepository;
 import roomescape.repository.FakeReservationRepository;
 import roomescape.repository.FakeThemeSlotRepository;
@@ -52,19 +48,9 @@ class PaymentServiceTest {
         fakeThemeSlotRepository.save(new ThemeSlot(THEME, DATE, TIME, false));
     }
 
-    private Reservation pendingReservation(String name, String orderId, Long amount) {
-        return fakeReservationRepository.save(
-                new Reservation(null, name, 1L, DATE, TIME, THEME, PendingStatus.getInstance(), orderId, amount)
-        );
-    }
-
     private Reservation pendingReservation(String orderId, Long amount) {
-        return pendingReservation("브라운", orderId, amount);
-    }
-
-    private Reservation confirmedReservation(String name, String orderId, Long amount) {
         return fakeReservationRepository.save(
-                new Reservation(null, name, 1L, DATE, TIME, THEME, ConfirmedStatus.getInstance(), orderId, amount)
+                new Reservation(null, "브라운", 1L, DATE, TIME, THEME, PendingStatus.getInstance(), orderId, amount)
         );
     }
 
@@ -117,162 +103,5 @@ class PaymentServiceTest {
         assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("예약이 존재하지 않습니다.");
-    }
-
-    @Test
-    @DisplayName("슬롯이 이미 다른 사용자에 의해 결제 완료된 경우 PAYMENT_SLOT_ALREADY_CONFIRMED 예외가 발생한다.")
-    void confirmPayment_slotAlreadyReserved_throwsException() {
-        // 슬롯을 is_reserved=true 상태로 갱신
-        fakeThemeSlotRepository.update(new ThemeSlot(THEME, DATE, TIME, true));
-        pendingReservation("브라운", "order-123", 10000L);
-        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
-
-        assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
-                .isInstanceOf(CustomException.class)
-                .extracting(e -> ((CustomException) e).getErrorCode())
-                .isEqualTo(ErrorCode.PAYMENT_SLOT_ALREADY_CONFIRMED);
-    }
-
-    @Test
-    @DisplayName("슬롯이 이미 선점된 경우 토스 결제 승인 API는 호출되지 않는다.")
-    void confirmPayment_slotAlreadyReserved_gatewayNotCalled() {
-        List<PaymentConfirmation> called = new ArrayList<>();
-        PaymentGateway trackingGateway = confirmation -> {
-            called.add(confirmation);
-            return new PaymentResult(confirmation.paymentKey(), confirmation.orderId(), confirmation.amount());
-        };
-        paymentService = new PaymentService(trackingGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
-
-        fakeThemeSlotRepository.update(new ThemeSlot(THEME, DATE, TIME, true));
-        pendingReservation("브라운", "order-123", 10000L);
-
-        assertThatThrownBy(() -> paymentService.confirmPayment(new PaymentConfirmation("pay-key", "order-123", 10000L)))
-                .isInstanceOf(CustomException.class);
-        assertThat(called).isEmpty();
-    }
-
-    @Test
-    @DisplayName("read timeout 발생 시 예약은 PENDING을 유지하고 UNCERTAIN Payment가 저장된다.")
-    void confirmPayment_readTimeout_savesUncertainPaymentAndKeepsPending() {
-        PaymentGateway timeoutGateway = confirmation -> {
-            throw new CustomException(ErrorCode.PAYMENT_READ_TIMEOUT);
-        };
-        paymentService = new PaymentService(timeoutGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
-
-        Reservation reservation = pendingReservation("order-123", 10000L);
-        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
-
-        Payment payment = paymentService.confirmPayment(confirmation);
-
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.UNCERTAIN);
-        assertThat(payment.getPaymentKey()).isNull();
-        assertThat(fakeReservationRepository.findById(reservation.getId()).get().isConfirmed()).isFalse();
-    }
-
-    @Test
-    @DisplayName("read timeout 이외의 결제 예외는 그대로 전파된다.")
-    void confirmPayment_connectionTimeout_propagatesException() {
-        PaymentGateway connectionFailGateway = confirmation -> {
-            throw new CustomException(ErrorCode.PAYMENT_CONNECTION_TIMEOUT);
-        };
-        paymentService = new PaymentService(connectionFailGateway, fakeReservationRepository, fakePaymentRepository, fakeThemeSlotRepository);
-
-        pendingReservation("order-123", 10000L);
-        PaymentConfirmation confirmation = new PaymentConfirmation("pay-key", "order-123", 10000L);
-
-        assertThatThrownBy(() -> paymentService.confirmPayment(confirmation))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ErrorCode.PAYMENT_CONNECTION_TIMEOUT.getMessage());
-    }
-
-    @Test
-    @DisplayName("결제 실패 처리 시 해당 orderId의 예약이 CANCELLED 상태가 된다.")
-    void handlePaymentFail_withValidOrderId_cancelsReservation() {
-        Reservation reservation = pendingReservation("order-123", 10000L);
-
-        paymentService.handlePaymentFail("order-123");
-
-        assertThat(fakeReservationRepository.findById(reservation.getId()).get().isCancelled()).isTrue();
-    }
-
-    @Test
-    @DisplayName("orderId가 null이면 결제 실패 처리 시 아무것도 하지 않는다.")
-    void handlePaymentFail_withNullOrderId_doesNothing() {
-        paymentService.handlePaymentFail(null);
-        // 예외 없이 정상 종료
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 orderId로 결제 실패 처리 시 조용히 무시된다.")
-    void handlePaymentFail_withUnknownOrderId_doesNothing() {
-        paymentService.handlePaymentFail("nonexistent-order");
-        // 예외 없이 정상 종료
-    }
-
-    // ── getPaymentHistory ─────────────────────────────────────────
-
-    @Test
-    @DisplayName("CONFIRMED payment가 있는 예약은 paymentStatus CONFIRMED와 paymentKey를 포함해 반환한다.")
-    void getPaymentHistory_confirmedPayment_returnsConfirmedStatus() {
-        Reservation reservation = confirmedReservation("브라운", "order-123", 10000L);
-        fakePaymentRepository.save(new Payment(reservation.getId(), "pay-key", "order-123", 10000L, PaymentStatus.CONFIRMED));
-
-        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
-
-        assertThat(history).hasSize(1);
-        assertThat(history.get(0).paymentStatus()).isEqualTo("CONFIRMED");
-        assertThat(history.get(0).paymentKey()).isEqualTo("pay-key");
-        assertThat(history.get(0).orderId()).isEqualTo("order-123");
-    }
-
-    @Test
-    @DisplayName("UNCERTAIN payment가 있는 예약은 paymentStatus UNCERTAIN이고 paymentKey는 null이다.")
-    void getPaymentHistory_uncertainPayment_returnsUncertainStatus() {
-        Reservation reservation = pendingReservation("브라운", "order-123", 10000L);
-        fakePaymentRepository.save(new Payment(reservation.getId(), null, "order-123", 10000L, PaymentStatus.UNCERTAIN));
-
-        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
-
-        assertThat(history).hasSize(1);
-        assertThat(history.get(0).paymentStatus()).isEqualTo("UNCERTAIN");
-        assertThat(history.get(0).paymentKey()).isNull();
-    }
-
-    @Test
-    @DisplayName("payment 기록이 없는 예약은 paymentStatus와 paymentKey가 null이다.")
-    void getPaymentHistory_noPayment_returnsNullPaymentStatus() {
-        pendingReservation("브라운", "order-123", 10000L);
-
-        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
-
-        assertThat(history).hasSize(1);
-        assertThat(history.get(0).paymentStatus()).isNull();
-        assertThat(history.get(0).paymentKey()).isNull();
-    }
-
-    @Test
-    @DisplayName("CONFIRMED/UNCERTAIN/결제없음 예약이 섞여 있어도 전체 목록을 반환한다.")
-    void getPaymentHistory_mixedStatuses_returnsAll() {
-        Reservation confirmed = confirmedReservation("브라운", "order-1", 10000L);
-        fakePaymentRepository.save(new Payment(confirmed.getId(), "pay-key", "order-1", 10000L, PaymentStatus.CONFIRMED));
-
-        Reservation uncertain = pendingReservation("브라운", "order-2", 10000L);
-        fakePaymentRepository.save(new Payment(uncertain.getId(), null, "order-2", 10000L, PaymentStatus.UNCERTAIN));
-
-        pendingReservation("브라운", "order-3", 10000L);
-
-        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("브라운");
-
-        assertThat(history).hasSize(3);
-        assertThat(history).extracting(ReservationPaymentResponse::paymentStatus)
-                .containsExactlyInAnyOrder("CONFIRMED", "UNCERTAIN", null);
-    }
-
-    @Test
-    @DisplayName("해당 이름의 예약이 없으면 빈 리스트를 반환한다.")
-    void getPaymentHistory_noReservation_returnsEmptyList() {
-        List<ReservationPaymentResponse> history = paymentService.getPaymentHistory("없는사람");
-
-        assertThat(history).isEmpty();
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,16 @@
+server.port=8080
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:database
+
+toss.secret-key=test_sk_placeholder
+toss.connect-timeout=3000
+toss.read-timeout=10000
+toss.retry.max-attempts=3
+toss.retry.fallback-wait-seconds=1
+
+rate-limit.capacity=100000
+rate-limit.refill-per-sec=100000
+
+outbound-rate-limit.capacity=100000
+outbound-rate-limit.refill-per-sec=100000


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [ ] 미션의 필수 요구사항을 모두 구현했나요?
- [ ] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [ ] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

## 구현 내용

외부 결제 API(Toss Payments) 연동에서 발생할 수 있는 호출량(throughput) 문제를 Rate Limit으로 제어합니다.
알고리즘은 토큰 버킷 하나, 방향은 들어오는(inbound)과 나가는(outbound) 둘입니다.

- 들어오는 요청이 한도를 초과하면 컨트롤러 호출 없이 429 + `Retry-After`로 즉시 거부합니다.
- 토스가 429를 반환하면 `Retry-After` 헤더를 읽어 대기 후 재시도합니다.
- 나가는 호출이 자체 한도를 초과하면 외부로 보내지 않고 즉시 거부합니다.

---

## 1. TokenBucketRateLimiter — 핵심 알고리즘

외부 의존성 없이 토큰 버킷을 직접 구현합니다.

```java
public class TokenBucketRateLimiter {
    private final long capacity;        // 최대 보유 가능 토큰 (허용 버스트)
    private final double refillPerSec;  // 초당 보충 토큰 수 (평균 TPS 상한)
    private final LongSupplier clock;   // 가짜 시계 주입용

    public synchronized boolean tryConsume() { ... }       // 토큰 소비 시도
    public synchronized long retryAfterSeconds() { ... }   // 1개 보충까지 필요 초 (올림)
    private void refill() { ... }                          // 경과 시간 × refillPerSec 보충
}
```

### 핵심 결정사항

**왜 `double tokens`인가?**
`long` 정수 토큰은 보충 주기가 1초 미만일 때 소수점 손실이 누적됩니다.
예) `refillPerSec = 2.0`이면 0.5초마다 1개 보충돼야 하는데, 정수로는 매번 0이 되어 실질적으로 보충이 안 됩니다.
`double`로 분수 토큰을 유지하면 누적 후 1 이상이 됐을 때 정확히 통과시킬 수 있습니다.

**왜 `synchronized`인가?**
`tryConsume()`은 read-modify-write 시퀀스(`tokens`, `lastRefillNanos` 두 필드 복합 갱신)입니다.
`AtomicLong` 하나로는 두 필드의 원자성을 동시에 보장할 수 없습니다.
처리량보다 정확성이 우선이므로 `synchronized`를 선택했습니다.

**가짜 시계(`LongSupplier`) 주입 이유**
`System::nanoTime`을 하드코딩하면 "1초 경과 후 2개 보충" 시나리오를 테스트하기 위해 실제로 1초를 기다려야 합니다.
`LongSupplier`를 생성자로 주입하면 `now[0] += 1_000_000_000L` 한 줄로 1초를 시뮬레이션합니다.

```java
// 테스트
long[] now = {0L};
TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(5, 2.0, () -> now[0]);
now[0] += 1_000_000_000L; // 1초 경과 → 2개 보충

// 프로덕션
new TokenBucketRateLimiter(capacity, refillPerSec, System::nanoTime);
```

---

## 2. ErrorCode 추가

```java
// 들어오는 요청 초과 (우리 서버가 429 반환)
RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),

// 나가는 호출 초과 (우리가 스스로 차단)
OUTBOUND_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "외부 API 호출 한도를 초과했습니다."),

// 토스가 429를 maxAttempts 이상 반환
TOSS_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "결제 서버의 요청 한도를 초과했습니다. 잠시 후 다시 시도해 주세요."),
```

---

## 3. 설정 외부화

`@ConfigurationProperties`로 Rate Limit 정책을 코드 밖으로 분리합니다.
값만 바꿔 재배포하면 거부 시점이 달라집니다.

```properties
rate-limit.capacity=10
rate-limit.refill-per-sec=5

outbound-rate-limit.capacity=5
outbound-rate-limit.refill-per-sec=3

toss.retry.max-attempts=3
toss.retry.fallback-wait-seconds=1
```

들어오는 한도(`rate-limit.*`)와 나가는 한도(`outbound-rate-limit.*`)를 분리한 이유:
들어오는 한도는 우리 서버의 처리 용량을 보호하고, 나가는 한도는 토스가 우리에게 허용한 API 호출량을 준수합니다.
요청 하나가 항상 토스 호출 하나로 이어지지 않을 수 있고(내부 검증 실패, 슬롯 선점 등), 토스의 한도는 우리 내부 처리량과 무관하게 토스가 정한 값입니다.

---

## 4. RateLimitInterceptor — 들어오는 요청 차단

`HandlerInterceptor.preHandle()`에서 컨트롤러 호출 없이 429를 반환합니다.

```java
@Override
public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
    if (!inboundRateLimiter.tryConsume()) {
        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
        response.setHeader("Retry-After", String.valueOf(inboundRateLimiter.retryAfterSeconds()));
        response.getWriter().write("{\"message\":\"요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.\"}");
        return false;
    }
    return true;
}
```

`WebConfig`에서 `/payment/**`, `/reservations/**` 경로에 등록합니다.

**왜 `CustomException`을 던지지 않는가?**
`CustomException`을 던지면 `GlobalExceptionHandler`가 JSON 본문을 쓰지만, `Retry-After` 헤더를 `ResponseEntity`에 포함시키기 어렵습니다.
`HttpServletResponse`에 직접 쓰면 헤더와 본문을 한 번에 제어할 수 있습니다.

---

## 5. RetryAfterInterceptor — 토스 429 백오프 재시도

`ClientHttpRequestInterceptor`로 RestClient 체인에 등록합니다.

```
요청 → [토스 전송] → 429 수신 → Retry-After 대기 → 재시도 (최대 maxAttempts)
                              └→ maxAttempts 초과 → TOSS_RATE_LIMIT_EXCEEDED
```

### read timeout(2단계) 재시도와의 차이

| 구분 | read timeout (`@Retryable`) | 429 (`RetryAfterInterceptor`) |
|------|----------------------------|-------------------------------|
| 처리 여부 | 모름 (불확실) | 안 됨 (확정) |
| 재시도 시점 | backoff 후 즉시 | `Retry-After` 대기 후 |
| 멱등키 필요성 | 필요 (이중 승인 방지) | 없어도 안전, 이미 등록돼 있음 |

두 메커니즘은 레이어와 트리거가 다르므로 분리해 관리합니다.

---

## 6. OutboundRateLimitInterceptor — 나가는 호출 자체 제한

한도를 초과하면 토스에 요청을 보내기 전 즉시 거부합니다(fail-fast).

```java
@Override
public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
    if (!outboundRateLimiter.tryConsume()) {
        throw new CustomException(ErrorCode.OUTBOUND_RATE_LIMIT_EXCEEDED);
    }
    return execution.execute(request, body);
}
```

TossPaymentConfig RestClient에 `outbound → retryAfter` 순으로 등록합니다.
순서가 중요합니다: outbound가 먼저 실행돼야 "자체 한도 초과 시 외부로 나가지 않음"이 보장됩니다.

**fail-fast를 선택한 이유**

| 전략 | 장점 | 단점 |
|------|------|------|
| fail-fast (현재) | 스레드 즉시 반환, 스레드 풀 안전 | 호출자가 에러 직접 처리 |
| blocking 대기 | 요청 손실 없음 | Tomcat thread-per-request에서 스레드 고갈 위험 |

Tomcat thread-per-request 모델에서는 blocking 대기가 스레드 풀을 고갈시킬 수 있어 fail-fast가 적합합니다.

---

## 테스트

### TokenBucketRateLimiter — 가짜 시계 단위 테스트

가짜 시계(`LongSupplier`)를 주입해 실시간 대기 없이 결정적으로 검증합니다.

- 초기 토큰이 `capacity`만큼 채워져 있다
- 토큰 소진 후 `tryConsume()`은 false를 반환한다
- 시간 경과 후 `refillPerSec`에 비례해 토큰이 보충된다
- 보충된 토큰은 `capacity`를 초과하지 않는다
- `retryAfterSeconds()`는 올림 값을 반환한다
- 소수점 보충이 누적돼 1 이상이 되면 통과한다
- 동시 요청에서 정확히 `capacity`개만 통과한다 (20개 스레드 동시 요청, capacity=5)

---

## 고민한 점

**`@WebMvcTest`에서 RateLimitConfig 빈 누락 문제**

`@WebMvcTest`는 `WebMvcConfigurer` 구현체(`WebConfig`)를 자동으로 로드하지만,
`@Configuration` 빈인 `RateLimitConfig`는 MVC 슬라이스 대상이 아니어서 로드하지 않습니다.
`WebConfig` → `RateLimitInterceptor` → `inboundRateLimiter` 의존 체인에서 빈을 찾지 못해
기존 컨트롤러 슬라이스 테스트가 컨텍스트 로드 실패로 깨졌습니다.

`WebConfig`에 `@Import(RateLimitConfig.class)`를 추가해 해결했습니다.
`WebConfig`가 로드될 때 `RateLimitConfig`도 함께 등록되어 두 Rate Limiter 빈이 생성됩니다.

**테스트 환경 Rate Limit 분리**

`src/test/resources/application.properties`에 `rate-limit.capacity=100000`을 별도로 설정해
인수·단위 테스트가 Rate Limit에 걸리지 않도록 분리합니다.
프로덕션 설정(`rate-limit.capacity=10`)은 `src/main/resources/application.properties`에만 적용됩니다.

**들어오는 Rate Limit과 나가는 Rate Limit을 같은 값으로 두면 안 되는 이유**

들어오는 한도(우리 처리 용량)와 나가는 한도(토스가 우리에게 허용한 몫)는 서로 다른 자원을 보호합니다.
요청 하나가 항상 토스 호출 하나로 이어지지 않을 수 있고,
토스의 Rate Limit은 우리 내부 처리량과 무관하게 토스가 정한 값입니다.
같은 값으로 두면 실제로는 다른 정책을 하나의 수치로 관리하게 돼 나중에 조정이 어렵습니다.
