### PR TITLE
[🚀 방탈출 예약 외부 API 연동 3단계] 로지(이지현) 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/common/config/TossClientConfig.java
+++ b/src/main/java/roomescape/common/config/TossClientConfig.java
@@ -1,4 +1,4 @@
-package roomescape.client;
+package roomescape.common.config;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -8,6 +8,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+import roomescape.common.ratelimit.TokenBucketRateLimiter;
+import roomescape.common.ratelimit.interceptor.OutboundRateLimitInterceptor;
+import roomescape.common.ratelimit.interceptor.RetryAfterInterceptor;
 
 @Configuration
 public class TossClientConfig {
@@ -17,7 +20,10 @@ public class TossClientConfig {
             @Value("${toss.base-url}") String baseUrl,
             @Value("${toss.secret-key}") String secretKey,
             @Value("${toss.connect-timeout-ms}") int connectTimeoutMs,
-            @Value("${toss.read-timeout-ms}") int readTimeoutMs
+            @Value("${toss.read-timeout-ms}") int readTimeoutMs,
+            @Value("${gateway.max-attempts}") int maxAttempts,
+            @Value("${outbound-rate-limit.capacity}") long outboundCapacity,
+            @Value("${outbound-rate-limit.refill-per-second}") double outboundRefillPerSecond
     ) {
         String basic = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
@@ -26,10 +32,15 @@ public class TossClientConfig {
         requestFactory.setConnectTimeout(connectTimeoutMs);
         requestFactory.setReadTimeout(readTimeoutMs);
 
+        TokenBucketRateLimiter outboundLimiter =
+                new TokenBucketRateLimiter(outboundCapacity, outboundRefillPerSecond, System::nanoTime);
+
         return RestClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basic)
                 .requestFactory(requestFactory)
+                .requestInterceptor(new OutboundRateLimitInterceptor(outboundLimiter))
+                .requestInterceptor(new RetryAfterInterceptor(maxAttempts))
                 .build();
     }
 }

--- a/src/main/java/roomescape/common/config/WebConfig.java
+++ b/src/main/java/roomescape/common/config/WebConfig.java
@@ -1,0 +1,27 @@
+package roomescape.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.common.ratelimit.TokenBucketRateLimiter;
+import roomescape.common.ratelimit.interceptor.RateLimitInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    public WebConfig(
+            @Value("${rate-limit.capacity}") long capacity,
+            @Value("${rate-limit.refill-per-second}") double refillPerSecond
+    ) {
+        this.rateLimiter = new TokenBucketRateLimiter(capacity, refillPerSecond, System::nanoTime);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RateLimitInterceptor(rateLimiter))
+                .addPathPatterns("/payment/**", "/reservations", "/waitings");
+    }
+}

