### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 카키(남해윤) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/domain/payment/PaymentClient.java
+++ b/src/main/java/roomescape/domain/payment/PaymentClient.java
@@ -5,5 +5,5 @@ import roomescape.domain.payment.dto.PaymentConfirmResponse;
 
 public interface PaymentClient {
 
-    PaymentConfirmResponse confirm(PaymentConfirmRequest request);
+    PaymentConfirmResponse confirm(PaymentConfirmRequest request, String idempotencyKey);
 }

--- a/src/main/java/roomescape/domain/payment/PaymentConnectionException.java
+++ b/src/main/java/roomescape/domain/payment/PaymentConnectionException.java
@@ -1,0 +1,14 @@
+package roomescape.domain.payment;
+
+import org.springframework.http.HttpStatus;
+
+public class PaymentConnectionException extends PaymentException {
+
+    public PaymentConnectionException() {
+        super(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "PAYMENT_CONNECTION_FAILED",
+            "결제 서버에 연결하지 못했습니다. 잠시 후 다시 시도해주세요."
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/payment/PaymentRepository.java
+++ b/src/main/java/roomescape/domain/payment/PaymentRepository.java
@@ -1,0 +1,104 @@
+package roomescape.domain.payment;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PaymentRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert simpleJdbcInsert;
+
+    private final RowMapper<ReservationPayment> rowMapper = (resultSet, rowNum) ->
+        new ReservationPayment(
+            resultSet.getLong("id"),
+            resultSet.getLong("reservation_id"),
+            resultSet.getString("order_id"),
+            resultSet.getString("payment_key"),
+            resultSet.getLong("amount"),
+            resultSet.getString("idempotency_key"),
+            PaymentStatus.valueOf(resultSet.getString("status"))
+        );
+
+    public PaymentRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.simpleJdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+            .withTableName("reservation_payment")
+            .usingGeneratedKeyColumns("id");
+    }
+
+    public ReservationPayment save(ReservationPayment payment) {
+        MapSqlParameterSource parameters = new MapSqlParameterSource()
+            .addValue("reservation_id", payment.reservationId())
+            .addValue("order_id", payment.orderId())
+            .addValue("payment_key", payment.paymentKey())
+            .addValue("amount", payment.amount())
+            .addValue("idempotency_key", payment.idempotencyKey())
+            .addValue("status", payment.status().name());
+        Long id = simpleJdbcInsert.executeAndReturnKey(parameters).longValue();
+        return new ReservationPayment(
+            id,
+            payment.reservationId(),
+            payment.orderId(),
+            payment.paymentKey(),
+            payment.amount(),
+            payment.idempotencyKey(),
+            payment.status()
+        );
+    }
+
+    public Optional<ReservationPayment> findByOrderId(String orderId) {
+        String query = """
+            SELECT id, reservation_id, order_id, payment_key, amount, idempotency_key, status
+            FROM reservation_payment
+            WHERE order_id = ?
+            """;
+        return jdbcTemplate.query(query, rowMapper, orderId).stream().findFirst();
+    }
+
+    public List<ReservationPayment> findByReservationIds(List<Long> reservationIds) {
+        if (reservationIds.isEmpty()) {
+            return List.of();
+        }
+        String placeholders = String.join(",", reservationIds.stream().map(id -> "?").toList());
+        String query = """
+            SELECT id, reservation_id, order_id, payment_key, amount, idempotency_key, status
+            FROM reservation_payment
+            WHERE reservation_id IN (%s)
+            """.formatted(placeholders);
+        return jdbcTemplate.query(query, rowMapper, reservationIds.toArray());
+    }
+
+    public void updateConfirmed(String orderId, String paymentKey, Long amount) {
+        String query = """
+            UPDATE reservation_payment
+            SET payment_key = ?, amount = ?, status = ?
+            WHERE order_id = ?
+            """;
+        jdbcTemplate.update(query, paymentKey, amount, PaymentStatus.CONFIRMED.name(), orderId);
+    }
+
+    public void updateStatus(String orderId, PaymentStatus status) {
+        String query = "UPDATE reservation_payment SET status = ? WHERE order_id = ?";
+        jdbcTemplate.update(query, status.name(), orderId);
+    }
+
+    public void updateRequiresConfirmation(String orderId, String paymentKey) {
+        String query = """
+            UPDATE reservation_payment
+            SET payment_key = ?, status = ?
+            WHERE order_id = ?
+            """;
+        jdbcTemplate.update(
+            query,
+            paymentKey,
+            PaymentStatus.REQUIRES_CONFIRMATION.name(),
+            orderId
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/payment/PaymentResultUnknownException.java
+++ b/src/main/java/roomescape/domain/payment/PaymentResultUnknownException.java
@@ -1,0 +1,14 @@
+package roomescape.domain.payment;
+
+import org.springframework.http.HttpStatus;
+
+public class PaymentResultUnknownException extends PaymentException {
+
+    public PaymentResultUnknownException() {
+        super(
+            HttpStatus.GATEWAY_TIMEOUT,
+            "PAYMENT_RESULT_UNKNOWN",
+            "결제 결과를 확인하지 못했습니다. 결제 내역을 확인하거나 다시 시도해주세요."
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/payment/PaymentService.java
+++ b/src/main/java/roomescape/domain/payment/PaymentService.java
@@ -3,17 +3,61 @@ package roomescape.domain.payment;
 import org.springframework.stereotype.Service;
 import roomescape.domain.payment.dto.PaymentConfirmRequest;
 import roomescape.domain.payment.dto.PaymentConfirmResponse;
+import roomescape.exception.ErrorCode;
+import roomescape.exception.RoomescapeException;
 
 @Service
 public class PaymentService {
 
     private final PaymentClient paymentClient;
+    private final PaymentRepository paymentRepository;
 
-    public PaymentService(PaymentClient paymentClient) {
+    public PaymentService(PaymentClient paymentClient, PaymentRepository paymentRepository) {
         this.paymentClient = paymentClient;
+        this.paymentRepository = paymentRepository;
     }
 
     public PaymentConfirmResponse confirm(PaymentConfirmRequest request) {
-        return paymentClient.confirm(request);
+        ReservationPayment payment = paymentRepository.findByOrderId(request.orderId())
+            .orElseThrow(() -> new RoomescapeException(ErrorCode.PAYMENT_ORDER_NOT_FOUND));
+        validateAmount(request, payment);
+
+        if (payment.status() == PaymentStatus.CONFIRMED) {
+            return confirmedResponse(payment);
+        }
+
+        try {
+            PaymentConfirmResponse response = paymentClient.confirm(request, payment.idempotencyKey());
+            paymentRepository.updateConfirmed(request.orderId(), response.paymentKey(), response.totalAmount());
+            return response;
+        } catch (PaymentResultUnknownException exception) {
+            paymentRepository.updateRequiresConfirmation(request.orderId(), request.paymentKey());
+            throw exception;
+        } catch (PaymentConnectionException exception) {
+            paymentRepository.updateStatus(request.orderId(), PaymentStatus.FAILED);
+            throw exception;
+        } catch (PaymentException exception) {
+            if ("ALREADY_PROCESSED_PAYMENT".equals(exception.getCode())) {
+                paymentRepository.updateRequiresConfirmation(request.orderId(), request.paymentKey());
+            } else {
+                paymentRepository.updateStatus(request.orderId(), PaymentStatus.FAILED);
+            }
+            throw exception;
+        }
+    }
+
+    private void validateAmount(PaymentConfirmRequest request, ReservationPayment payment) {
+        if (!payment.amount().equals(request.amount())) {
+            throw new RoomescapeException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    private PaymentConfirmResponse confirmedResponse(ReservationPayment payment) {
+        return new PaymentConfirmResponse(
+            payment.paymentKey(),
+            payment.orderId(),
+            payment.amount(),
+            "DONE"
+        );
     }
 }

--- a/src/main/java/roomescape/domain/payment/PaymentStatus.java
+++ b/src/main/java/roomescape/domain/payment/PaymentStatus.java
@@ -1,0 +1,8 @@
+package roomescape.domain.payment;
+
+public enum PaymentStatus {
+    PENDING,
+    CONFIRMED,
+    FAILED,
+    REQUIRES_CONFIRMATION
+}

--- a/src/main/java/roomescape/domain/payment/ReservationPayment.java
+++ b/src/main/java/roomescape/domain/payment/ReservationPayment.java
@@ -1,0 +1,26 @@
+package roomescape.domain.payment;
+
+import java.util.UUID;
+
+public record ReservationPayment(
+    Long id,
+    Long reservationId,
+    String orderId,
+    String paymentKey,
+    Long amount,
+    String idempotencyKey,
+    PaymentStatus status
+) {
+
+    public static ReservationPayment pending(Long reservationId, Long amount) {
+        return new ReservationPayment(
+            null,
+            reservationId,
+            UUID.randomUUID().toString(),
+            null,
+            amount,
+            UUID.randomUUID().toString(),
+            PaymentStatus.PENDING
+        );
+    }
+}

--- a/src/main/java/roomescape/domain/payment/TossPaymentsClient.java
+++ b/src/main/java/roomescape/domain/payment/TossPaymentsClient.java
@@ -2,14 +2,20 @@ package roomescape.domain.payment;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.ResourceAccessException;
 import roomescape.domain.payment.dto.PaymentConfirmRequest;
 import roomescape.domain.payment.dto.PaymentConfirmResponse;
 import roomescape.domain.payment.dto.PaymentErrorResponse;
@@ -23,19 +29,30 @@ public class TossPaymentsClient implements PaymentClient {
     private final ObjectMapper objectMapper;
     private final String secretKey;
 
+    @Autowired
     public TossPaymentsClient(
         RestClient.Builder restClientBuilder,
         ObjectMapper objectMapper,
         @Value("${toss.payments.base-url:https://api.tosspayments.com}") String baseUrl,
-        @Value("${toss.payments.secret-key:}") String secretKey
+        @Value("${toss.payments.secret-key:}") String secretKey,
+        @Value("${toss.payments.connect-timeout}") Duration connectTimeout,
+        @Value("${toss.payments.read-timeout}") Duration readTimeout
     ) {
-        this.restClient = restClientBuilder.baseUrl(baseUrl).build();
+        this(
+            buildRestClient(restClientBuilder, baseUrl, connectTimeout, readTimeout),
+            objectMapper,
+            secretKey
+        );
+    }
+
+    TossPaymentsClient(RestClient restClient, ObjectMapper objectMapper, String secretKey) {
+        this.restClient = restClient;
         this.objectMapper = objectMapper;
         this.secretKey = secretKey;
     }
 
     @Override
-    public PaymentConfirmResponse confirm(PaymentConfirmRequest request) {
+    public PaymentConfirmResponse confirm(PaymentConfirmRequest request, String idempotencyKey) {
         if (!StringUtils.hasText(secretKey)) {
             throw new RoomescapeException(ErrorCode.PAYMENT_SECRET_KEY_NOT_CONFIGURED);
         }
@@ -44,6 +61,7 @@ public class TossPaymentsClient implements PaymentClient {
             return restClient.post()
                 .uri("/v1/payments/confirm")
                 .header(HttpHeaders.AUTHORIZATION, authorizationHeader())
+                .header("Idempotency-Key", idempotencyKey)
                 .body(request)
                 .retrieve()
                 .body(PaymentConfirmResponse.class);
@@ -54,6 +72,16 @@ public class TossPaymentsClient implements PaymentClient {
                 errorResponse.code(),
                 errorResponse.message()
             );
+        } catch (ResourceAccessException exception) {
+            if (isReadTimeout(exception)) {
+                throw new PaymentResultUnknownException();
+            }
+            throw new PaymentConnectionException();
+        } catch (RestClientException exception) {
+            if (hasCause(exception, SocketTimeoutException.class)) {
+                throw new PaymentResultUnknownException();
+            }
+            throw new PaymentConnectionException();
         }
     }
 
@@ -69,5 +97,41 @@ public class TossPaymentsClient implements PaymentClient {
         } catch (JsonProcessingException exception) {
             return new PaymentErrorResponse(null, null);
         }
+    }
+
+    private boolean isReadTimeout(Throwable throwable) {
+        Throwable rootCause = rootCause(throwable);
+        if (!(rootCause instanceof SocketTimeoutException)) {
+            return false;
+        }
+        String message = rootCause.getMessage();
+        return message == null || !message.toLowerCase().contains("connect");
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+        return causeType.isInstance(rootCause(throwable));
+    }
+
+    private Throwable rootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static RestClient buildRestClient(
+        RestClient.Builder restClientBuilder,
+        String baseUrl,
+        Duration connectTimeout,
+        Duration readTimeout
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeout);
+        requestFactory.setReadTimeout(readTimeout);
+        return restClientBuilder
+            .baseUrl(baseUrl)
+            .requestFactory(requestFactory)
+            .build();
     }
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationService.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationService.java
@@ -1,7 +1,10 @@
 package roomescape.domain.reservation;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +12,8 @@ import roomescape.domain.reservation.dto.MyReservationsResponse;
 import roomescape.domain.reservation.dto.ReservationFixRequest;
 import roomescape.domain.reservation.dto.ReservationRequest;
 import roomescape.domain.reservation.dto.ReservationResponse;
+import roomescape.domain.payment.PaymentRepository;
+import roomescape.domain.payment.ReservationPayment;
 import roomescape.domain.reservationtime.ReservationTime;
 import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
@@ -22,21 +27,26 @@ import roomescape.exception.RoomescapeException;
 @Service
 public class ReservationService {
 
+    private static final long RESERVATION_PRICE = 10_000L;
+
     private final ReservationRepository reservationRepository;
     private final ReservationTimeRepository reservationTimeRepository;
     private final ThemeRepository themeRepository;
     private final WaitingRepository waitingRepository;
+    private final PaymentRepository paymentRepository;
 
     public ReservationService(
         ReservationRepository reservationRepository,
         ReservationTimeRepository reservationTimeRepository,
         ThemeRepository themeRepository,
-        WaitingRepository waitingRepository
+        WaitingRepository waitingRepository,
+        PaymentRepository paymentRepository
     ) {
         this.reservationRepository = reservationRepository;
         this.reservationTimeRepository = reservationTimeRepository;
         this.themeRepository = themeRepository;
         this.waitingRepository = waitingRepository;
+        this.paymentRepository = paymentRepository;
     }
 
     @Transactional
@@ -58,7 +68,8 @@ public class ReservationService {
 
         try {
             Reservation saved = reservationRepository.save(reservation);
-            return ReservationResponse.from(saved);
+            ReservationPayment payment = createPendingPayment(saved.getId());
+            return ReservationResponse.from(saved, payment);
         } catch (DuplicateKeyException exception) {
             throw new RoomescapeException(ErrorCode.DUPLICATE_RESERVATION);
         }
@@ -88,7 +99,13 @@ public class ReservationService {
     @Transactional(readOnly = true)
     public MyReservationsResponse getMyReservations(String name) {
         List<Reservation> reservations = reservationRepository.findByName(name);
-        return MyReservationsResponse.from(reservations);
+        List<Long> reservationIds = reservations.stream()
+            .map(Reservation::getId)
+            .toList();
+        Map<Long, ReservationPayment> paymentsByReservationId =
+            paymentRepository.findByReservationIds(reservationIds).stream()
+                .collect(Collectors.toMap(ReservationPayment::reservationId, Function.identity()));
+        return MyReservationsResponse.from(reservations, paymentsByReservationId);
     }
 
     @Transactional
@@ -125,14 +142,18 @@ public class ReservationService {
 
         waitingRepository.findFirstByTimeSlotForUpdate(canceledReservationSlot)
             .ifPresent(waiting -> {
-                reservationRepository.save(Reservation.of(
+                Reservation promotedReservation = reservationRepository.save(Reservation.of(
                     waiting.getName(),
                     waiting.getDate(),
                     waiting.getTime(),
                     waiting.getTheme()
                 ));
+                createPendingPayment(promotedReservation.getId());
                 waitingRepository.deleteById(waiting.getId());
             });
     }
 
+    private ReservationPayment createPendingPayment(Long reservationId) {
+        return paymentRepository.save(ReservationPayment.pending(reservationId, RESERVATION_PRICE));
+    }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/MyReservationResponse.java
@@ -2,6 +2,8 @@ package roomescape.domain.reservation.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import roomescape.domain.payment.PaymentStatus;
+import roomescape.domain.payment.ReservationPayment;
 import roomescape.domain.reservation.Reservation;
 
 public record MyReservationResponse(
@@ -9,16 +11,24 @@ public record MyReservationResponse(
     String name,
     LocalDate date,
     LocalTime time,
-    String themeName
+    String themeName,
+    PaymentStatus paymentStatus,
+    String orderId,
+    String paymentKey,
+    Long amount
 ) {
 
-    public static MyReservationResponse from(Reservation reservation) {
+    public static MyReservationResponse from(Reservation reservation, ReservationPayment payment) {
         return new MyReservationResponse(
             reservation.getId(),
             reservation.getName(),
             reservation.getDate(),
             reservation.getTime().getStartAt(),
-            reservation.getTheme().getName()
+            reservation.getTheme().getName(),
+            payment == null ? PaymentStatus.PENDING : payment.status(),
+            payment == null ? null : payment.orderId(),
+            payment == null ? null : payment.paymentKey(),
+            payment == null ? null : payment.amount()
         );
     }
 }

--- a/src/main/java/roomescape/domain/reservation/dto/MyReservationsResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/MyReservationsResponse.java
@@ -1,15 +1,23 @@
 package roomescape.domain.reservation.dto;
 
 import java.util.List;
+import java.util.Map;
+import roomescape.domain.payment.ReservationPayment;
 import roomescape.domain.reservation.Reservation;
 
 public record MyReservationsResponse(
     List<MyReservationResponse> reservations
 ) {
 
-    public static MyReservationsResponse from(List<Reservation> reservations) {
+    public static MyReservationsResponse from(
+        List<Reservation> reservations,
+        Map<Long, ReservationPayment> paymentsByReservationId
+    ) {
         return new MyReservationsResponse(reservations.stream()
-            .map(MyReservationResponse::from)
+            .map(reservation -> MyReservationResponse.from(
+                reservation,
+                paymentsByReservationId.get(reservation.getId())
+            ))
             .toList()
         );
     }

--- a/src/main/java/roomescape/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/domain/reservation/dto/ReservationResponse.java
@@ -1,6 +1,7 @@
 package roomescape.domain.reservation.dto;
 
 import java.time.LocalDate;
+import roomescape.domain.payment.ReservationPayment;
 import roomescape.domain.reservation.Reservation;
 
 public record ReservationResponse(
@@ -8,16 +9,20 @@ public record ReservationResponse(
     String name,
     LocalDate date,
     Long timeId,
-    Long themeId
+    Long themeId,
+    String orderId,
+    Long amount
 ) {
 
-    public static ReservationResponse from(Reservation reservation) {
+    public static ReservationResponse from(Reservation reservation, ReservationPayment payment) {
         return new ReservationResponse(
             reservation.getId(),
             reservation.getName(),
             reservation.getDate(),
             reservation.getTime().getId(),
-            reservation.getTheme().getId()
+            reservation.getTheme().getId(),
+            payment.orderId(),
+            payment.amount()
         );
     }
 }

--- a/src/main/java/roomescape/exception/ErrorCode.java
+++ b/src/main/java/roomescape/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
     INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 입력값 입니다."),
     MISSING_NAME(HttpStatus.BAD_REQUEST, "이름은 필수 입력 값입니다."),
     PAYMENT_SECRET_KEY_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "결제 시크릿 키가 설정되어있지 않습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "주문 금액과 결제 금액이 일치하지 않습니다."),
 
     //401 - UNAUTHORIZED
     UNAUTHORIZED_NAME(HttpStatus.UNAUTHORIZED, "해당 예약을 삭제할 권한이 없습니다."),
@@ -16,6 +17,7 @@ public enum ErrorCode {
     THEME_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 theme id를 찾을 수 없습니다."),
     RESERVATION_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 reservation id를 찾을 수 없습니다."),
     WAITING_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 waiting id를 찾을 수 없습니다."),
+    PAYMENT_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "결제할 주문을 찾을 수 없습니다."),
 
     //409 - CONFLICT
     DUPLICATE_RESERVATION(HttpStatus.CONFLICT, "이미 선택된 예약입니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
 toss.payments.secret-key=${TOSS_PAYMENTS_SECRET_KEY:}
+toss.payments.connect-timeout=2s
+toss.payments.read-timeout=3s

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -93,6 +93,16 @@ VALUES
     ('user1', '2026-06-06', 5, 20),
     ('user1', '2026-06-07', 8, 15);
 
+INSERT INTO reservation_payment
+    (reservation_id, order_id, payment_key, amount, idempotency_key, status)
+SELECT id,
+       CAST(RANDOM_UUID() AS VARCHAR),
+       NULL,
+       10000,
+       CAST(RANDOM_UUID() AS VARCHAR),
+       'PENDING'
+FROM reservation;
+
 -- 예약 대기 데이터
 INSERT INTO waiting (name, date, time_id, theme_id)
 VALUES ('waiting1', '2026-05-25', 1, 1),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS waiting;
+DROP TABLE IF EXISTS reservation_payment;
 DROP TABLE IF EXISTS reservation;
 DROP TABLE IF EXISTS theme;
 DROP TABLE IF EXISTS reservation_time;
@@ -45,4 +46,17 @@ CREATE TABLE waiting
     FOREIGN KEY (theme_id) REFERENCES theme (id),
     FOREIGN KEY (time_id) REFERENCES reservation_time (id),
     CONSTRAINT unique_waiting UNIQUE (date, time_id, theme_id, name)
+);
+
+CREATE TABLE reservation_payment
+(
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    reservation_id  BIGINT       NOT NULL UNIQUE,
+    order_id         VARCHAR(100) NOT NULL UNIQUE,
+    payment_key      VARCHAR(200),
+    amount           BIGINT       NOT NULL,
+    idempotency_key  VARCHAR(300) NOT NULL UNIQUE,
+    status           VARCHAR(30)  NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (reservation_id) REFERENCES reservation (id) ON DELETE CASCADE
 );

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -313,6 +313,20 @@ img { max-width: 100%; display: block; }
 .actions-cell > .btn + .btn { margin-left: 6px; }
 .actions-cell > .btn { vertical-align: middle; }
 
+.payment-status {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.payment-status-pending { background: #fff4cc; color: #765900; }
+.payment-status-confirmed { background: #dff5e5; color: #176b36; }
+.payment-status-failed { background: #fde3e3; color: #a12828; }
+.payment-status-requires_confirmation { background: #e8e5ff; color: #4d3aa8; }
+
 /* ─── Section ─── */
 .section { margin-top: 56px; }
 .section:first-of-type { margin-top: 0; }
@@ -507,7 +521,7 @@ select.form-control { appearance: none; background-image: url("data:image/svg+xm
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
   box-shadow: var(--shadow-sm);
 }
 
@@ -534,6 +548,9 @@ table.table tbody td {
 }
 
 table.table tbody tr:hover { background: var(--surface-2); }
+
+.payment-history-table { min-width: 1250px; }
+.payment-history-table td { overflow-wrap: anywhere; }
 
 table.table td .form-control { height: 36px; padding: 6px 10px; }
 

--- a/src/main/resources/static/js/my-reservations.js
+++ b/src/main/resources/static/js/my-reservations.js
@@ -70,9 +70,16 @@ function buildRow(r) {
   row.appendChild(cell(r.themeName || '-'));
   row.appendChild(cell(r.date));
   row.appendChild(cell(formatTime(r.time)));
+  row.appendChild(paymentStatusCell(r.paymentStatus));
+  row.appendChild(cell(r.orderId || '-'));
+  row.appendChild(cell(r.paymentKey || '-'));
+  row.appendChild(cell(formatAmount(r.amount)));
 
   const actions = document.createElement('td');
   actions.className = 'actions-cell';
+  if (r.paymentStatus === 'REQUIRES_CONFIRMATION') {
+    actions.appendChild(button('결제 재확인', 'btn btn-success btn-sm', () => retryPayment(r)));
+  }
   actions.appendChild(button('수정', 'btn btn-primary btn-sm', () => startEdit(row, r)));
   actions.appendChild(button('삭제', 'btn btn-danger btn-sm', () => deleteReservation(r.id, row)));
   row.appendChild(actions);
@@ -119,7 +126,7 @@ function startEdit(row, r) {
   });
   cells[3].appendChild(timeSelect);
 
-  const actions = cells[4];
+  const actions = cells[8];
   actions.innerHTML = '';
   actions.className = 'actions-cell';
   actions.appendChild(button('저장', 'btn btn-success btn-sm', () => {
@@ -158,6 +165,23 @@ function deleteReservation(id, row) {
     .catch(showError);
 }
 
+function retryPayment(reservation) {
+  apiFetch('/payments/confirm', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      paymentKey: reservation.paymentKey,
+      orderId: reservation.orderId,
+      amount: reservation.amount
+    })
+  })
+    .then(() => {
+      alert('결제 결과가 확인되었습니다.');
+      searchReservations();
+    })
+    .catch(showError);
+}
+
 function deleteWaiting(id, row) {
   if (!confirm('이 예약 대기를 삭제하시겠습니까?')) return;
   apiFetch(`/reservations/waiting/${id}`, { method: 'DELETE' })
@@ -175,6 +199,26 @@ function cell(text) {
   const td = document.createElement('td');
   td.textContent = text;
   return td;
+}
+
+function paymentStatusCell(status) {
+  const labels = {
+    PENDING: '결제 대기',
+    CONFIRMED: '확정',
+    FAILED: '실패',
+    REQUIRES_CONFIRMATION: '확인 필요'
+  };
+  const td = document.createElement('td');
+  const badge = document.createElement('span');
+  badge.className = `payment-status payment-status-${(status || 'PENDING').toLowerCase()}`;
+  badge.textContent = labels[status] || labels.PENDING;
+  td.appendChild(badge);
+  return td;
+}
+
+function formatAmount(amount) {
+  if (amount === null || amount === undefined) return '-';
+  return `${Number(amount).toLocaleString('ko-KR')}원`;
 }
 
 function button(label, className, handler) {

--- a/src/main/resources/templates/my-reservations.html
+++ b/src/main/resources/templates/my-reservations.html
@@ -48,13 +48,17 @@
 
   <h2 class="section-title">확정 예약</h2>
   <div class="table-container my-table-section">
-    <table class="table">
+    <table class="table payment-history-table">
       <thead>
       <tr>
         <th style="width:80px;">번호</th>
         <th>테마</th>
         <th style="width:140px;">날짜</th>
         <th style="width:100px;">시간</th>
+        <th style="width:120px;">결제 상태</th>
+        <th>주문 번호</th>
+        <th>결제 키</th>
+        <th style="width:110px;">금액</th>
         <th style="width:220px;text-align:right;">관리</th>
       </tr>
       </thead>

--- a/src/test/java/roomescape/domain/payment/PaymentControllerTest.java
+++ b/src/test/java/roomescape/domain/payment/PaymentControllerTest.java
@@ -25,7 +25,7 @@ class PaymentControllerTest {
     private int port;
 
     @MockitoBean
-    private PaymentClient paymentClient;
+    private PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
@@ -34,7 +34,7 @@ class PaymentControllerTest {
 
     @Test
     void 결제_승인_요청_성공_테스트() {
-        given(paymentClient.confirm(any(PaymentConfirmRequest.class)))
+        given(paymentService.confirm(any(PaymentConfirmRequest.class)))
             .willReturn(new PaymentConfirmResponse("paymentKey", "orderId", 1000L, "DONE"));
 
         Map<String, Object> params = new HashMap<>();
@@ -72,7 +72,7 @@ class PaymentControllerTest {
 
     @Test
     void 토스_승인_에러의_code와_message를_반환한다() {
-        given(paymentClient.confirm(any(PaymentConfirmRequest.class)))
+        given(paymentService.confirm(any(PaymentConfirmRequest.class)))
             .willThrow(new PaymentException(
                 HttpStatus.BAD_REQUEST,
                 "ALREADY_PROCESSED_PAYMENT",

--- a/src/test/java/roomescape/domain/payment/PaymentRepositoryTest.java
+++ b/src/test/java/roomescape/domain/payment/PaymentRepositoryTest.java
@@ -1,0 +1,79 @@
+package roomescape.domain.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@JdbcTest
+@Import(PaymentRepository.class)
+class PaymentRepositoryTest {
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 주문의_멱등키와_결제_상태를_저장하고_조회한다() {
+        Long reservationId = createReservation();
+        ReservationPayment pending = ReservationPayment.pending(reservationId, 10_000L);
+
+        ReservationPayment saved = paymentRepository.save(pending);
+        ReservationPayment found = paymentRepository.findByOrderId(saved.orderId()).orElseThrow();
+
+        assertThat(found.idempotencyKey()).isEqualTo(saved.idempotencyKey());
+        assertThat(found.status()).isEqualTo(PaymentStatus.PENDING);
+    }
+
+    @Test
+    void 승인_결과를_저장한다() {
+        Long reservationId = createReservation();
+        ReservationPayment saved = paymentRepository.save(
+            ReservationPayment.pending(reservationId, 10_000L)
+        );
+
+        paymentRepository.updateConfirmed(saved.orderId(), "paymentKey", 10_000L);
+
+        ReservationPayment confirmed = paymentRepository.findByOrderId(saved.orderId()).orElseThrow();
+        assertThat(confirmed.paymentKey()).isEqualTo("paymentKey");
+        assertThat(confirmed.status()).isEqualTo(PaymentStatus.CONFIRMED);
+    }
+
+    @Test
+    void 결과가_불명확하면_paymentKey와_확인_필요_상태를_저장한다() {
+        Long reservationId = createReservation();
+        ReservationPayment saved = paymentRepository.save(
+            ReservationPayment.pending(reservationId, 10_000L)
+        );
+
+        paymentRepository.updateRequiresConfirmation(saved.orderId(), "paymentKey");
+
+        ReservationPayment unknown = paymentRepository.findByOrderId(saved.orderId()).orElseThrow();
+        assertThat(unknown.paymentKey()).isEqualTo("paymentKey");
+        assertThat(unknown.status()).isEqualTo(PaymentStatus.REQUIRES_CONFIRMATION);
+    }
+
+    private Long createReservation() {
+        jdbcTemplate.update(
+            "INSERT INTO reservation_time (start_at, finish_at) VALUES ('20:00:00', '21:00:00')"
+        );
+        jdbcTemplate.update(
+            "INSERT INTO theme (name, description, image_url) VALUES ('결제테마', '설명', 'image')"
+        );
+        jdbcTemplate.update("""
+            INSERT INTO reservation (name, date, time_id, theme_id)
+            VALUES ('결제자', '2099-12-31',
+                    (SELECT id FROM reservation_time WHERE start_at = '20:00:00'),
+                    (SELECT id FROM theme WHERE name = '결제테마'))
+            """);
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM reservation WHERE name = '결제자'",
+            Long.class
+        );
+    }
+}

--- a/src/test/java/roomescape/domain/payment/PaymentServiceTest.java
+++ b/src/test/java/roomescape/domain/payment/PaymentServiceTest.java
@@ -2,13 +2,16 @@ package roomescape.domain.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import roomescape.exception.RoomescapeException;
 import roomescape.domain.payment.dto.PaymentConfirmRequest;
 import roomescape.domain.payment.dto.PaymentConfirmResponse;
 
@@ -18,6 +21,9 @@ class PaymentServiceTest {
     @Mock
     private PaymentClient paymentClient;
 
+    @Mock
+    private PaymentRepository paymentRepository;
+
     @InjectMocks
     private PaymentService paymentService;
 
@@ -25,11 +31,84 @@ class PaymentServiceTest {
     void 결제_승인_요청을_클라이언트에_위임한다() {
         PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
         PaymentConfirmResponse expected = new PaymentConfirmResponse("paymentKey", "orderId", 1000L, "DONE");
-        given(paymentClient.confirm(request)).willReturn(expected);
+        ReservationPayment payment = new ReservationPayment(
+            1L,
+            1L,
+            "orderId",
+            null,
+            1000L,
+            "fixed-idempotency-key",
+            PaymentStatus.PENDING
+        );
+        given(paymentRepository.findByOrderId("orderId")).willReturn(Optional.of(payment));
+        given(paymentClient.confirm(request, "fixed-idempotency-key")).willReturn(expected);
 
         PaymentConfirmResponse response = paymentService.confirm(request);
 
         assertThat(response).isEqualTo(expected);
-        verify(paymentClient).confirm(request);
+        verify(paymentClient).confirm(request, "fixed-idempotency-key");
+        verify(paymentRepository).updateConfirmed("orderId", "paymentKey", 1000L);
+    }
+
+    @Test
+    void read_timeout이면_결제_상태를_확인_필요로_변경한다() {
+        PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
+        ReservationPayment payment = new ReservationPayment(
+            1L,
+            1L,
+            "orderId",
+            null,
+            1000L,
+            "fixed-idempotency-key",
+            PaymentStatus.PENDING
+        );
+        given(paymentRepository.findByOrderId("orderId")).willReturn(Optional.of(payment));
+        given(paymentClient.confirm(request, "fixed-idempotency-key"))
+            .willThrow(new PaymentResultUnknownException());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> paymentService.confirm(request))
+            .isInstanceOf(PaymentResultUnknownException.class);
+
+        verify(paymentRepository).updateRequiresConfirmation("orderId", "paymentKey");
+    }
+
+    @Test
+    void 이미_확정된_주문은_토스를_다시_호출하지_않는다() {
+        PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
+        ReservationPayment payment = new ReservationPayment(
+            1L,
+            1L,
+            "orderId",
+            "paymentKey",
+            1000L,
+            "fixed-idempotency-key",
+            PaymentStatus.CONFIRMED
+        );
+        given(paymentRepository.findByOrderId("orderId")).willReturn(Optional.of(payment));
+
+        PaymentConfirmResponse response = paymentService.confirm(request);
+
+        assertThat(response.status()).isEqualTo("DONE");
+        verify(paymentClient, never()).confirm(request, "fixed-idempotency-key");
+    }
+
+    @Test
+    void 저장된_주문_금액과_다르면_승인하지_않는다() {
+        PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 2000L);
+        ReservationPayment payment = new ReservationPayment(
+            1L,
+            1L,
+            "orderId",
+            null,
+            1000L,
+            "fixed-idempotency-key",
+            PaymentStatus.PENDING
+        );
+        given(paymentRepository.findByOrderId("orderId")).willReturn(Optional.of(payment));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> paymentService.confirm(request))
+            .isInstanceOf(RoomescapeException.class);
+
+        verify(paymentClient, never()).confirm(request, "fixed-idempotency-key");
     }
 }

--- a/src/test/java/roomescape/domain/payment/TossPaymentsClientTest.java
+++ b/src/test/java/roomescape/domain/payment/TossPaymentsClientTest.java
@@ -26,15 +26,15 @@ class TossPaymentsClientTest {
 
     private static final String BASE_URL = "https://api.tosspayments.com";
     private static final String SECRET_KEY = "test_sk_dummy";
+    private static final String IDEMPOTENCY_KEY = "fixed-idempotency-key";
 
     @Test
     void 토스_결제_승인_API를_호출한다() {
         RestClient.Builder restClientBuilder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
         TossPaymentsClient client = new TossPaymentsClient(
-            restClientBuilder,
+            restClientBuilder.baseUrl(BASE_URL).build(),
             new ObjectMapper(),
-            BASE_URL,
             SECRET_KEY
         );
         PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
@@ -42,6 +42,7 @@ class TossPaymentsClientTest {
         server.expect(once(), requestTo(BASE_URL + "/v1/payments/confirm"))
             .andExpect(method(HttpMethod.POST))
             .andExpect(header(HttpHeaders.AUTHORIZATION, authorizationHeader()))
+            .andExpect(header("Idempotency-Key", IDEMPOTENCY_KEY))
             .andExpect(content().json("""
                 {
                   "paymentKey": "paymentKey",
@@ -58,7 +59,7 @@ class TossPaymentsClientTest {
                 }
                 """, MediaType.APPLICATION_JSON));
 
-        PaymentConfirmResponse response = client.confirm(request);
+        PaymentConfirmResponse response = client.confirm(request, IDEMPOTENCY_KEY);
 
         assertThat(response.status()).isEqualTo("DONE");
         assertThat(response.totalAmount()).isEqualTo(1000L);
@@ -70,9 +71,8 @@ class TossPaymentsClientTest {
         RestClient.Builder restClientBuilder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
         TossPaymentsClient client = new TossPaymentsClient(
-            restClientBuilder,
+            restClientBuilder.baseUrl(BASE_URL).build(),
             new ObjectMapper(),
-            BASE_URL,
             SECRET_KEY
         );
         PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
@@ -85,7 +85,7 @@ class TossPaymentsClientTest {
                 }
                 """).contentType(MediaType.APPLICATION_JSON));
 
-        assertThatThrownBy(() -> client.confirm(request))
+        assertThatThrownBy(() -> client.confirm(request, IDEMPOTENCY_KEY))
             .isInstanceOf(PaymentException.class)
             .extracting("code")
             .isEqualTo("ALREADY_PROCESSED_PAYMENT");

--- a/src/test/java/roomescape/domain/payment/TossPaymentsClientTimeoutTest.java
+++ b/src/test/java/roomescape/domain/payment/TossPaymentsClientTimeoutTest.java
@@ -1,0 +1,79 @@
+package roomescape.domain.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import roomescape.domain.payment.dto.PaymentConfirmRequest;
+
+class TossPaymentsClientTimeoutTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void 느린_응답은_read_timeout만큼만_기다리고_결과_확인_필요_예외를_던진다() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/payments/confirm", exchange -> {
+            try {
+                Thread.sleep(1_000);
+                byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody().write(body);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        TossPaymentsClient client = new TossPaymentsClient(
+            RestClient.builder(),
+            new ObjectMapper(),
+            "http://localhost:" + server.getAddress().getPort(),
+            "test_sk_dummy",
+            Duration.ofMillis(100),
+            Duration.ofMillis(150)
+        );
+        PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
+
+        long startedAt = System.nanoTime();
+
+        assertThatThrownBy(() -> client.confirm(request, "fixed-idempotency-key"))
+            .isInstanceOf(PaymentResultUnknownException.class);
+
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+        assertThat(elapsed).isLessThan(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void 연결할_수_없는_서버는_연결_실패로_구분한다() {
+        TossPaymentsClient client = new TossPaymentsClient(
+            RestClient.builder(),
+            new ObjectMapper(),
+            "http://localhost:1",
+            "test_sk_dummy",
+            Duration.ofMillis(100),
+            Duration.ofMillis(100)
+        );
+        PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "orderId", 1000L);
+
+        assertThatThrownBy(() -> client.confirm(request, "fixed-idempotency-key"))
+            .isInstanceOf(PaymentConnectionException.class);
+    }
+}

--- a/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/domain/reservation/ReservationServiceTest.java
@@ -27,6 +27,9 @@ import org.springframework.dao.DuplicateKeyException;
 import roomescape.domain.reservation.dto.MyReservationsResponse;
 import roomescape.domain.reservation.dto.ReservationFixRequest;
 import roomescape.domain.reservation.dto.ReservationRequest;
+import roomescape.domain.payment.PaymentRepository;
+import roomescape.domain.payment.PaymentStatus;
+import roomescape.domain.payment.ReservationPayment;
 import roomescape.domain.reservationtime.ReservationTime;
 import roomescape.domain.reservationtime.ReservationTimeRepository;
 import roomescape.domain.reservationtime.dto.TimeResponse;
@@ -53,6 +56,9 @@ class ReservationServiceTest {
     @Mock
     private WaitingRepository waitingRepository;
 
+    @Mock
+    private PaymentRepository paymentRepository;
+
     @InjectMocks
     private ReservationService reservationService;
 
@@ -77,6 +83,7 @@ class ReservationServiceTest {
             when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
             when(reservationRepository.existsByDateAndTimeIdAndThemeId(request.date(), 1L, 1L)).thenReturn(false);
             when(reservationRepository.save(any(Reservation.class))).thenReturn(saved);
+            when(paymentRepository.save(any(ReservationPayment.class))).thenReturn(paymentFor(saved.getId()));
 
             reservationService.createReservation(request);
 
@@ -198,6 +205,9 @@ class ReservationServiceTest {
             TimeSlot canceledReservationSlot = TimeSlot.from(reservation);
             when(reservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(reservation));
             when(waitingRepository.findFirstByTimeSlotForUpdate(canceledReservationSlot)).thenReturn(Optional.of(waiting));
+            Reservation promoted = Reservation.of(3L, "대기자1", LocalDate.of(2099, 12, 31), time, theme);
+            when(reservationRepository.save(any(Reservation.class))).thenReturn(promoted);
+            when(paymentRepository.save(any(ReservationPayment.class))).thenReturn(paymentFor(promoted.getId()));
 
             reservationService.deleteReservation(1L, "예약자");
 
@@ -227,6 +237,8 @@ class ReservationServiceTest {
         void 이름으로_조회() {
             Reservation reservation = Reservation.of(1L, "유저1", LocalDate.of(2099, 12, 31), time, theme);
             when(reservationRepository.findByName("유저1")).thenReturn(List.of(reservation));
+            when(paymentRepository.findByReservationIds(List.of(1L)))
+                .thenReturn(List.of(paymentFor(1L)));
 
             MyReservationsResponse response = reservationService.getMyReservations("유저1");
 
@@ -240,6 +252,7 @@ class ReservationServiceTest {
         @Test
         void 결과가_없으면_빈_리스트() {
             when(reservationRepository.findByName("없는유저")).thenReturn(List.of());
+            when(paymentRepository.findByReservationIds(List.of())).thenReturn(List.of());
 
             MyReservationsResponse response = reservationService.getMyReservations("없는유저");
 
@@ -348,5 +361,17 @@ class ReservationServiceTest {
                 .isInstanceOf(RoomescapeException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_RESERVATION);
         }
+    }
+
+    private ReservationPayment paymentFor(Long reservationId) {
+        return new ReservationPayment(
+            reservationId,
+            reservationId,
+            "order-" + reservationId,
+            null,
+            10_000L,
+            "idempotency-" + reservationId,
+            PaymentStatus.PENDING
+        );
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,5 @@ spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
 spring.sql.init.data-locations=
 toss.payments.secret-key=test_sk_dummy
+toss.payments.connect-timeout=200ms
+toss.payments.read-timeout=300ms


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 구현 사항

- 예약과 1:1 관계인 `reservation_payment` 테이블을 추가했습니다.
- 예약 생성 시 `orderId`, 주문별 고정 `idempotencyKey`, 결제 금액과 `PENDING` 상태를 함께 저장합니다.
- 결제 상태를 `PENDING`, `CONFIRMED`, `FAILED`, `REQUIRES_CONFIRMATION`으로 구분했습니다.

### 타임아웃 및 외부 호출 예외 처리
- `SimpleClientHttpRequestFactory`를 사용해 토스 `RestClient`에 connect/read timeout을 설정했습니다.
- 타임아웃 값은 프로퍼티로 외부화했습니다.
- 토스 오류 응답, 연결 실패, read timeout을 각각 구분해 처리했습니다.
- read timeout은 승인 여부를 알 수 없으므로 실패가 아닌 `REQUIRES_CONFIRMATION` 상태로 저장합니다.

### 중복 승인 방지
- 주문 생성 시 만든 고정 UUID를 `Idempotency-Key` 헤더로 전달합니다.
- 같은 주문의 재시도에서도 동일한 멱등키를 사용합니다.
- 이미 `CONFIRMED`인 주문은 토스 API를 다시 호출하지 않고 저장된 승인 결과를 반환합니다.
- 서버에 저장된 주문 금액과 승인 요청 금액이 다르면 토스 호출 전에 차단합니다.

### 결제 내역 조회
- 내 예약 화면에서 결제 상태, `orderId`, `paymentKey`, 결제 금액을 확인할 수 있도록 했습니다.
- 결과가 불명확한 결제는 `확인 필요`로 표시합니다.
- `확인 필요` 상태에서는 저장된 결제 정보와 멱등키를 이용해 안전하게 재확인할 수 있습니다.