### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 무빙(이동건) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/config/PaymentConfig.java
+++ b/src/main/java/roomescape/config/PaymentConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import roomescape.payment.adapter.TossPaymentGateway;
 import roomescape.payment.port.PaymentGateway;
@@ -21,10 +22,15 @@ public class PaymentConfig {
         String encoded = Base64.getEncoder()
                 .encodeToString((properties.secretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.connectTimeoutMs());  // SYN -> ACK 대기 최대 시간
+        factory.setReadTimeout(properties.readTimeoutMs());  // 연결 후 응답 도착 최대 시간
+
         return RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .requestFactory(factory)
                 .build();
     }
 

--- a/src/main/java/roomescape/config/TossPaymentProperties.java
+++ b/src/main/java/roomescape/config/TossPaymentProperties.java
@@ -3,5 +3,6 @@ package roomescape.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "toss.payments")
-public record TossPaymentProperties(String secretKey, String clientKey, String baseUrl) {
+public record TossPaymentProperties(String secretKey, String clientKey, String baseUrl,
+                                    int connectTimeoutMs, int readTimeoutMs) {
 }

--- a/src/main/java/roomescape/payment/PaymentConnectionException.java
+++ b/src/main/java/roomescape/payment/PaymentConnectionException.java
@@ -1,0 +1,9 @@
+package roomescape.payment;
+
+// 연결 단계에서 실패 — Toss 서버에 요청이 도달하지 않았으므로 결제 취소 후 재시도 안내.
+public class PaymentConnectionException extends RuntimeException {
+
+    public PaymentConnectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/payment/PaymentUncertainException.java
+++ b/src/main/java/roomescape/payment/PaymentUncertainException.java
@@ -1,0 +1,10 @@
+package roomescape.payment;
+
+// read timeout — Toss가 이미 처리했을 수 있어 결제 성공/실패를 단정할 수 없다.
+// 예약을 PAYMENT_UNCERTAIN으로 보존하고, 멱등키 덕에 재시도해도 이중 승인되지 않는다.
+public class PaymentUncertainException extends RuntimeException {
+
+    public PaymentUncertainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/payment/adapter/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/adapter/TossPaymentGateway.java
@@ -1,8 +1,12 @@
 package roomescape.payment.adapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.ConnectException;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import roomescape.payment.PaymentConnectionException;
+import roomescape.payment.PaymentUncertainException;
 import roomescape.payment.TossPaymentException;
 import roomescape.payment.domain.PaymentConfirmation;
 import roomescape.payment.domain.PaymentResult;
@@ -28,17 +32,26 @@ public class TossPaymentGateway implements PaymentGateway {
         ConfirmRequest request = new ConfirmRequest(confirmation.paymentKey(), confirmation.orderId(),
                 confirmation.amount());
 
-        TossPaymentResponse tossResponse = tossRestClient.post()
-                .uri("/v1/payments/confirm")
-                .header("Idempotency-Key", confirmation.orderId())
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    TossErrorResponse error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
-                    throw TossPaymentException.of(res.getStatusCode(), error);
-                })
-                .body(TossPaymentResponse.class);
+        try {
+            TossPaymentResponse tossResponse = tossRestClient.post()
+                    .uri("/v1/payments/confirm")
+                    .header("Idempotency-Key", confirmation.orderId())
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        TossErrorResponse error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
+                        throw TossPaymentException.of(res.getStatusCode(), error);
+                    })
+                    .body(TossPaymentResponse.class);
 
-        return new PaymentResult(tossResponse.paymentKey());
+            return new PaymentResult(tossResponse.paymentKey());
+        } catch (ResourceAccessException e) {
+            // ConnectException: TCP 연결 자체 실패 → Toss에 요청이 도달하지 않았으므로 취소 안전
+            if (e.getCause() instanceof ConnectException) {
+                throw new PaymentConnectionException("결제 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.");
+            }
+            // SocketTimeoutException: read timeout → Toss가 이미 처리했을 수 있어 결과 불명
+            throw new PaymentUncertainException("결제 처리 결과를 확인할 수 없습니다. 내 예약에서 결제 상태를 확인해 주세요.");
+        }
     }
 }

