### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 정콩이(유정빈) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,39 @@ RESERVATION_PAYMENT_AMOUNT=50000
 예약 생성 시 서버가 `orderId`와 금액을 저장하고 예약을 `PENDING`으로 만든다. 브라우저 인증이 끝난 후 서버 승인까지 성공해야 `CONFIRMED` 예약과 생성 이력이 남는다.
 
 실제 샌드박스 어댑터 테스트는 기본 테스트에서 제외된다. `RUN_REAL_API=true`와 `TOSS_SECRET_KEY`를 주입하면 오류 응답 변환을 확인할 수 있고, 브라우저 인증 결과인 `TOSS_TEST_PAYMENT_KEY`, `TOSS_TEST_ORDER_ID`, `TOSS_TEST_AMOUNT`까지 주입하면 성공 승인도 검증한다.
+
+## 결과 불명확 결제와 회복 흐름 (확인 필요 상태)
+
+토스 confirm 호출이 read timeout으로 끊겼을 때 "이 결제가 처리됐는지 아닌지"를 우리 서버가 알 수 없다. "결제 실패"로 단정 짓지 않는다 — 결과가 불명확한 상태를 별도로 표현해 사용자가 회복할 수 있도록 만든다.
+
+### 상태와 전이
+
+`PaymentOrderStatus`는 `READY → UNCONFIRMED → DONE` 흐름을 갖는다.
+
+- **READY** — 결제 시도 전. 사용자가 결제창에서 진행하기 전.
+- **UNCONFIRMED** — 토스 응답을 못 받아 결과 미확정. 클라이언트가 보낸 `paymentKey`는 저장돼 회복용 식별자로 쓰인다.
+- **DONE** — 토스가 승인을 확인해 줬고, 예약은 `CONFIRMED`. 이력 1건 기록.
+
+### 자동 재시도 + 트랜잭션 분리
+
+`PaymentService.confirm`은 외부 호출을 트랜잭션 밖으로 빼고 `TransactionTemplate`로 세 구간을 나눈다.
+
+1. `prepareConfirm` — 잠금 조회, 소유·금액 검증, 이미 DONE이면 멱등 단축.
+2. 외부 호출 — `PaymentGatewayResponseTimeoutException`이면 지수 백오프(500ms → 1s → 2s)로 최대 3회 시도. `Idempotency-Key`(`orderId`)가 함께 박혀 이중 승인은 토스 측에서도 차단된다.
+3. 결과 분기 — 성공이면 `finalizeConfirm`으로 DONE 전이 + 예약 CONFIRMED + 이력 기록. 끝까지 timeout이면 `markUnconfirmed`로 `UNCONFIRMED` 상태와 `paymentKey`를 커밋하고 예외를 전파한다.
+
+같은 트랜잭션 안에서 던지면 마킹도 함께 롤백되기 때문에 트랜잭션을 잘게 쪼갠다. `TransactionTemplate`은 Spring 프록시를 거치지 않아 한 클래스 안에서 self-invocation 함정 없이 안전하게 분리된다.
+
+### 사용자 회복 동선
+
+"내 예약" 페이지(`GET /api/v1/reservations`) 응답이 결제 정보를 함께 내려준다(`orderId`, `paymentKey`, `amount`, `paymentStatus`).
+
+- `paymentStatus = DONE` → "결제 완료" pill.
+- `paymentStatus = UNCONFIRMED` → "확인 필요" pill + ↻ "다시 확인" 버튼.
+- `paymentStatus = READY` → "결제 대기" pill.
+
+"다시 확인"은 같은 `paymentKey` / `orderId` / `amount`로 `POST /api/v1/payments/confirm`을 재호출한다. 토스 측 멱등성과 `Idempotency-Key`로 이중 청구가 발생하지 않으며, 우리 서버는 `confirmAfterRecovery`로 `UNCONFIRMED → DONE` 전이 후 예약을 `CONFIRMED`로 마무리한다.
+
+### 한계와 후속
+
+`UNCONFIRMED`인데 `paymentKey`가 비어 있는 경우(클라이언트가 키를 받기도 전에 끊긴 흐름)는 자동 회복 대상이 아니다. 화면에서 "다시 확인" 버튼이 비활성화되며, 사용자는 결제창에서 다시 진행하거나 운영자가 수동 정정한다. 결제 조회 API를 도입하는 다음 사이클에서, `UNCONFIRMED` 주문의 실제 상태를 토스에 직접 물어 자동 정정하는 보상 흐름으로 확장할 수 있다.

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'

--- a/src/main/java/roomescape/payment/application/PaymentService.java
+++ b/src/main/java/roomescape/payment/application/PaymentService.java
@@ -2,11 +2,15 @@ package roomescape.payment.application;
 
 import java.time.LocalDate;
 import java.util.UUID;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import roomescape.payment.domain.PaymentConfirmation;
 import roomescape.payment.domain.PaymentGateway;
 import roomescape.payment.domain.PaymentOrder;
@@ -16,6 +20,7 @@ import roomescape.payment.domain.PaymentStatus;
 import roomescape.payment.domain.exception.PaymentAlreadyProcessedException;
 import roomescape.payment.domain.exception.PaymentAmountMismatchException;
 import roomescape.payment.domain.exception.PaymentGatewayException;
+import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
 import roomescape.payment.domain.exception.PaymentNotFoundException;
 import roomescape.payment.domain.exception.PaymentOwnerMismatchException;
 import roomescape.reservation.Reservation;