--- a/src/main/java/roomescape/common/exception/OutboundRateLimitException.java
+++ b/src/main/java/roomescape/common/exception/OutboundRateLimitException.java
@@ -1,0 +1,9 @@
+package roomescape.common.exception;
+
+public class OutboundRateLimitException extends RuntimeException {
+
+  public OutboundRateLimitException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/roomescape/common/exception/code/PaymentErrorCode.java
+++ b/src/main/java/roomescape/common/exception/code/PaymentErrorCode.java
@@ -13,6 +13,7 @@ public enum PaymentErrorCode implements ErrorCode {
     GATEWAY_CONFIG_ERROR("결제 설정 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     GATEWAY_INTERNAL_ERROR("결제 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.BAD_GATEWAY),
     UNKNOWN("결제 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    RATE_LIMIT_EXCEEDED("결제 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.TOO_MANY_REQUESTS),
     ;
 
     private final String message;

--- a/src/main/java/roomescape/common/ratelimit/TokenBucketRateLimiter.java
+++ b/src/main/java/roomescape/common/ratelimit/TokenBucketRateLimiter.java
@@ -1,0 +1,45 @@
+package roomescape.common.ratelimit;
+
+import java.util.function.LongSupplier;
+
+public class TokenBucketRateLimiter {
+
+    private final long capacity;
+    private final double refillPerSec;
+    private final LongSupplier nanoClock;
+
+    private double availableTokens;
+    private long lastRefillNanos;
+
+    public TokenBucketRateLimiter(long capacity, double refillPerSec, LongSupplier nanoClock) {
+        this.capacity = capacity;
+        this.refillPerSec = refillPerSec;
+        this.nanoClock = nanoClock;
+        this.availableTokens = capacity;
+        this.lastRefillNanos = nanoClock.getAsLong();
+    }
+
+    public synchronized boolean tryConsume() {
+        refill();
+        if (availableTokens >= 1) {
+            availableTokens -= 1;
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized long retryAfterSeconds() {
+        refill();
+        if (availableTokens >= 1) {
+            return 0;
+        }
+        return (long) Math.ceil((1 - availableTokens) / refillPerSec);
+    }
+
+    private void refill() {
+        long now = nanoClock.getAsLong();
+        double elapsedSec = (now - lastRefillNanos) / 1_000_000_000.0;
+        availableTokens = Math.min(capacity, availableTokens + elapsedSec * refillPerSec);
+        lastRefillNanos = now;
+    }
+}

--- a/src/main/java/roomescape/common/ratelimit/interceptor/OutboundRateLimitInterceptor.java
+++ b/src/main/java/roomescape/common/ratelimit/interceptor/OutboundRateLimitInterceptor.java
@@ -1,0 +1,27 @@
+package roomescape.common.ratelimit.interceptor;
+
+import java.io.IOException;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import roomescape.common.exception.OutboundRateLimitException;
+import roomescape.common.ratelimit.TokenBucketRateLimiter;
+
+public class OutboundRateLimitInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    public OutboundRateLimitInterceptor(TokenBucketRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        if (!rateLimiter.tryConsume()) {
+            throw new OutboundRateLimitException("나가는 호출이 자체 Rate Limit을 초과해 외부로 보내지 않았습니다.");
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/roomescape/common/ratelimit/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/roomescape/common/ratelimit/interceptor/RateLimitInterceptor.java
@@ -1,0 +1,28 @@
+package roomescape.common.ratelimit.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import roomescape.common.ratelimit.TokenBucketRateLimiter;
+
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final TokenBucketRateLimiter rateLimiter;
+
+    public RateLimitInterceptor(TokenBucketRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (rateLimiter.tryConsume()) {
+            return true;
+        }
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(rateLimiter.retryAfterSeconds()));
+        return false;
+    }
+}

--- a/src/main/java/roomescape/common/ratelimit/interceptor/RetryAfterInterceptor.java
+++ b/src/main/java/roomescape/common/ratelimit/interceptor/RetryAfterInterceptor.java
@@ -1,0 +1,61 @@
+package roomescape.common.ratelimit.interceptor;
+
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final long DEFAULT_RETRY_AFTER_SECONDS = 1L;
+
+    private final int maxAttempts;
+
+    public RetryAfterInterceptor(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        ClientHttpResponse response = execution.execute(request, body);
+        long attempt = 1;
+
+        while (isTooManyRequests(response) && attempt < maxAttempts) {
+            long waitSeconds = parseRetryAfterSeconds(response);
+            response.close();
+            sleepSeconds(waitSeconds);
+            response = execution.execute(request, body);
+            attempt++;
+        }
+        return response;
+    }
+
+    private boolean isTooManyRequests(ClientHttpResponse response) throws IOException {
+        return response.getStatusCode().value() == HttpStatus.TOO_MANY_REQUESTS.value();
+    }
+
+    private long parseRetryAfterSeconds(ClientHttpResponse response) {
+        var value = response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER);
+        if (value == null) {
+            return DEFAULT_RETRY_AFTER_SECONDS;
+        }
+        try {
+            return Math.max(0, Long.parseLong(value.trim()));
+        } catch (NumberFormatException e) {
+            return DEFAULT_RETRY_AFTER_SECONDS;
+        }
+    }
+
+    private void sleepSeconds(long seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("재시도 대기 중 인터럽트되었습니다.", e);
+        }
+    }
+}

--- a/src/main/java/roomescape/common/ratelimit/interceptor/RetryAfterInterceptor.java
+++ b/src/main/java/roomescape/common/ratelimit/interceptor/RetryAfterInterceptor.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import roomescape.common.exception.RoomEscapeException;
+import roomescape.common.exception.code.PaymentErrorCode;
 
 public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
 
@@ -30,6 +32,10 @@ public class RetryAfterInterceptor implements ClientHttpRequestInterceptor {
             sleepSeconds(waitSeconds);
             response = execution.execute(request, body);
             attempt++;
+        }
+        if (isTooManyRequests(response)) {
+            response.close();
+            throw new RoomEscapeException(PaymentErrorCode.RATE_LIMIT_EXCEEDED);
         }
         return response;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,11 @@ toss.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 toss.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
 toss.connect-timeout-ms: 1000
 toss.read-timeout-ms: 2000
+
+rate-limit.capacity=5
+rate-limit.refill-per-second=1.0
+
+gateway.max-attempts=3
+
+outbound-rate-limit.capacity=5
+outbound-rate-limit.refill-per-second=1.0

--- a/src/test/java/roomescape/client/TossClientTimeoutTest.java
+++ b/src/test/java/roomescape/client/TossClientTimeoutTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import roomescape.common.config.TossClientConfig;
 import roomescape.dto.request.PaymentConfirmation;
 import roomescape.domain.PaymentStatus;
 
@@ -114,7 +115,7 @@ class TossClientTimeoutTest {
         // 학생이 채운 tossRestClient 의 connect timeout 을 그대로 검증한다.
         // 설정 전(initial)엔 타임아웃이 없어 블랙홀 연결이 매달리므로 @Timeout(3초)이 끊어 실패시킨다.
         var gateway = new TossPaymentGateway(
-                new TossClientConfig().tossRestClient(BLACKHOLE_URL, "test_gsk_dummy", 500, 500),
+                new TossClientConfig().tossRestClient(BLACKHOLE_URL, "test_gsk_dummy", 500, 500, 3, 100L, 10.0),
                 new ObjectMapper()
         );
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,3 +5,11 @@ toss.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 toss.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
 toss.connect-timeout-ms=3000
 toss.read-timeout-ms=3000
+
+rate-limit.capacity=100
+rate-limit.refill-per-second=100.0
+
+gateway.max-attempts=3
+
+outbound-rate-limit.capacity=100
+outbound-rate-limit.refill-per-second=100.0


### PR DESCRIPTION
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

---

## 어떤 부분에 집중하여 리뷰해야 할까요?
### 1. capacity를 키우면 순간 버스트가, refillPerSec를 키우면 평균 처리량이 어떻게 변하는가?
capacity를 키우면 순간 버스트 허용량을 키울 수 있고, refillPerSec를 키우면 평균 처리량이 높아진다고 생각합니다.

### 2. 들어오는 한도(우리 처리 용량)와 나가는 한도(상대가 우리에게 허용한 몫)를 늘 같은 값으로 두면 안 되는 이유는?
아웃바운드는 결제와 같은 특정 기능을 위한 값이고, 인바운드는 결제뿐만이 아닌 우리 서버가 처리해야 할 전체 용량이기 때문에 아웃바운드와 같은 값으로 두면 서버가 정상적으로 동작할 수 없습니다. 우리 서버가 외부 서버에 의존적이게 되기 때문입니다. 쪽은 지금 한도 초과 시 즉시 거부(fail-fast)한다. 거부 대신 토큰이 찰 때까지 대기(블로킹) 시키는 방식과 비교하면 장단점은?(대기는 호출을 매끄럽게 흘리지만 스레드를 잡고 결정적 테스트가 어렵다.)

### 3. read timeout(2단계) 재시도와 429 재시도는 무엇이 다른가("이미 처리됐을 수 있음" vs "아직 처리 안 됨")? 각각 어떤 안전장치가 필요한지 멱등성과 연결해 정리해보자.
read timeout은 요청이 토스에 도달해서 처리됐을 가능성이 있기 때문에 재시도 시 이중 결제 위험이 있습니다. 반면 429는 토스가 요청을 아직 처리하지 않고 거부한 것이므로 재시도가 안전합니다. 따라서 read timeout 재시도에는 멱등키가 필수적이고, 429 재시도는 멱등키 없이도 안전하지만 "read timeout인지 429인지 구분 없이 항상 같은 키를 유지"하면 두 경우를 통합해서 안전하게 처리할 수 있습니다.

### 4. Rate Limit은 호출량(throughput)을 다룬다. 외부가 연속으로 실패(5xx·타임아웃)할 때는 양과 무관하게 호출을 끊는 서킷 브레이커가 필요할 수 있다. Rate Limit과 무엇이 다르고 어떻게 보완하는가?
Rate Limit은 호출량 기준으로 초과분을 거부하지만, 외부 서버가 연속으로 실패하는 상황에서는 한도 내의 호출도 모두 실패합니다. 이때 계속 호출을 보내면 우리 서버의 스레드와 리소스가 낭비됩니다. 서킷 브레이커는 실패율이 임계값을 넘으면 호출 자체를 차단해서 장애가 전파되는 것을 막고, 일정 시간 후 소량의 호출로 복구 여부를 확인합니다. Rate Limit이 "얼마나 보낼지"를 다룬다면, 서킷 브레이커는 "보낼 수 있는 상태인지"를 다룬다고 볼 수 있습니다.