--- a/src/main/java/roomescape/payment/adapter/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/adapter/TossPaymentGateway.java
@@ -30,6 +30,7 @@ public class TossPaymentGateway implements PaymentGateway {
 
         TossPaymentResponse tossResponse = tossRestClient.post()
                 .uri("/v1/payments/confirm")
+                .header("Idempotency-Key", confirmation.orderId())
                 .body(request)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {

--- a/src/main/java/roomescape/payment/controller/PaymentController.java
+++ b/src/main/java/roomescape/payment/controller/PaymentController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import roomescape.common.exception.BusinessException;
 import roomescape.config.TossPaymentProperties;
+import roomescape.payment.PaymentConnectionException;
+import roomescape.payment.PaymentUncertainException;
 import roomescape.payment.TossPaymentException;
 import roomescape.payment.service.PaymentService;
 
@@ -43,6 +45,13 @@ public class PaymentController {
             return redirectToFail(redirectAttributes, e.getCode(), e.getMessage(), orderId);
         } catch (BusinessException e) {
             return redirectToFail(redirectAttributes, e.getErrorCode().name(), e.getMessage(), orderId);
+        } catch (PaymentConnectionException e) {
+            // Toss에 요청이 도달하지 않아 결제 안 됨 → fail 엔드포인트에서 예약 정리.
+            return redirectToFail(redirectAttributes, "CONNECTION_FAILED", e.getMessage(), orderId);
+        } catch (PaymentUncertainException e) {
+            // read timeout: 결제 처리 여부 불명 → 예약을 PAYMENT_UNCERTAIN으로 보존, 삭제하지 않음.
+            paymentService.markAsUncertain(orderId);
+            return redirectToFail(redirectAttributes, "PAYMENT_UNCERTAIN", e.getMessage(), orderId);
         }
     }
 

--- a/src/main/java/roomescape/payment/domain/Payment.java
+++ b/src/main/java/roomescape/payment/domain/Payment.java
@@ -17,22 +17,20 @@ public class Payment {
         return new Payment(orderId, amount, paymentKey, reservationId);
     }
 
-    // 결제 정보 생성(이후 토스 결제창 뜸)
     public static Payment pending(String orderId, Long amount, Long reservationId) {
         return new Payment(orderId, amount, null, reservationId);
     }
 
-    // 결제 완료해서 새로운 paymentKey 발급 받음
     public Payment confirm(String paymentKey) {
         return new Payment(orderId, amount, paymentKey, reservationId);
     }
 
-    public Long getAmount() {
-        return amount;
-    }
-
     public String getOrderId() {
         return orderId;
+    }
+
+    public Long getAmount() {
+        return amount;
     }
 
     public String getPaymentKey() {

--- a/src/main/java/roomescape/payment/service/PaymentService.java
+++ b/src/main/java/roomescape/payment/service/PaymentService.java
@@ -48,6 +48,12 @@ public class PaymentService {
     }
 
     @Transactional
+    public void markAsUncertain(String orderId) {
+        paymentRepository.findByOrderId(orderId).ifPresent(payment ->
+                reservationRepository.updateStatus(payment.getReservationId(), PaymentStatus.PAYMENT_UNCERTAIN));
+    }
+
+    @Transactional
     public void cancelPending(String orderId) {
         paymentRepository.findByOrderId(orderId).ifPresent(payment ->
                 reservationRepository.findById(payment.getReservationId()).ifPresent(reservation -> {

--- a/src/main/java/roomescape/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/ReservationController.java
@@ -20,6 +20,7 @@ import roomescape.reservation.dto.ReservationIdResponse;
 import roomescape.reservation.dto.ReservationRequest;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.dto.ReservationUpdateRequest;
+import roomescape.reservation.dto.ReservationWithPaymentResponse;
 import roomescape.reservation.service.ReservationService;
 
 @Tag(name = "예약", description = "예약 생성·조회·수정·삭제 API")
@@ -37,6 +38,11 @@ public class ReservationController {
     public ResponseEntity<List<ReservationResponse>> getReservationsByName(
             @RequestParam(required = false) String name) {
         return ResponseEntity.ok(reservationService.getReservationsByName(name));
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<ReservationWithPaymentResponse>> getMyReservations(@RequestParam String name) {
+        return ResponseEntity.ok(reservationService.getMyReservations(name));
     }
 
     @GetMapping("/id")

--- a/src/main/java/roomescape/reservation/domain/PaymentStatus.java
+++ b/src/main/java/roomescape/reservation/domain/PaymentStatus.java
@@ -2,5 +2,6 @@ package roomescape.reservation.domain;
 
 public enum PaymentStatus {
     PAYMENT_PENDING,
-    CONFIRMED
+    CONFIRMED,
+    PAYMENT_UNCERTAIN
 }

--- a/src/main/java/roomescape/reservation/dto/ReservationWithPaymentResponse.java
+++ b/src/main/java/roomescape/reservation/dto/ReservationWithPaymentResponse.java
@@ -1,0 +1,18 @@
+package roomescape.reservation.dto;
+
+import java.time.LocalDate;
+import roomescape.reservation.domain.PaymentStatus;
+import roomescape.reservationtime.dto.TimeResponse;
+
+public record ReservationWithPaymentResponse(
+        Long id,
+        String name,
+        LocalDate date,
+        TimeResponse time,
+        String themeName,
+        PaymentStatus status,
+        String orderId,
+        String paymentKey,
+        Long amount
+) {
+}

--- a/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
@@ -177,7 +177,7 @@ public class JdbcReservationRepository implements ReservationRepository {
                 JOIN reservation_time rt ON r.time_id = rt.id
                 JOIN theme t ON r.theme_id = t.id
                 LEFT JOIN payment p ON p.reservation_id = r.id
-                WHERE r.name = ? AND r.status IN ('CONFIRMED', 'PAYMENT_UNCERTAIN')
+                WHERE r.name = ? AND r.status IN ('CONFIRMED', 'PAYMENT_UNCERTAIN', 'PAYMENT_PENDING')
                 ORDER BY r.date DESC, rt.start_at DESC
                 """;
         return jdbcTemplate.query(query, (rs, rowNum) -> new ReservationWithPaymentResponse(

--- a/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/JdbcReservationRepository.java
@@ -13,7 +13,9 @@ import roomescape.common.domain.ReservationSlot;
 import roomescape.reservation.domain.PaymentStatus;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.dto.ReservationIdResponse;
+import roomescape.reservation.dto.ReservationWithPaymentResponse;
 import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.reservationtime.dto.TimeResponse;
 import roomescape.theme.domain.Theme;
 
 @Repository
@@ -161,5 +163,36 @@ public class JdbcReservationRepository implements ReservationRepository {
     public void updateStatus(Long reservationId, PaymentStatus status) {
         String query = "UPDATE reservation SET status = ? WHERE id = ?";
         jdbcTemplate.update(query, status.name(), reservationId);
+    }
+
+    @Override
+    public List<ReservationWithPaymentResponse> findWithPaymentByName(String name) {
+        String query = """
+                SELECT r.id as reservation_id, r.name, r.date,
+                       rt.id as time_id, rt.start_at as time_start_at, rt.finish_at as time_finish_at,
+                       t.name as theme_name,
+                       r.status,
+                       p.order_id, p.payment_key, p.amount as payment_amount
+                FROM reservation r
+                JOIN reservation_time rt ON r.time_id = rt.id
+                JOIN theme t ON r.theme_id = t.id
+                LEFT JOIN payment p ON p.reservation_id = r.id
+                WHERE r.name = ? AND r.status IN ('CONFIRMED', 'PAYMENT_UNCERTAIN')
+                ORDER BY r.date DESC, rt.start_at DESC
+                """;
+        return jdbcTemplate.query(query, (rs, rowNum) -> new ReservationWithPaymentResponse(
+                rs.getLong("reservation_id"),
+                rs.getString("name"),
+                rs.getDate("date").toLocalDate(),
+                new TimeResponse(
+                        rs.getLong("time_id"),
+                        rs.getTime("time_start_at").toLocalTime()
+                ),
+                rs.getString("theme_name"),
+                PaymentStatus.valueOf(rs.getString("status")),
+                rs.getString("order_id"),
+                rs.getString("payment_key"),
+                rs.getLong("payment_amount")
+        ), name);
     }
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -7,6 +7,7 @@ import roomescape.common.domain.ReservationSlot;
 import roomescape.reservation.domain.PaymentStatus;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.dto.ReservationIdResponse;
+import roomescape.reservation.dto.ReservationWithPaymentResponse;
 
 public interface ReservationRepository {
     Reservation save(Reservation reservation);
@@ -30,4 +31,6 @@ public interface ReservationRepository {
     ReservationIdResponse findIdBySlot(LocalDate date, Long themeId, Long timeId);
 
     void updateStatus(Long reservationId, PaymentStatus status);
+
+    List<ReservationWithPaymentResponse> findWithPaymentByName(String name);
 }

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -23,6 +23,7 @@ import roomescape.reservation.dto.ReservationIdResponse;
 import roomescape.reservation.dto.ReservationRequest;
 import roomescape.reservation.dto.ReservationResponse;
 import roomescape.reservation.dto.ReservationUpdateRequest;
+import roomescape.reservation.dto.ReservationWithPaymentResponse;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.service.ReservationTimeService;
@@ -119,6 +120,10 @@ public class ReservationService {
     private Reservation getById(Long id) {
         return reservationRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    public List<ReservationWithPaymentResponse> getMyReservations(String name) {
+        return reservationRepository.findWithPaymentByName(name);
     }
 
     public ReservationIdResponse getReservationId(LocalDate date, Long themeId, Long timeId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ toss.payments.base-url=https://api.tosspayments.com
 # 본인 상점 키를 쓰려면 환경변수 TOSS_CLIENT_KEY / TOSS_SECRET_KEY 로 덮어쓴다.
 toss.payments.client-key=${TOSS_CLIENT_KEY:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
 toss.payments.secret-key=${TOSS_SECRET_KEY:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+toss.payments.connect-timeout-ms=1000
+toss.payments.read-timeout-ms=2000

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -53,10 +53,10 @@ CREATE TABLE reservation_waiting
 );
 
 CREATE TABLE payment (
-    order_id VARCHAR(64) NOT NULL,
-    amount      INT          NOT NULL,
-    payment_key VARCHAR(200),
-    reservation_id BIGINT   NOT NULL,
+    order_id       VARCHAR(64)  NOT NULL,
+    amount         INT          NOT NULL,
+    payment_key    VARCHAR(200),
+    reservation_id BIGINT       NOT NULL,
     PRIMARY KEY (order_id),
     FOREIGN KEY (reservation_id) REFERENCES reservation(id) ON DELETE CASCADE
 )

--- a/src/main/resources/static/js/my-reservations.js
+++ b/src/main/resources/static/js/my-reservations.js
@@ -60,24 +60,37 @@ function renderAll(reservations, waitings) {
   rows.forEach(({type, data}) => {
     const tr = document.createElement('tr');
     if (type === 'reservation') {
+      const isPending   = data.status === 'PAYMENT_PENDING';
       const isUncertain = data.status === 'PAYMENT_UNCERTAIN';
-      const statusBadge = isUncertain
-        ? `<span class="status-badge" style="background:#fff3cd;color:#856404;border:1px solid #ffc107;">확인 필요</span>`
-        : `<span class="status-badge status-badge--reserved">예약 확정</span>`;
-      const paymentInfo = isUncertain
-        ? `<div style="font-size:0.78rem;color:#856404;margin-top:4px;">주문번호: ${data.orderId ?? '-'}</div>`
-        : `<div style="font-size:0.78rem;color:var(--text-muted);margin-top:4px;">${data.amount != null ? data.amount.toLocaleString() + '원' : ''}</div>`;
+
+      let statusBadge, paymentInfo, actionButtons;
+
+      if (isPending) {
+        const checkoutUrl = `/payments/checkout?orderId=${encodeURIComponent(data.orderId)}&orderName=${encodeURIComponent(data.themeName)}`;
+        statusBadge  = `<span class="status-badge" style="background:#e2e3e5;color:#383d41;border:1px solid #d6d8db;">결제 대기</span>`;
+        paymentInfo  = `<div style="font-size:0.78rem;color:#6c757d;margin-top:4px;">${data.amount != null ? data.amount.toLocaleString() + '원' : ''}</div>`;
+        actionButtons = `
+          <a href="${checkoutUrl}" class="btn btn-primary" style="font-size:0.82rem;padding:6px 12px;margin-right:4px;">결제하기</a>
+          <button class="btn btn-danger" onclick="cancelReservation(${data.id}, this)">취소</button>`;
+      } else if (isUncertain) {
+        statusBadge  = `<span class="status-badge" style="background:#fff3cd;color:#856404;border:1px solid #ffc107;">확인 필요</span>`;
+        paymentInfo  = `<div style="font-size:0.78rem;color:#856404;margin-top:4px;">주문번호: ${data.orderId ?? '-'}</div>`;
+        actionButtons = `<button class="btn btn-danger" onclick="cancelReservation(${data.id}, this)">취소</button>`;
+      } else {
+        statusBadge  = `<span class="status-badge status-badge--reserved">예약 확정</span>`;
+        paymentInfo  = `<div style="font-size:0.78rem;color:var(--text-muted);margin-top:4px;">${data.amount != null ? data.amount.toLocaleString() + '원' : ''}</div>`;
+        actionButtons = `
+          <button class="btn btn-secondary" style="font-size:0.82rem;padding:6px 12px;margin-right:4px;"
+            onclick="openEditModal(${data.id}, '${data.date}', ${data.themeId})">변경</button>
+          <button class="btn btn-danger" onclick="cancelReservation(${data.id}, this)">취소</button>`;
+      }
+
       tr.innerHTML = `
         <td>${data.date}</td>
         <td>${data.themeName}</td>
         <td>${formatTime(data.time.startAt)}</td>
         <td>${statusBadge}${paymentInfo}</td>
-        <td style="text-align:right;">
-          <button class="btn btn-secondary" style="font-size:0.82rem;padding:6px 12px;margin-right:4px;"
-            onclick="openEditModal(${data.id}, '${data.date}', ${data.themeId})">변경</button>
-          <button class="btn btn-danger"
-            onclick="cancelReservation(${data.id}, this)">취소</button>
-        </td>
+        <td style="text-align:right;">${actionButtons}</td>
       `;
     } else {
       tr.innerHTML = `

--- a/src/main/resources/static/js/my-reservations.js
+++ b/src/main/resources/static/js/my-reservations.js
@@ -28,7 +28,7 @@ function search() {
   if (!name) { showToast('이름을 입력해주세요.'); return; }
 
   Promise.all([
-    fetch(`/reservations?name=${encodeURIComponent(name)}`).then(r => r.json()),
+    fetch(`/reservations/my?name=${encodeURIComponent(name)}`).then(r => r.json()),
     fetch(`/waitings?name=${encodeURIComponent(name)}`).then(r => r.json())
   ])
     .then(([reservations, waitings]) => renderAll(reservations, waitings))
@@ -60,11 +60,18 @@ function renderAll(reservations, waitings) {
   rows.forEach(({type, data}) => {
     const tr = document.createElement('tr');
     if (type === 'reservation') {
+      const isUncertain = data.status === 'PAYMENT_UNCERTAIN';
+      const statusBadge = isUncertain
+        ? `<span class="status-badge" style="background:#fff3cd;color:#856404;border:1px solid #ffc107;">확인 필요</span>`
+        : `<span class="status-badge status-badge--reserved">예약 확정</span>`;
+      const paymentInfo = isUncertain
+        ? `<div style="font-size:0.78rem;color:#856404;margin-top:4px;">주문번호: ${data.orderId ?? '-'}</div>`
+        : `<div style="font-size:0.78rem;color:var(--text-muted);margin-top:4px;">${data.amount != null ? data.amount.toLocaleString() + '원' : ''}</div>`;
       tr.innerHTML = `
         <td>${data.date}</td>
         <td>${data.themeName}</td>
         <td>${formatTime(data.time.startAt)}</td>
-        <td><span class="status-badge status-badge--reserved">예약</span></td>
+        <td>${statusBadge}${paymentInfo}</td>
         <td style="text-align:right;">
           <button class="btn btn-secondary" style="font-size:0.82rem;padding:6px 12px;margin-right:4px;"
             onclick="openEditModal(${data.id}, '${data.date}', ${data.themeId})">변경</button>

--- a/src/main/resources/templates/my-reservations.html
+++ b/src/main/resources/templates/my-reservations.html
@@ -49,7 +49,7 @@
           <th>날짜</th>
           <th>테마</th>
           <th>시간</th>
-          <th>상태</th>
+          <th>결제 상태 / 금액</th>
           <th style="width:180px;text-align:right;">관리</th>
         </tr>
       </thead>


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [x] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->


## 1. RestClient 타임아웃 설정
`SimpleClientHttpRequestFactory`로 connect/read timeout을 설정하고, 값은 `application.properties`로 외부화했다.
```
toss.payments.connect-timeout-ms=1000
toss.payments.read-timeout-ms=2000
```

## 2. 타임아웃 예외 => 도메인 예외 변환
`TossPaymentGateway`에서 `ResourceAccessException`을 잡아 원인에 따라 분기한다.

## 3. Idempotency-Key 헤더
`TossPaymentGateway.confirm()`에서 `Idempotency-Key: {orderId}` 헤더를 추가한다.
orderId는 주문당 고정 UUID이므로 조건(같은 주문 = 같은 키)을 이미 만족한다.
같은 orderId로 confirm을 다시 보내면 토스가 첫 응답을 그대로 돌려줘 이중 승인이 없다.

```
.header("Idempotency-Key", confirmation.orderId())
```

## 4. 내 예약 페이지 — 결제 상태 표시
`GET /reservations/my?name=` 엔드포인트를 추가하고 reservation + payment를 LEFT JOIN해 반환한다. `PAYMENT_PENDING`도 포함하였다.

상태 | 표시 | 버튼
-- | -- | --
PAYMENT_PENDING | 결제 대기 | 결제하기 (checkout 재진입) + 취소
PAYMENT_UNCERTAIN | 확인 필요 | 취소
CONFIRMED | 예약 확정 + 금액 | 변경 + 취소

"결제하기" 버튼으로 checkout에 재진입해도 Idempotency-Key 덕에 이중 승인 없음.

