### PR TITLE
[🚀 방탈출 예약 외부 API 연동 3단계] 무빙 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/common/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import roomescape.payment.TossPaymentException;
+import roomescape.ratelimit.OutboundRateLimitException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -110,6 +111,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("Toss 결제 오류 [{}]: {}", e.getCode(), e.getMessage());
         return ResponseEntity.status(e.getStatus())
                 .body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(OutboundRateLimitException.class)
+    public ResponseEntity<ErrorResponse> handleOutboundRateLimit(OutboundRateLimitException e) {
+        log.warn("아웃바운드 Rate Limit 초과: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", String.valueOf(e.getRetryAfterSeconds()))
+                .body(new ErrorResponse("OUTBOUND_RATE_LIMIT_EXCEEDED", "현재 결제 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/roomescape/config/PaymentConfig.java
+++ b/src/main/java/roomescape/config/PaymentConfig.java
@@ -12,25 +12,34 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import roomescape.payment.adapter.TossPaymentGateway;
 import roomescape.payment.port.PaymentGateway;
+import roomescape.ratelimit.OutboundRateLimitInterceptor;
+import roomescape.ratelimit.OutboundRateLimitProperties;
+import roomescape.ratelimit.TokenBucketRateLimiter;
 
 @Configuration
 @EnableConfigurationProperties(TossPaymentProperties.class)
 public class PaymentConfig {
 
     @Bean
-    public RestClient tossRestClient(TossPaymentProperties properties) {
+    public TokenBucketRateLimiter outboundRateLimiter(OutboundRateLimitProperties properties) {
+        return new TokenBucketRateLimiter(properties.capacity(), properties.refillPerSec(), System::nanoTime);
+    }
+
+    @Bean
+    public RestClient tossRestClient(TossPaymentProperties properties, TokenBucketRateLimiter outboundRateLimiter) {
         String encoded = Base64.getEncoder()
                 .encodeToString((properties.secretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(properties.connectTimeoutMs());  // SYN -> ACK 대기 최대 시간
-        factory.setReadTimeout(properties.readTimeoutMs());  // 연결 후 응답 도착 최대 시간
+        factory.setConnectTimeout(properties.connectTimeoutMs());
+        factory.setReadTimeout(properties.readTimeoutMs());
 
         return RestClient.builder()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .requestFactory(factory)
+                .requestInterceptor(new OutboundRateLimitInterceptor(outboundRateLimiter))
                 .build();
     }
 

--- a/src/main/java/roomescape/config/PaymentConfig.java
+++ b/src/main/java/roomescape/config/PaymentConfig.java
@@ -14,6 +14,7 @@ import roomescape.payment.adapter.TossPaymentGateway;
 import roomescape.payment.port.PaymentGateway;
 import roomescape.ratelimit.OutboundRateLimitInterceptor;
 import roomescape.ratelimit.OutboundRateLimitProperties;
+import roomescape.ratelimit.RetryAfterInterceptor;
 import roomescape.ratelimit.TokenBucketRateLimiter;
 
 @Configuration
@@ -39,6 +40,7 @@ public class PaymentConfig {
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .requestFactory(factory)
+                .requestInterceptor(new RetryAfterInterceptor(properties.maxRetryAttempts()))
                 .requestInterceptor(new OutboundRateLimitInterceptor(outboundRateLimiter))
                 .build();
     }

--- a/src/main/java/roomescape/config/TossPaymentProperties.java
+++ b/src/main/java/roomescape/config/TossPaymentProperties.java
@@ -4,5 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "toss.payments")
 public record TossPaymentProperties(String secretKey, String clientKey, String baseUrl,
-                                    int connectTimeoutMs, int readTimeoutMs) {
+                                    int connectTimeoutMs, int readTimeoutMs, int maxRetryAttempts) {
 }

--- a/src/main/java/roomescape/config/WebMvcConfig.java
+++ b/src/main/java/roomescape/config/WebMvcConfig.java
@@ -1,0 +1,29 @@
+package roomescape.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.ratelimit.OutboundRateLimitProperties;
+import roomescape.ratelimit.RateLimitInterceptor;
+import roomescape.ratelimit.RateLimitProperties;
+import roomescape.ratelimit.TokenBucketRateLimiter;
+
+@Configuration
+@EnableConfigurationProperties({RateLimitProperties.class, OutboundRateLimitProperties.class})
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final RateLimitProperties rateLimitProperties;
+
+    public WebMvcConfig(RateLimitProperties rateLimitProperties) {
+        this.rateLimitProperties = rateLimitProperties;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        TokenBucketRateLimiter limiter = new TokenBucketRateLimiter(
+                rateLimitProperties.capacity(), rateLimitProperties.refillPerSec(), System::nanoTime
+        );
+        registry.addInterceptor(new RateLimitInterceptor(limiter))
+                .addPathPatterns("/reservations/**", "/payments/**");
+    }
+}

--- a/src/main/java/roomescape/ratelimit/OutboundRateLimitException.java
+++ b/src/main/java/roomescape/ratelimit/OutboundRateLimitException.java
@@ -1,7 +1,15 @@
 package roomescape.ratelimit;
 
 public class OutboundRateLimitException extends RuntimeException {
-    public OutboundRateLimitException(String message) {
+
+    private final long retryAfterSeconds;
+
+    public OutboundRateLimitException(String message, long retryAfterSeconds) {
         super(message);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
     }
 }

--- a/src/main/java/roomescape/ratelimit/OutboundRateLimitException.java
+++ b/src/main/java/roomescape/ratelimit/OutboundRateLimitException.java
@@ -1,0 +1,7 @@
+package roomescape.ratelimit;
+
+public class OutboundRateLimitException extends RuntimeException {
+    public OutboundRateLimitException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/ratelimit/OutboundRateLimitInterceptor.java
+++ b/src/main/java/roomescape/ratelimit/OutboundRateLimitInterceptor.java
@@ -1,0 +1,25 @@
+package roomescape.ratelimit;
+
+import java.io.IOException;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class OutboundRateLimitInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    public OutboundRateLimitInterceptor(TokenBucketRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        if (!rateLimiter.tryConsume()) {
+            throw new OutboundRateLimitException("아웃바운드 Rate Limit 초과 — 토스로 요청을 보내지 않음");
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/roomescape/ratelimit/OutboundRateLimitInterceptor.java
+++ b/src/main/java/roomescape/ratelimit/OutboundRateLimitInterceptor.java
@@ -18,7 +18,8 @@ public class OutboundRateLimitInterceptor implements ClientHttpRequestIntercepto
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
             throws IOException {
         if (!rateLimiter.tryConsume()) {
-            throw new OutboundRateLimitException("아웃바운드 Rate Limit 초과 — 토스로 요청을 보내지 않음");
+            throw new OutboundRateLimitException("아웃바운드 Rate Limit 초과 — 토스로 요청을 보내지 않음",
+                    rateLimiter.retryAfterSeconds());
         }
         return execution.execute(request, body);
     }

--- a/src/main/java/roomescape/ratelimit/OutboundRateLimitProperties.java
+++ b/src/main/java/roomescape/ratelimit/OutboundRateLimitProperties.java
@@ -1,0 +1,7 @@
+package roomescape.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "outbound-rate-limit")
+public record OutboundRateLimitProperties(long capacity, double refillPerSec) {
+}

--- a/src/main/java/roomescape/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/roomescape/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,23 @@
+package roomescape.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class RateLimitInterceptor implements HandlerInterceptor {
+    private final TokenBucketRateLimiter rateLimiter;
+
+    public RateLimitInterceptor(TokenBucketRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (rateLimiter.tryConsume()) {
+            return true;  // 컨트롤러로 진행
+        }
+        response.setStatus(429);
+        response.setHeader("Retry-After", String.valueOf(rateLimiter.retryAfterSeconds()));
+        return false;  // 컨트롤러 호출 차단
+    }
+}

--- a/src/main/java/roomescape/ratelimit/RateLimitProperties.java
+++ b/src/main/java/roomescape/ratelimit/RateLimitProperties.java
@@ -1,0 +1,7 @@
+package roomescape.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(long capacity, double refillPerSec) {
+}

--- a/src/main/java/roomescape/ratelimit/RetryAfterInterceptor.java
+++ b/src/main/java/roomescape/ratelimit/RetryAfterInterceptor.java
@@ -1,0 +1,55 @@
+package roomescape.ratelimit;
+
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final long DEFAULT_RETRY_AFTER_SECONDS = 1L;
+
+    private final int maxAttempts;
+
+    public RetryAfterInterceptor(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(
+            HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            ClientHttpResponse response = execution.execute(request, body);
+            if (response.getStatusCode().value() != 429 || attempt == maxAttempts) {
+                return response;
+            }
+            long waitSeconds = parseRetryAfterSeconds(response);
+            response.close();
+            sleepSeconds(waitSeconds);
+        }
+        throw new IllegalStateException("unreachable");
+    }
+
+    private long parseRetryAfterSeconds(ClientHttpResponse response) {
+        var value = response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER);
+        if (value == null) {
+            return DEFAULT_RETRY_AFTER_SECONDS;
+        }
+        try {
+            return Math.max(0, Long.parseLong(value.trim()));
+        } catch (NumberFormatException e) {
+            return DEFAULT_RETRY_AFTER_SECONDS;
+        }
+    }
+
+    private void sleepSeconds(long seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("재시도 대기 중 인터럽트되었습니다.", e);
+        }
+    }
+}

--- a/src/main/java/roomescape/ratelimit/TokenBucketRateLimiter.java
+++ b/src/main/java/roomescape/ratelimit/TokenBucketRateLimiter.java
@@ -1,0 +1,65 @@
+package roomescape.ratelimit;
+
+import java.util.function.LongSupplier;
+
+/**
+ * 토큰 버킷(Token Bucket) 방식의 Rate Limiter.
+ *
+ * <p>시계를 {@link LongSupplier} 로 주입받아, 테스트에서 가짜 시계로 결정적으로 검증할 수 있다.
+ */
+public class TokenBucketRateLimiter {
+
+    private final long capacity;        // 버킷 최대 용량(버스트 허용량)
+    private final double refillPerSec;    // 초당 보충 토큰 수 = 허용 TPS 상한
+    private final LongSupplier nanoClock;   // 시계 — 실제론 System::nanoTime, 테스트에선 AtomicLong
+
+    private double availableTokens;   // 남은(사용가능한) 토큰
+    private long lastRefillNanos;   // 마지막으로 물을 채운 시각(나노초)
+
+    public TokenBucketRateLimiter(long capacity, double refillPerSec, LongSupplier nanoClock) {
+        this.capacity = capacity;
+        this.refillPerSec = refillPerSec;
+        this.nanoClock = nanoClock;
+        this.availableTokens = capacity;            // 시작은 가득 찬 상태
+        this.lastRefillNanos = nanoClock.getAsLong();
+    }
+
+    /**
+     * 토큰이 있으면 1개 소비하고 true, 없으면 false. 요청 하나 처리 시도
+     */
+    public synchronized boolean tryConsume() {
+        // refill() 후 토큰이 1개 이상이면 1개 소비하고 true, 아니면 false.
+        refill();
+        if (availableTokens >= 1) {
+            availableTokens -= 1;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 다음 요청이 통과 가능해질 때까지 권장 대기 시간(초). 토큰이 충분하면 0.
+     */
+    public synchronized long retryAfterSeconds() {
+        // refill() 후 토큰이 1개 이상이면 0, 부족하면 1개가 찰 때까지 필요한 초를 올림으로 반환한다.
+        refill();
+        if (availableTokens >= 1) {
+            return 0;
+        }
+        double needed = 1.0 - availableTokens;
+        return (long) Math.ceil(needed / refillPerSec);
+    }
+
+    /**
+     * 마지막 보충 이후 경과 시간에 비례해 토큰을 보충한다(상한 capacity).
+     */
+    private void refill() {
+        // 경과 시간(nanoClock - lastRefillNanos)에 비례해 토큰을 보충하고(상한 capacity), lastRefillNanos 를 갱신한다.
+        long now = nanoClock.getAsLong();    // 현재 시각(나노초)
+        double elapsed = (now - lastRefillNanos) / 1000000000.0;     // 경과시간(나노초를 초로 변환)
+
+        availableTokens = Math.min(capacity, availableTokens + elapsed * refillPerSec);  // 크기를 넘으면 버린다.
+        lastRefillNanos = now;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,9 @@ toss.payments.client-key=${TOSS_CLIENT_KEY:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlz
 toss.payments.secret-key=${TOSS_SECRET_KEY:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
 toss.payments.connect-timeout-ms=1000
 toss.payments.read-timeout-ms=2000
+# ???? (?? ??? ?? ?? ??)
+rate-limit.capacity=10
+rate-limit.refill-per-sec=5
+# ????? (??? ??? ?? ??)
+outbound-rate-limit.capacity=5
+outbound-rate-limit.refill-per-sec=2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ toss.payments.client-key=${TOSS_CLIENT_KEY:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlz
 toss.payments.secret-key=${TOSS_SECRET_KEY:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
 toss.payments.connect-timeout-ms=1000
 toss.payments.read-timeout-ms=2000
+toss.payments.max-retry-attempts=3
 # ???? (?? ??? ?? ?? ??)
 rate-limit.capacity=10
 rate-limit.refill-per-sec=5

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,3 +2,7 @@ spring.datasource.url=jdbc:h2:mem:database
 spring.sql.init.data-locations=
 toss.payments.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
 toss.payments.max-retry-attempts=3
+rate-limit.capacity=10000
+rate-limit.refill-per-sec=10000
+outbound-rate-limit.capacity=10000
+outbound-rate-limit.refill-per-sec=10000

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 spring.datasource.url=jdbc:h2:mem:database
 spring.sql.init.data-locations=
 toss.payments.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+toss.payments.max-retry-attempts=3


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [[참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->

## 체크 리스트

- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크

- [ ] 이전 미션의 내 코드에서 시작 
- [x] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?

<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

2단계에서 타임아웃과 멱등키로 느린 호출과 중복 승인을 막았습니다. 이번엔 호출량 상한(Rate Limit) 을 다룹니다.

같은 알고리즘(토큰 버킷), 다른 방향 두 곳에 적용했다.

- 인바운드: 들어오는 요청이 몰리면 초과분을 429로 거부 (서버 입장)
- 아웃바운드: 토스를 호출할 때 상대 한도를 넘지 않도록 스스로 조절 (클라이언트 입장)


## 구현 내용

### 1. `TokenBucketRateLimiter` — 토큰 버킷 알고리즘

- capacity      = 허용 버스트 (순간 최대 처리량)
- refillPerSec  = 초당 보충 토큰 수 (지속 처리량 상한)

### 2. 인바운드 Rate Limit — `RateLimitInterceptor`

`HandlerInterceptor.preHandle()`에서 `tryConsume()`이 `false`면 컨트롤러 호출 없이 차단.

### 3. 아웃바운드 Rate Limit — `OutboundRateLimitInterceptor`

`ClientHttpRequestInterceptor`로 토스 `RestClient`에 등록. 토큰 없으면 HTTP 요청 자체를 보내지 않고 `OutboundRateLimitException` 발생 -> `GlobalExceptionHandler`가 429로 응답.

### 4. 토스 429 백오프 재시도 — `RetryAfterInterceptor`

토스가 429를 돌려줬을 때 `Retry-After` 헤더만큼 대기 후 재시도.