@@ -30,13 +35,17 @@ import roomescape.reservationtime.exception.ReservationTimeNotFoundException;
 @Service
 public class PaymentService {
 
+    private static final Logger log = LoggerFactory.getLogger(PaymentService.class);
     private static final String ORDER_NAME = "방탈출 예약";
+    private static final int MAX_GATEWAY_ATTEMPTS = 3;
+    private static final long INITIAL_BACKOFF_MS = 500L;
 
     private final PaymentOrderRepository paymentOrderRepository;
     private final PaymentGateway paymentGateway;
     private final ReservationDao reservationDao;
     private final ReservationTimeDao reservationTimeDao;
     private final ReservationHistoryService reservationHistoryService;
+    private final TransactionTemplate transactionTemplate;
     private final Long reservationAmount;
 
     public PaymentService(
@@ -45,6 +54,7 @@ public class PaymentService {
             ReservationDao reservationDao,
             ReservationTimeDao reservationTimeDao,
             ReservationHistoryService reservationHistoryService,
+            TransactionTemplate transactionTemplate,
             @Value("${payment.reservation-amount}") Long reservationAmount
     ) {
         this.paymentOrderRepository = paymentOrderRepository;
@@ -52,6 +62,7 @@ public class PaymentService {
         this.reservationDao = reservationDao;
         this.reservationTimeDao = reservationTimeDao;
         this.reservationHistoryService = reservationHistoryService;
+        this.transactionTemplate = transactionTemplate;
         this.reservationAmount = reservationAmount;
     }
 
@@ -77,28 +88,20 @@ public class PaymentService {
         return new PaymentCheckout(saved, orderId, ORDER_NAME, reservationAmount);
     }
 
-    @Transactional
     public PaymentResult confirm(Long memberId, String paymentKey, String orderId, Long amount) {
-        PaymentOrder order = findPaymentOrder(orderId);
-        Reservation reservation = findReservation(order.getReservationId());
-        validateOwner(reservation, memberId);
-        validateAmount(order, amount);
-
-        if (order.isDone()) {
-            if (order.getPaymentKey().equals(paymentKey)) {
-                return new PaymentResult(paymentKey, orderId, PaymentStatus.DONE, order.getAmount());
-            }
-            throw new PaymentAlreadyProcessedException();
+        Prepared prepared = transactionTemplate.execute(s -> prepareConfirm(memberId, paymentKey, orderId, amount));
+        if (prepared.shortCircuit() != null) {
+            return prepared.shortCircuit();
         }
 
-        PaymentResult result = paymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount));
-        validateResult(order, paymentKey, result);
-
-        paymentOrderRepository.update(order.complete(result.paymentKey()));
-        Reservation confirmed = reservation.confirm();
-        reservationDao.update(confirmed);
-        reservationHistoryService.recordCreated(confirmed, memberId);
-        return result;
+        try {
+            PaymentResult result = retryOnTimeout(() ->
+                    paymentGateway.confirm(new PaymentConfirmation(paymentKey, orderId, amount)));
+            return transactionTemplate.execute(s -> finalizeConfirm(orderId, paymentKey, memberId, result));
+        } catch (PaymentGatewayResponseTimeoutException e) {
+            transactionTemplate.executeWithoutResult(s -> markUnconfirmed(orderId, paymentKey));
+            throw e;
+        }
     }
 
     @Transactional
@@ -107,13 +110,91 @@ public class PaymentService {
             return;
         }
         PaymentOrder order = paymentOrderRepository.findByOrderId(orderId).orElse(null);
-        if (order == null || order.isDone()) {
+        if (order == null || order.isDone() || order.isUnconfirmed()) {
             return;
         }
         Reservation reservation = findReservation(order.getReservationId());
         validateOwner(reservation, memberId);
         paymentOrderRepository.deleteByOrderId(orderId);
         reservationDao.delete(reservation.getId());
+    }
+
+    private Prepared prepareConfirm(Long memberId, String paymentKey, String orderId, Long amount) {
+        PaymentOrder order = findPaymentOrder(orderId);
+        Reservation reservation = findReservation(order.getReservationId());
+        validateOwner(reservation, memberId);
+        validateAmount(order, amount);
+
+        if (order.isDone()) {
+            if (order.getPaymentKey().equals(paymentKey)) {
+                return Prepared.shortCircuit(
+                        new PaymentResult(paymentKey, orderId, PaymentStatus.DONE, order.getAmount()));
+            }
+            throw new PaymentAlreadyProcessedException();
+        }
+        if (order.isUnconfirmed() && !order.getPaymentKey().equals(paymentKey)) {
+            throw new PaymentAlreadyProcessedException();
+        }
+        return Prepared.proceed();
+    }
+
+    private PaymentResult finalizeConfirm(String orderId, String paymentKey, Long memberId, PaymentResult result) {
+        PaymentOrder order = findPaymentOrder(orderId);
+        validateResult(order, paymentKey, result);
+
+        if (order.isDone()) {
+            return result;
+        }
+
+        PaymentOrder completed = order.isUnconfirmed()
+                ? order.confirmAfterRecovery(result.paymentKey())
+                : order.complete(result.paymentKey());
+        paymentOrderRepository.update(completed);
+
+        Reservation reservation = findReservation(order.getReservationId());
+        if (!reservation.isConfirmed()) {
+            Reservation confirmed = reservation.confirm();
+            reservationDao.update(confirmed);
+            reservationHistoryService.recordCreated(confirmed, memberId);
+        }
+        return result;
+    }
+
+    private void markUnconfirmed(String orderId, String paymentKey) {
+        PaymentOrder order = paymentOrderRepository.findByOrderIdForUpdate(orderId)
+                .orElseThrow(PaymentNotFoundException::new);
+        if (order.isDone() || order.isUnconfirmed()) {
+            return;
+        }
+        paymentOrderRepository.update(order.markUnconfirmed(paymentKey));
+        log.warn("결제 결과 불명확 — UNCONFIRMED 마킹. orderId={}", orderId);
+    }
+
+    private <T> T retryOnTimeout(Supplier<T> call) {
+        int attempts = 0;
+        long backoffMs = INITIAL_BACKOFF_MS;
+        while (true) {
+            try {
+                return call.get();
+            } catch (PaymentGatewayResponseTimeoutException e) {
+                attempts++;
+                if (attempts >= MAX_GATEWAY_ATTEMPTS) {
+                    throw e;
+                }
+                log.warn("결제 게이트웨이 응답 타임아웃 — {}회 재시도 예정", attempts);
+                sleep(backoffMs);
+                backoffMs *= 2;
+            }
+        }
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PaymentGatewayResponseTimeoutException();
+        }
     }
 
     private void validateOwner(Reservation reservation, Long memberId) {
@@ -161,5 +242,15 @@ public class PaymentService {
 
     private String generateOrderId() {
         return "order-" + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private record Prepared(PaymentResult shortCircuit) {
+        static Prepared shortCircuit(PaymentResult result) {
+            return new Prepared(result);
+        }
+
+        static Prepared proceed() {
+            return new Prepared(null);
+        }
     }
 }

--- a/src/main/java/roomescape/payment/application/PaymentService.java
+++ b/src/main/java/roomescape/payment/application/PaymentService.java
@@ -18,8 +18,6 @@ import roomescape.payment.domain.PaymentOrderRepository;
 import roomescape.payment.domain.PaymentResult;
 import roomescape.payment.domain.PaymentStatus;
 import roomescape.payment.domain.exception.PaymentAlreadyProcessedException;
-import roomescape.payment.domain.exception.PaymentAmountMismatchException;
-import roomescape.payment.domain.exception.PaymentGatewayException;
 import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
 import roomescape.payment.domain.exception.PaymentNotFoundException;
 import roomescape.payment.domain.exception.PaymentOwnerMismatchException;
@@ -123,7 +121,7 @@ public class PaymentService {
         PaymentOrder order = findPaymentOrder(orderId);
         Reservation reservation = findReservation(order.getReservationId());
         validateOwner(reservation, memberId);
-        validateAmount(order, amount);
+        order.requireAmount(amount);
 
         if (order.isDone()) {
             if (order.getPaymentKey().equals(paymentKey)) {
@@ -140,16 +138,13 @@ public class PaymentService {
 
     private PaymentResult finalizeConfirm(String orderId, String paymentKey, Long memberId, PaymentResult result) {
         PaymentOrder order = findPaymentOrder(orderId);
-        validateResult(order, paymentKey, result);
+        order.requireMatchingResult(paymentKey, result);
 
         if (order.isDone()) {
             return result;
         }
 
-        PaymentOrder completed = order.isUnconfirmed()
-                ? order.confirmAfterRecovery(result.paymentKey())
-                : order.complete(result.paymentKey());
-        paymentOrderRepository.update(completed);
+        paymentOrderRepository.update(order.confirmWith(result.paymentKey()));
 
         Reservation reservation = findReservation(order.getReservationId());
         if (!reservation.isConfirmed()) {
@@ -200,22 +195,6 @@ public class PaymentService {
     private void validateOwner(Reservation reservation, Long memberId) {
         if (!reservation.isReservedBy(memberId)) {
             throw new PaymentOwnerMismatchException();
-        }
-    }
-
-    private void validateAmount(PaymentOrder order, Long amount) {
-        if (!order.getAmount().equals(amount)) {
-            throw new PaymentAmountMismatchException();
-        }
-    }
-
-    private void validateResult(PaymentOrder order, String paymentKey, PaymentResult result) {
-        if (result == null
-                || result.status() != PaymentStatus.DONE
-                || !order.getOrderId().equals(result.orderId())
-                || !order.getAmount().equals(result.approvedAmount())
-                || !paymentKey.equals(result.paymentKey())) {
-            throw new PaymentGatewayException();
         }
     }
 

--- a/src/main/java/roomescape/payment/domain/PaymentOrder.java
+++ b/src/main/java/roomescape/payment/domain/PaymentOrder.java
@@ -2,6 +2,8 @@ package roomescape.payment.domain;
 
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
+import roomescape.payment.domain.exception.PaymentAmountMismatchException;
+import roomescape.payment.domain.exception.PaymentGatewayException;
 
 public class PaymentOrder {
 
@@ -65,6 +67,28 @@ public class PaymentOrder {
         }
         return new PaymentOrder(id, orderId, reservationId, amount, approvedPaymentKey,
                 PaymentOrderStatus.DONE, createdAt);
+    }
+
+    public PaymentOrder confirmWith(String approvedPaymentKey) {
+        return isUnconfirmed()
+                ? confirmAfterRecovery(approvedPaymentKey)
+                : complete(approvedPaymentKey);
+    }
+
+    public void requireAmount(Long requested) {
+        if (!this.amount.equals(requested)) {
+            throw new PaymentAmountMismatchException();
+        }
+    }
+
+    public void requireMatchingResult(String attemptedPaymentKey, PaymentResult result) {
+        if (result == null
+                || result.status() != PaymentStatus.DONE
+                || !this.orderId.equals(result.orderId())
+                || !this.amount.equals(result.approvedAmount())
+                || !attemptedPaymentKey.equals(result.paymentKey())) {
+            throw new PaymentGatewayException();
+        }
     }
 
     public boolean isDone() {

--- a/src/main/java/roomescape/payment/domain/PaymentOrder.java
+++ b/src/main/java/roomescape/payment/domain/PaymentOrder.java
@@ -42,8 +42,37 @@ public class PaymentOrder {
                 PaymentOrderStatus.DONE, createdAt);
     }
 
+    public PaymentOrder markUnconfirmed(String attemptedPaymentKey) {
+        if (status != PaymentOrderStatus.READY) {
+            throw new IllegalStateException("READY 상태의 결제 주문만 결과 불명확으로 표시할 수 있습니다.");
+        }
+        if (attemptedPaymentKey == null || attemptedPaymentKey.isBlank()) {
+            throw new IllegalArgumentException("결제 키는 비어 있을 수 없습니다.");
+        }
+        return new PaymentOrder(id, orderId, reservationId, amount, attemptedPaymentKey,
+                PaymentOrderStatus.UNCONFIRMED, createdAt);
+    }
+
+    public PaymentOrder confirmAfterRecovery(String approvedPaymentKey) {
+        if (status != PaymentOrderStatus.UNCONFIRMED) {
+            throw new IllegalStateException("결과 불명확 상태의 결제 주문만 회복 확정할 수 있습니다.");
+        }
+        if (approvedPaymentKey == null || approvedPaymentKey.isBlank()) {
+            throw new IllegalArgumentException("결제 키는 비어 있을 수 없습니다.");
+        }
+        if (!paymentKey.equals(approvedPaymentKey)) {
+            throw new IllegalStateException("결제 키가 일치하지 않습니다.");
+        }
+        return new PaymentOrder(id, orderId, reservationId, amount, approvedPaymentKey,
+                PaymentOrderStatus.DONE, createdAt);
+    }
+
     public boolean isDone() {
         return status == PaymentOrderStatus.DONE;
+    }
+
+    public boolean isUnconfirmed() {
+        return status == PaymentOrderStatus.UNCONFIRMED;
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/payment/domain/PaymentOrderRepository.java
+++ b/src/main/java/roomescape/payment/domain/PaymentOrderRepository.java
@@ -1,5 +1,6 @@
 package roomescape.payment.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentOrderRepository {
@@ -9,6 +10,8 @@ public interface PaymentOrderRepository {
     Optional<PaymentOrder> findByOrderId(String orderId);
 
     Optional<PaymentOrder> findByOrderIdForUpdate(String orderId);
+
+    List<PaymentOrder> findAllByReservationIdIn(List<Long> reservationIds);
 
     PaymentOrder update(PaymentOrder order);
 

--- a/src/main/java/roomescape/payment/domain/PaymentOrderStatus.java
+++ b/src/main/java/roomescape/payment/domain/PaymentOrderStatus.java
@@ -2,5 +2,6 @@ package roomescape.payment.domain;
 
 public enum PaymentOrderStatus {
     READY,
+    UNCONFIRMED,
     DONE
 }

--- a/src/main/java/roomescape/payment/domain/exception/PaymentErrorType.java
+++ b/src/main/java/roomescape/payment/domain/exception/PaymentErrorType.java
@@ -13,9 +13,10 @@ public enum PaymentErrorType implements ErrorType {
     OWNER_MISMATCH(HttpStatus.FORBIDDEN, "PAYMENT403_001", "본인의 결제 주문만 처리할 수 있습니다."),
     CARD_REJECTED(HttpStatus.UNPROCESSABLE_ENTITY, "PAYMENT422_001", "카드 결제가 거절되었습니다. 결제 수단을 확인해 주세요."),
     GATEWAY_CONFIGURATION(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT500_001", "결제 설정 오류가 발생했습니다."),
-    GATEWAY_RETRYABLE(HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT503_001",
-            "결제 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해 주세요."),
-    GATEWAY_ERROR(HttpStatus.BAD_GATEWAY, "PAYMENT502_001", "결제 승인 중 오류가 발생했습니다.");
+    GATEWAY_RETRYABLE(HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT503_001", "결제 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해 주세요."),
+    GATEWAY_ERROR(HttpStatus.BAD_GATEWAY, "PAYMENT502_001", "결제 승인 중 오류가 발생했습니다."),
+    GATEWAY_CONNECTION_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "PAYMENT504_001", "결제 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+    GATEWAY_RESPONSE_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "PAYMENT504_002", "결제 결과 확인이 필요합니다. 내 결제 내역에서 상태를 확인해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/roomescape/payment/domain/exception/PaymentGatewayConnectionTimeoutException.java
+++ b/src/main/java/roomescape/payment/domain/exception/PaymentGatewayConnectionTimeoutException.java
@@ -1,0 +1,10 @@
+package roomescape.payment.domain.exception;
+
+import roomescape.common.exception.BusinessException;
+
+public class PaymentGatewayConnectionTimeoutException extends BusinessException {
+
+    public PaymentGatewayConnectionTimeoutException() {
+        super(PaymentErrorType.GATEWAY_CONNECTION_TIMEOUT);
+    }
+}

--- a/src/main/java/roomescape/payment/domain/exception/PaymentGatewayResponseTimeoutException.java
+++ b/src/main/java/roomescape/payment/domain/exception/PaymentGatewayResponseTimeoutException.java
@@ -1,0 +1,10 @@
+package roomescape.payment.domain.exception;
+
+import roomescape.common.exception.BusinessException;
+
+public class PaymentGatewayResponseTimeoutException extends BusinessException {
+
+    public PaymentGatewayResponseTimeoutException() {
+        super(PaymentErrorType.GATEWAY_RESPONSE_TIMEOUT);
+    }
+}

--- a/src/main/java/roomescape/payment/infrastructure/JdbcPaymentOrderRepository.java
+++ b/src/main/java/roomescape/payment/infrastructure/JdbcPaymentOrderRepository.java
@@ -2,6 +2,8 @@ package roomescape.payment.infrastructure;
 
 import java.sql.PreparedStatement;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -50,6 +52,17 @@ public class JdbcPaymentOrderRepository implements PaymentOrderRepository {
         String sql = "select id, order_id, reservation_id, amount, payment_key, status, created_at "
                 + "from payment_order where order_id = ? for update";
         return jdbcTemplate.query(sql, rowMapper(), orderId).stream().findFirst();
+    }
+
+    @Override
+    public List<PaymentOrder> findAllByReservationIdIn(List<Long> reservationIds) {
+        if (reservationIds == null || reservationIds.isEmpty()) {
+            return List.of();
+        }
+        String placeholders = String.join(",", Collections.nCopies(reservationIds.size(), "?"));
+        String sql = "select id, order_id, reservation_id, amount, payment_key, status, created_at "
+                + "from payment_order where reservation_id in (" + placeholders + ")";
+        return jdbcTemplate.query(sql, rowMapper(), reservationIds.toArray());
     }
 
     @Override

--- a/src/main/java/roomescape/payment/infrastructure/toss/TossClientConfig.java
+++ b/src/main/java/roomescape/payment/infrastructure/toss/TossClientConfig.java
@@ -2,10 +2,14 @@ package roomescape.payment.infrastructure.toss;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -14,13 +18,26 @@ public class TossClientConfig {
     @Bean("tossRestClient")
     public RestClient tossRestClient(
             @Value("${payment.toss.base-url}") String baseUrl,
-            @Value("${payment.toss.secret-key}") String secretKey
+            @Value("${payment.toss.secret-key}") String secretKey,
+            @Value("${payment.toss.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${payment.toss.read-timeout-ms}") int readTimeoutMs
     ) {
         String credential = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        var requestConfig = RequestConfig.custom()
+                .setConnectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+                .setResponseTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
+                .build();
+
+        var httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+
+        var factory = new HttpComponentsClientHttpRequestFactory(httpClient);
+
         return RestClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + credential)
+                .requestFactory(factory)
                 .build();
     }
 }

--- a/src/main/java/roomescape/payment/infrastructure/toss/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/infrastructure/toss/TossPaymentGateway.java
@@ -2,19 +2,26 @@ package roomescape.payment.infrastructure.toss;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.ConnectException;
+import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 import roomescape.payment.domain.PaymentConfirmation;
 import roomescape.payment.domain.PaymentGateway;
 import roomescape.payment.domain.PaymentResult;
 import roomescape.payment.domain.PaymentStatus;
 import roomescape.payment.domain.exception.PaymentGatewayConfigurationException;
+import roomescape.payment.domain.exception.PaymentGatewayConnectionTimeoutException;
 import roomescape.payment.domain.exception.PaymentGatewayException;
+import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
 import roomescape.payment.domain.exception.RetryablePaymentException;
 import roomescape.payment.infrastructure.toss.dto.TossConfirmRequest;
 import roomescape.payment.infrastructure.toss.dto.TossErrorResponse;
@@ -40,24 +47,19 @@ public class TossPaymentGateway implements PaymentGateway {
     public PaymentResult confirm(PaymentConfirmation confirmation) {
         TossConfirmRequest request = new TossConfirmRequest(
                 confirmation.paymentKey(), confirmation.orderId(), confirmation.amount());
-        TossPaymentResponse response = tossRestClient.post()
-                .uri("/v1/payments/confirm")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (httpRequest, httpResponse) -> {
-                    try {
-                        TossErrorResponse error = objectMapper.readValue(
-                                httpResponse.getBody(), TossErrorResponse.class);
-                        RuntimeException exception = TossPaymentExceptionMapper.map(error.code());
-                        logExternalFailure(exception, error);
-                        throw exception;
-                    } catch (IOException e) {
-                        log.error("Toss 결제 승인 에러 응답을 역직렬화하지 못했습니다.", e);
-                        throw new PaymentGatewayException();
-                    }
-                })
-                .body(TossPaymentResponse.class);
+        TossPaymentResponse response;
+        try {
+            response = tossRestClient.post()
+                    .uri("/v1/payments/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Idempotency-Key", confirmation.orderId())
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
+                    .body(TossPaymentResponse.class);
+        } catch (ResourceAccessException e) {
+            throw translateNetworkFailure(e, confirmation.orderId());
+        }
 
         if (response == null) {
             log.error("Toss 결제 승인 응답 본문이 비어 있습니다. orderId={}", confirmation.orderId());
@@ -69,6 +71,28 @@ public class TossPaymentGateway implements PaymentGateway {
                 PaymentStatus.from(response.status()),
                 response.totalAmount()
         );
+    }
+
+    private void handleErrorResponse(HttpRequest request, ClientHttpResponse response) throws IOException {
+        try {
+            TossErrorResponse error = objectMapper.readValue(response.getBody(), TossErrorResponse.class);
+            RuntimeException exception = TossPaymentExceptionMapper.map(error.code());
+            logExternalFailure(exception, error);
+            throw exception;
+        } catch (IOException e) {
+            log.error("Toss 결제 승인 에러 응답을 역직렬화하지 못했습니다.", e);
+            throw new PaymentGatewayException();
+        }
+    }
+
+    private RuntimeException translateNetworkFailure(ResourceAccessException e, String orderId) {
+        Throwable cause = e.getCause();
+        if (cause instanceof ConnectTimeoutException || cause instanceof ConnectException) {
+            log.warn("Toss 연결 실패 — orderId={}", orderId, e);
+            return new PaymentGatewayConnectionTimeoutException();
+        }
+        log.warn("Toss 응답 대기 중 타임아웃 — orderId={}", orderId, e);
+        return new PaymentGatewayResponseTimeoutException();
     }
 
     private void logExternalFailure(RuntimeException exception, TossErrorResponse error) {

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -47,10 +47,10 @@ public class ReservationController {
 
     @GetMapping
     public ResponseEntity<MyReservationsAndWaitsResponse> getReservations(@LoginMember Long memberId) {
-        List<Reservation> reservations = reservationService.getReservations(memberId);
+        List<ReservationResponse> reservations = reservationService.getReservationsWithPayments(memberId);
         List<WaitingResult> waitingResponseResults = reservationWaitService.getWaitings(memberId);
         MyReservationsAndWaitsResponse myReservationsAndWaitsResponse = new MyReservationsAndWaitsResponse(
-                ReservationResponse.fromAll(reservations), WaitingResponse.fromAll(waitingResponseResults));
+                reservations, WaitingResponse.fromAll(waitingResponseResults));
         return ResponseEntity.ok().body(myReservationsAndWaitsResponse);
     }
 

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -2,19 +2,24 @@ package roomescape.reservation;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.payment.domain.PaymentOrder;
+import roomescape.payment.domain.PaymentOrderRepository;
+import roomescape.reservation.dto.ReservationResponse;
+import roomescape.reservation.exception.ReservationAlreadyExistsException;
+import roomescape.reservation.exception.ReservationNotFoundException;
+import roomescape.reservationtime.ReservationTime;
 import roomescape.reservationtime.ReservationTimeDao;
+import roomescape.reservationtime.exception.ReservationTimeNotFoundException;
 import roomescape.reservationwait.ReservationWaitDao;
 import roomescape.member.Member;
 import roomescape.reservationhistory.ReservationHistoryService;
-import roomescape.reservationtime.ReservationTime;
-import roomescape.reservation.exception.ReservationAlreadyExistsException;
-import roomescape.reservation.exception.ReservationNotFoundException;
-import roomescape.reservationtime.exception.ReservationTimeNotFoundException;
-import roomescape.payment.domain.PaymentOrderRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -39,6 +44,17 @@ public class ReservationService {
 
     public List<Reservation> getReservations(Long memberId) {
         return reservationDao.findAllReservationsByMemberId(memberId);
+    }
+
+    public List<ReservationResponse> getReservationsWithPayments(Long memberId) {
+        List<Reservation> reservations = reservationDao.findAllReservationsByMemberId(memberId);
+        List<Long> reservationIds = reservations.stream().map(Reservation::getId).toList();
+        Map<Long, PaymentOrder> byReservationId = paymentOrderRepository.findAllByReservationIdIn(reservationIds)
+                .stream()
+                .collect(Collectors.toMap(PaymentOrder::getReservationId, Function.identity()));
+        return reservations.stream()
+                .map(r -> ReservationResponse.from(r, byReservationId.get(r.getId())))
+                .toList();
     }
 
     public List<Reservation> findReservationsByStoreId(Long storeId) {

--- a/src/main/java/roomescape/reservation/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/ReservationResponse.java
@@ -1,10 +1,12 @@
 package roomescape.reservation.dto;
 
 import java.util.List;
-import roomescape.reservationtime.dto.ReservationTimeResponse;
+import roomescape.payment.domain.PaymentOrder;
+import roomescape.payment.domain.PaymentOrderStatus;
 import roomescape.reservation.Reservation;
 import roomescape.reservation.ReservationStatus;
 import roomescape.reservationtime.ReservationTime;
+import roomescape.reservationtime.dto.ReservationTimeResponse;
 
 public record ReservationResponse(
         Long id,
@@ -13,9 +15,17 @@ public record ReservationResponse(
         ReservationTimeResponse time,
         Long themeId,
         Long storeId,
-        ReservationStatus status
+        ReservationStatus status,
+        String orderId,
+        String paymentKey,
+        Long amount,
+        PaymentOrderStatus paymentStatus
 ) {
     public static ReservationResponse from(Reservation reservation) {
+        return from(reservation, null);
+    }
+
+    public static ReservationResponse from(Reservation reservation, PaymentOrder paymentOrder) {
         ReservationTime reservationTime = reservation.getTime();
         return new ReservationResponse(
                 reservation.getId(),
@@ -24,7 +34,11 @@ public record ReservationResponse(
                 ReservationTimeResponse.from(reservationTime),
                 reservation.getThemeId(),
                 reservation.getStoreId(),
-                reservation.getStatus()
+                reservation.getStatus(),
+                paymentOrder == null ? null : paymentOrder.getOrderId(),
+                paymentOrder == null ? null : paymentOrder.getPaymentKey(),
+                paymentOrder == null ? null : paymentOrder.getAmount(),
+                paymentOrder == null ? null : paymentOrder.getStatus()
         );
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ payment.toss.base-url=${TOSS_BASE_URL:https://api.tosspayments.com}
 payment.toss.client-key=${TOSS_CLIENT_KEY}
 payment.toss.secret-key=${TOSS_SECRET_KEY}
 payment.reservation-amount=${RESERVATION_PAYMENT_AMOUNT:50000}
+payment.toss.connect-timeout-ms=${TOSS_CONNECT_TIMEOUT_MS:500}
+payment.toss.read-timeout-ms=${TOSS_READ_TIMEOUT_MS:500}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -61,7 +61,7 @@ CREATE TABLE payment_order
     amount         BIGINT       NOT NULL CHECK (amount > 0),
     payment_key    VARCHAR(200),
     status         VARCHAR(20)  NOT NULL DEFAULT 'READY'
-        CHECK (status IN ('READY', 'DONE')),
+        CHECK (status IN ('READY', 'UNCONFIRMED', 'DONE')),
     created_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     CONSTRAINT uq_payment_order_order_id UNIQUE (order_id),

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1351,6 +1351,8 @@
         PAYMENT500_001: "결제 설정에 문제가 있습니다. 관리자에게 문의해 주세요.",
         PAYMENT502_001: "결제 승인 중 문제가 발생했습니다.",
         PAYMENT503_001: "결제 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해 주세요.",
+        PAYMENT504_001: "결제 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+        PAYMENT504_002: "결제 결과 확인이 필요합니다. 내 결제 내역에서 상태를 확인해 주세요.",
         THEME404_001: "선택한 테마를 찾을 수 없습니다.",
         THEME409_001: "이미 예약이 존재하는 테마는 삭제할 수 없습니다.",
         COMMON400_001: "입력값이 올바르지 않습니다.",
@@ -1806,6 +1808,35 @@
         }
     }
 
+    function paymentBadge(r) {
+        if (!r.paymentStatus) {
+            return `<span class="pill pill--confirmed">확정</span>`;
+        }
+        switch (r.paymentStatus) {
+            case "DONE":
+                return `<span class="pill pill--confirmed" title="결제 완료${r.amount ? ` · ${r.amount.toLocaleString()}원` : ""}">결제 완료</span>`;
+            case "UNCONFIRMED":
+                return `<span class="pill" style="background:#fef3c7;color:#92400e;" title="결제 결과 확인 필요">확인 필요</span>`;
+            case "READY":
+                return `<span class="pill" style="background:#dbeafe;color:#1e40af;" title="결제 진행 전 / 미완">결제 대기</span>`;
+            default:
+                return `<span class="pill pill--confirmed">확정</span>`;
+        }
+    }
+
+    function paymentReconfirmButton(r) {
+        if (r.paymentStatus !== "UNCONFIRMED") return "";
+        if (!r.paymentKey) {
+            return `<button type="button" class="btn-icon" disabled title="결제창에서 다시 시도해 주세요" aria-label="결제 키 없음">↻</button>`;
+        }
+        return `<button type="button" class="btn-icon"
+                data-reconfirm="1"
+                data-payment-key="${r.paymentKey}"
+                data-order-id="${r.orderId}"
+                data-amount="${r.amount}"
+                title="결제 결과를 다시 확인합니다" aria-label="결제 다시 확인">↻</button>`;
+    }
+
     async function loadMyReservations() {
         try {
             const data = await getJson("/api/v1/reservations");
@@ -1841,7 +1872,8 @@
                             </div>
                         </div>
                         <div class="row-actions">
-                            <span class="pill pill--confirmed">확정</span>
+                            ${paymentBadge(r)}
+                            ${paymentReconfirmButton(r)}
                             <button type="button" class="btn-icon" data-cancel-id="${r.id}" title="예약 취소" aria-label="예약 취소">✕</button>
                         </div>
                     </div>
@@ -1856,6 +1888,22 @@
                             await loadMyReservations();
                         } catch (e) {
                             setStatus(userStatus, "error", e.message);
+                        }
+                    });
+                });
+
+                myReservationsList.querySelectorAll("[data-reconfirm]").forEach(el => {
+                    el.addEventListener("click", async () => {
+                        try {
+                            await postJson("/api/v1/payments/confirm", {
+                                paymentKey: el.dataset.paymentKey,
+                                orderId: el.dataset.orderId,
+                                amount: Number(el.dataset.amount),
+                            });
+                            setStatus(userStatus, "success", "결제가 확인되었습니다.");
+                            await loadMyReservations();
+                        } catch (e) {
+                            setStatus(userStatus, "error", e.message || "결제 확인에 실패했습니다.");
                         }
                     });
                 });

--- a/src/test/java/roomescape/payment/application/PaymentServiceTest.java
+++ b/src/test/java/roomescape/payment/application/PaymentServiceTest.java
@@ -23,6 +23,7 @@ import roomescape.payment.domain.PaymentGateway;
 import roomescape.payment.domain.PaymentResult;
 import roomescape.payment.domain.PaymentStatus;
 import roomescape.payment.domain.exception.PaymentAmountMismatchException;
+import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -94,6 +95,43 @@ class PaymentServiceTest {
 
         assertThat(retried.status()).isEqualTo(PaymentStatus.DONE);
         verify(paymentGateway, times(1)).confirm(any());
+        assertThat(value("SELECT COUNT(*) FROM reservation_history", Integer.class)).isEqualTo(1);
+    }
+
+    @Test
+    void read_timeout이_재시도_끝까지_계속되면_PaymentOrder가_UNCONFIRMED로_저장되고_예외가_전파된다() {
+        PaymentCheckout checkout = prepare();
+        given(paymentGateway.confirm(any())).willThrow(new PaymentGatewayResponseTimeoutException());
+
+        assertThatThrownBy(() -> paymentService.confirm(1L, "payment-key", checkout.orderId(), 50_000L))
+                .isInstanceOf(PaymentGatewayResponseTimeoutException.class);
+
+        verify(paymentGateway, times(3)).confirm(any());
+        assertThat(value("SELECT status FROM payment_order WHERE reservation_id = 1", String.class))
+                .isEqualTo("UNCONFIRMED");
+        assertThat(value("SELECT payment_key FROM payment_order WHERE reservation_id = 1", String.class))
+                .isEqualTo("payment-key");
+        assertThat(value("SELECT status FROM reservation WHERE id = 1", String.class)).isEqualTo("PENDING");
+        assertThat(value("SELECT COUNT(*) FROM reservation_history", Integer.class)).isZero();
+    }
+
+    @Test
+    void UNCONFIRMED_주문에_같은_paymentKey로_재confirm하면_DONE으로_복구되고_예약은_CONFIRMED로_전환된다() {
+        PaymentCheckout checkout = prepare();
+        given(paymentGateway.confirm(any()))
+                .willThrow(new PaymentGatewayResponseTimeoutException())
+                .willThrow(new PaymentGatewayResponseTimeoutException())
+                .willThrow(new PaymentGatewayResponseTimeoutException())
+                .willReturn(new PaymentResult("payment-key", checkout.orderId(), PaymentStatus.DONE, 50_000L));
+
+        assertThatThrownBy(() -> paymentService.confirm(1L, "payment-key", checkout.orderId(), 50_000L))
+                .isInstanceOf(PaymentGatewayResponseTimeoutException.class);
+
+        PaymentResult result = paymentService.confirm(1L, "payment-key", checkout.orderId(), 50_000L);
+
+        assertThat(result.status()).isEqualTo(PaymentStatus.DONE);
+        assertThat(value("SELECT status FROM payment_order WHERE reservation_id = 1", String.class)).isEqualTo("DONE");
+        assertThat(value("SELECT status FROM reservation WHERE id = 1", String.class)).isEqualTo("CONFIRMED");
         assertThat(value("SELECT COUNT(*) FROM reservation_history", Integer.class)).isEqualTo(1);
     }
 

--- a/src/test/java/roomescape/payment/infrastructure/toss/TossPaymentGatewayIdempotencyTest.java
+++ b/src/test/java/roomescape/payment/infrastructure/toss/TossPaymentGatewayIdempotencyTest.java
@@ -1,0 +1,150 @@
+package roomescape.payment.infrastructure.toss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestClientException;
+import roomescape.payment.domain.PaymentConfirmation;
+import roomescape.payment.domain.PaymentResult;
+import roomescape.payment.domain.PaymentStatus;
+import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
+
+/**
+ * 타임아웃의 두 번째 위험을 다룬다. read timeout 은 "요청은 도달했는데 응답만 못 받은" 상태를 만들 수 있어,
+ * 끊긴 뒤 재시도하면 같은 결제가 두 번 일어날 수 있다. Idempotency-Key 로 그 중복을 막는 것을 확인한다.
+ *
+ * <p>선행: 이 테스트는 read timeout 이 동작해야 시나리오가 성립한다. {@link TossPaymentGatewayTimeoutTest} 를 먼저 통과시킨 뒤 풀자.
+ */
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class TossPaymentGatewayIdempotencyTest {
+
+    private static final MockWebServer MOCK_WEB_SERVER = startServer();
+
+    @Autowired
+    private TossPaymentGateway tossPaymentGateway;
+
+    @DynamicPropertySource
+    static void tossProperties(DynamicPropertyRegistry registry) {
+        registry.add("payment.toss.base-url", () -> MOCK_WEB_SERVER.url("/").toString());
+        registry.add("payment.toss.secret-key", () -> "test_sk_dummy");
+        registry.add("payment.toss.connect-timeout-ms", () -> "500");
+        registry.add("payment.toss.read-timeout-ms", () -> "500");
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        MOCK_WEB_SERVER.shutdown();
+    }
+
+    @Test
+    void read_timeout으로_끊겨_재시도해도_같은_멱등키면_중복_결제가_생기지_않는다() {
+        IdempotentGatewayStub stub = new IdempotentGatewayStub();
+        MOCK_WEB_SERVER.setDispatcher(stub);
+        PaymentConfirmation confirmation = new PaymentConfirmation("test_pk_1", "order-1", 10000L);
+
+        // 1차: 서버는 결제를 처리하지만 응답이 느려 read timeout(500ms) 으로 끊긴다.
+        //      클라이언트는 실패로 알지만 서버에는 이미 결제가 만들어졌다 — 응답만 유실된 것.
+        assertThatThrownBy(() -> tossPaymentGateway.confirm(confirmation))
+                .isInstanceOf(PaymentGatewayResponseTimeoutException.class);
+
+        // 2차(재시도): 같은 Idempotency-Key 라 서버가 중복을 인지해 재처리 없이 첫 결과를 즉시 돌려준다.
+        PaymentResult result = tossPaymentGateway.confirm(confirmation);
+
+        assertThat(result.status()).isEqualTo(PaymentStatus.DONE);
+        // 두 번 호출됐지만 서버가 만든 결제는 1건뿐 — 이중 청구가 아니다.
+        assertThat(stub.createdPayments()).isEqualTo(1);
+        // 중복으로 묶일 수 있었던 건, 두 요청이 같은(그리고 비어 있지 않은) 키를 실어 보냈기 때문이다.
+        assertThat(stub.seenKeys()).hasSize(2);
+        assertThat(stub.seenKeys().get(0)).isNotBlank().isEqualTo(stub.seenKeys().get(1));
+    }
+
+    private static MockWebServer startServer() {
+        MockWebServer server = new MockWebServer();
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return server;
+    }
+
+    /**
+     * 멱등키로 중복 요청을 걸러내는 결제 게이트웨이 스텁. 처음 보는 키는 결제를 만들되 응답을 느리게 줘
+     * (read timeout 유발), 같은 키 재요청은 첫 결과를 즉시 돌려준다. 키가 없으면 매 요청을 새 결제로 처리한다.
+     */
+    private static class IdempotentGatewayStub extends Dispatcher {
+
+        private final Map<String, String> paymentKeyByIdempotencyKey = new ConcurrentHashMap<>();
+        private final AtomicInteger createdPayments = new AtomicInteger();
+        private final List<String> seenKeys = new CopyOnWriteArrayList<>();
+
+        @Override
+        public MockResponse dispatch(RecordedRequest request) {
+            String key = request.getHeader("Idempotency-Key");
+            seenKeys.add(key);
+
+            // 키가 없으면 매 요청을 새 결제로 처리한다 — 재시도가 곧 중복 결제가 된다.
+            if (key == null || key.isBlank()) {
+                return slowSuccess(newPaymentKey());
+            }
+            // 이미 처리한 키면 재처리 없이 첫 결과를 즉시 돌려준다(멱등).
+            String existing = paymentKeyByIdempotencyKey.get(key);
+            if (existing != null) {
+                return fastSuccess(existing);
+            }
+            // 처음 보는 키: 결제를 만들고 결과를 기록한다. 단 응답이 느려 클라이언트는 이번엔 받지 못한다.
+            String paymentKey = newPaymentKey();
+            paymentKeyByIdempotencyKey.put(key, paymentKey);
+            return slowSuccess(paymentKey);
+        }
+
+        int createdPayments() {
+            return createdPayments.get();
+        }
+
+        List<String> seenKeys() {
+            return seenKeys;
+        }
+
+        private String newPaymentKey() {
+            return "pk_" + createdPayments.incrementAndGet();
+        }
+
+        private MockResponse slowSuccess(String paymentKey) {
+            return success(paymentKey).setHeadersDelay(2, TimeUnit.SECONDS);
+        }
+
+        private MockResponse fastSuccess(String paymentKey) {
+            return success(paymentKey);
+        }
+
+        private MockResponse success(String paymentKey) {
+            return new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("""
+                            {"paymentKey": "%s", "orderId": "order-1", "status": "DONE", "totalAmount": 10000}
+                            """.formatted(paymentKey));
+        }
+    }
+}

--- a/src/test/java/roomescape/payment/infrastructure/toss/TossPaymentGatewayTimeoutTest.java
+++ b/src/test/java/roomescape/payment/infrastructure/toss/TossPaymentGatewayTimeoutTest.java
@@ -1,0 +1,139 @@
+package roomescape.payment.infrastructure.toss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import roomescape.payment.domain.PaymentConfirmation;
+import roomescape.payment.domain.exception.PaymentGatewayConnectionTimeoutException;
+import roomescape.payment.domain.exception.PaymentGatewayResponseTimeoutException;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class TossPaymentGatewayTimeoutTest {
+
+    // 응답 없는(SYN 무응답) IP → connect 가 매달려 connect timeout 을 유발한다.
+    // 일부 환경(사내망/CI)에선 즉시 거부 응답이 와서 시나리오가 깨질 수 있으니, 본인 환경에서 침묵하는 IP인지 먼저 확인하라.
+    private static final String BLACKHOLE_URL = "http://10.255.255.1:81";
+
+    private static final String SUCCESS_BODY = """
+            {"paymentKey": "test_pk_1", "orderId": "order-1", "status": "DONE", "totalAmount": 10000}
+            """;
+
+    private static final MockWebServer MOCK_WEB_SERVER = startServer();
+
+    @Autowired
+    private TossPaymentGateway tossPaymentGateway;
+
+    @DynamicPropertySource
+    static void tossProperties(DynamicPropertyRegistry registry) {
+        registry.add("payment.toss.base-url", () -> MOCK_WEB_SERVER.url("/").toString());
+        registry.add("payment.toss.secret-key", () -> "test_sk_dummy");
+        registry.add("payment.toss.connect-timeout-ms", () -> "500");
+        registry.add("payment.toss.read-timeout-ms", () -> "500");
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        MOCK_WEB_SERVER.shutdown();
+    }
+
+    private PaymentConfirmation confirmation() {
+        return new PaymentConfirmation("test_pk_1", "order-1", 10000L);
+    }
+
+    @Test
+    void 읽기타임아웃이면_readTimeout만큼만_기다렸다가_도메인_예외로_실패한다() {
+        MOCK_WEB_SERVER.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(SUCCESS_BODY)
+                .setHeadersDelay(2, TimeUnit.SECONDS));
+
+        long start = System.nanoTime();
+        assertThatThrownBy(() -> tossPaymentGateway.confirm(confirmation()))
+                .isInstanceOf(PaymentGatewayResponseTimeoutException.class);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // 서버는 2초를 끌지만 read timeout(500ms) 이 먼저 끊는다.
+        assertThat(elapsedMs).isLessThan(1500);
+    }
+
+    @Test
+    void 느린_호출이_섞여도_타임아웃이_있으면_성공_TPS가_유지된다() {
+        // 느린 응답(2초)과 정상 응답이 번갈아 온다 — 느린 의존성에 일부 호출만 물리는 상황.
+        for (int i = 0; i < 3; i++) {
+            MOCK_WEB_SERVER.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(SUCCESS_BODY)
+                    .setHeadersDelay(2, TimeUnit.SECONDS));
+            MOCK_WEB_SERVER.enqueue(new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(SUCCESS_BODY));
+        }
+
+        int succeeded = 0;
+        long start = System.nanoTime();
+        for (int i = 0; i < 6; i++) {
+            try {
+                tossPaymentGateway.confirm(confirmation());
+                succeeded++;
+            } catch (PaymentGatewayResponseTimeoutException e) {
+                // 타임아웃으로 일찍 포기한 호출 — 성공 TPS 에 세지 않는다.
+            }
+        }
+        double elapsedSeconds = (System.nanoTime() - start) / 1_000_000_000.0;
+        double tps = succeeded / elapsedSeconds;
+
+        // read timeout(500ms) 이 있으면 느린 3건을 일찍 포기한 덕에 정상 3건이 제때 처리된다 → ~1.8.
+        // 없으면 느린 호출이 스레드를 2초씩 붙잡아, 6건 전부 성공하고도 1.0 을 넘지 못한다.
+        assertThat(tps).isGreaterThan(1.1);
+    }
+
+    @Test
+    @Timeout(value = 3, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+    void 라우팅불가_IP면_connectTimeout만큼_기다렸다가_SocketTimeout으로_실패한다() {
+        // TossClientConfig.tossRestClient 가 채워둔 connect timeout 을 그대로 검증한다.
+        // 설정 전(initial)엔 타임아웃이 없어 블랙홀 연결이 매달리므로 @Timeout(3초) 이 끊어 실패시킨다.
+        TossPaymentGateway gateway = new TossPaymentGateway(
+                new TossClientConfig().tossRestClient(BLACKHOLE_URL, "test_sk_dummy", 500, 500),
+                new ObjectMapper());
+
+        long start = System.nanoTime();
+        assertThatThrownBy(() -> gateway.confirm(confirmation()))
+                .isInstanceOf(PaymentGatewayConnectionTimeoutException.class);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // connect timeout(500ms) 만큼 기다렸다가 끊긴다.
+        assertThat(elapsedMs).isBetween(300L, 2500L);
+    }
+
+    private static MockWebServer startServer() {
+        MockWebServer server = new MockWebServer();
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return server;
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,3 +4,5 @@ security.jwt.token.secret-key=/BWxvVt/eMsTVSq+RI9kRCrZKK38KNGIWi7ilxCg9So=
 security.jwt.token.expire-length=3600000
 payment.toss.client-key=test_ck_dummy
 payment.toss.secret-key=test_sk_dummy
+payment.toss.connect-timeout-ms=500
+payment.toss.read-timeout-ms=500


### PR DESCRIPTION
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [ ] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 작업 내용

### 1. Toss 호출 보호 — timeout + Idempotency-Key
- `TossClientConfig`에 **Apache HttpComponents** 요청 팩토리 도입, `connect-timeout` / `response-timeout` 설정
- 타임아웃 값은 코드에 박지 않고 `application.properties`로 외부화 (`payment.toss.connect-timeout-ms`, `payment.toss.read-timeout-ms`)
- `TossPaymentGateway.confirm`에 `Idempotency-Key: {orderId}` 헤더 추가 (주문당 고정 → 재시도해도 같은 키)
- 학습 테스트 추가 (`MockWebServer` 기반): connect/read timeout 동작, 성공 TPS 유지, 멱등 재시도 시 이중 결제 차단

### 2. 타임아웃·연결 실패를 도메인 예외로 번역
- 신규 도메인 예외 2개
  - `PaymentGatewayConnectionTimeoutException` (HTTP 504, 연결 단계 실패)
  - `PaymentGatewayResponseTimeoutException` (HTTP 504, 응답 읽기 단계 실패)
- `TossPaymentGateway.translateNetworkFailure`에서 `ResourceAccessException`의 `cause`로 분기 (`ConnectTimeoutException`/`ConnectException` vs `SocketTimeoutException`)
- 토스의 거절성 응답(`code/message`)과 어휘 분리 — 거절은 "사용자 조치", 타임아웃은 "답 없음 / 확인 필요"

### 3. 결과 불명확 결제(UNCONFIRMED) + 자동 회복 흐름
- `PaymentOrderStatus`에 **UNCONFIRMED** 추가, schema CHECK 갱신
- 도메인 메서드 추가: `markUnconfirmed`, `confirmAfterRecovery`, `confirmWith`, `requireAmount`, `requireMatchingResult`
- `PaymentService.confirm`을 `TransactionTemplate`로 **3구간 트랜잭션 분리**
  - `prepareConfirm` (잠금 조회·검증·멱등 단축)
  - 외부 호출 (트랜잭션 밖, 지수 백오프 500ms→1s→2s, 최대 3회 자동 재시도)
  - `finalizeConfirm` (성공 시) 또는 `markUnconfirmed` (끝까지 timeout 시) — 마킹 커밋 후 예외 전파
- self-invocation 함정 회피: `TransactionTemplate`은 프록시를 거치지 않아 같은 빈 안에서 안전하게 트랜잭션 경계 분리

### 4. "내 예약" 페이지에 결제 정보 통합
- `PaymentOrderRepository.findAllByReservationIdIn` 추가 (빈 리스트 가드 포함, N+1 없음)
- `ReservationResponse`에 nullable 결제 4필드 추가 (`orderId`, `paymentKey`, `amount`, `paymentStatus`)
- `ReservationService.getReservationsWithPayments`로 reservation ↔ payment 결합
- 화면(`static/index.html`)에 pill 분기 — **결제 완료 / 확인 필요 / 결제 대기** + UNCONFIRMED일 때만 ↻ **다시 확인** 버튼 노출 (paymentKey 부재 시 disabled + 안내)
- "다시 확인" → 같은 paymentKey/orderId/amount로 `POST /payments/confirm` 재호출 → `confirmAfterRecovery`로 DONE 전이
