### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 캐리 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/controller/dto/response/BookingPaymentResponse.java
+++ b/src/main/java/roomescape/controller/dto/response/BookingPaymentResponse.java
@@ -1,0 +1,28 @@
+package roomescape.controller.dto.response;
+
+import roomescape.domain.PaymentStatus;
+import roomescape.service.dto.BookingPaymentInfo;
+
+public record BookingPaymentResponse(
+        String orderId,
+        Long amount,
+        String paymentKey,
+        PaymentStatus status,
+        String failureCode,
+        String failureMessage
+) {
+
+    public static BookingPaymentResponse from(BookingPaymentInfo payment) {
+        if (payment == null) {
+            return null;
+        }
+        return new BookingPaymentResponse(
+                payment.orderId(),
+                payment.amount(),
+                payment.paymentKey(),
+                payment.status(),
+                payment.failureCode(),
+                payment.failureMessage()
+        );
+    }
+}

--- a/src/main/java/roomescape/controller/dto/response/BookingStatusResponse.java
+++ b/src/main/java/roomescape/controller/dto/response/BookingStatusResponse.java
@@ -13,7 +13,8 @@ public record BookingStatusResponse(
         ReservationThemeResponse theme,
         BookingType bookingType,
         ReservationStatus reservationStatus,
-        Long turn
+        Long turn,
+        BookingPaymentResponse payment
 ) {
 
     public static BookingStatusResponse from(BookingStatus bookingStatus) {
@@ -25,7 +26,8 @@ public record BookingStatusResponse(
                 ReservationThemeResponse.from(bookingStatus.theme()),
                 bookingStatus.bookingType(),
                 bookingStatus.reservationStatus(),
-                bookingStatus.turn()
+                bookingStatus.turn(),
+                BookingPaymentResponse.from(bookingStatus.payment())
         );
     }
 }

--- a/src/main/java/roomescape/controller/view/PaymentSuccessController.java
+++ b/src/main/java/roomescape/controller/view/PaymentSuccessController.java
@@ -3,8 +3,10 @@ package roomescape.controller.view;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import roomescape.controller.view.dto.PaymentFailRequest;
 import roomescape.controller.view.dto.PaymentReservationView;
+import roomescape.controller.view.dto.PaymentSuccessRequest;
 import roomescape.domain.Reservation;
 import roomescape.service.payment.PaymentAmountMismatchException;
 import roomescape.service.payment.PaymentGatewayException;
@@ -22,44 +24,37 @@ public class PaymentSuccessController {
 
     @GetMapping("/payments/success")
     public String success(
-            @RequestParam String paymentKey,
-            @RequestParam String orderId,
-            @RequestParam Long amount,
-            @RequestParam(required = false) String name,
+            @ModelAttribute PaymentSuccessRequest request,
             Model model
     ) {
         try {
-            PaymentResult result = paymentService.confirm(paymentKey, orderId, amount);
+            PaymentResult result = paymentService.confirm(request.paymentKey(), request.orderId(), request.amount());
             model.addAttribute("result", result);
-            addReservationViewByOrderId(model, orderId);
-            model.addAttribute("name", name);
+            addReservationViewByOrderId(model, request.orderId());
+            model.addAttribute("name", request.name());
             return "payment-success";
         } catch (PaymentAmountMismatchException e) {
-            return failView(model, "AMOUNT_MISMATCH", e.getMessage(), orderId, name,
-                    paymentService.findReservationByOrderId(orderId));
+            return failView(model, "AMOUNT_MISMATCH", e.getMessage(), request.orderId(), request.name(),
+                    paymentService.findReservationByOrderId(request.orderId()));
         } catch (PaymentGatewayException e) {
-            return failView(model, e.getCode(), e.getMessage(), orderId, name,
-                    paymentService.findReservationByOrderId(orderId));
+            return failView(model, e.getCode(), e.getMessage(), request.orderId(), request.name(),
+                    paymentService.findReservationByOrderId(request.orderId()));
         }
     }
 
     @GetMapping("/payments/fail")
     public String fail(
-            @RequestParam(required = false) String code,
-            @RequestParam(required = false) String message,
-            @RequestParam(required = false) String orderId,
-            @RequestParam(required = false) Long paymentId,
-            @RequestParam(required = false) String name,
+            @ModelAttribute PaymentFailRequest request,
             Model model
     ) {
         Reservation reservation = null;
-        if (paymentId != null) {
-            paymentService.fail(paymentId, code, message);
-            reservation = paymentService.findReservationByPaymentId(paymentId);
-        } else if (orderId != null) {
-            reservation = paymentService.findReservationByOrderId(orderId);
+        if (request.paymentId() != null) {
+            paymentService.fail(request.paymentId(), request.code(), request.message());
+            reservation = paymentService.findReservationByPaymentId(request.paymentId());
+        } else if (request.orderId() != null) {
+            reservation = paymentService.findReservationByOrderId(request.orderId());
         }
-        return failView(model, code, message, orderId, name, reservation);
+        return failView(model, request.code(), request.message(), request.orderId(), request.name(), reservation);
     }
 
     private void addReservationViewByOrderId(Model model, String orderId) {

--- a/src/main/java/roomescape/controller/view/PaymentSuccessController.java
+++ b/src/main/java/roomescape/controller/view/PaymentSuccessController.java
@@ -16,6 +16,8 @@ import roomescape.service.PaymentService;
 @Controller
 public class PaymentSuccessController {
 
+    private static final String PAYMENT_CONFIRMATION_UNKNOWN = "PAYMENT_CONFIRMATION_UNKNOWN";
+
     private final PaymentService paymentService;
 
     public PaymentSuccessController(PaymentService paymentService) {
@@ -68,6 +70,7 @@ public class PaymentSuccessController {
         model.addAttribute("message", message);
         model.addAttribute("orderId", orderId);
         model.addAttribute("name", name);
+        model.addAttribute("confirmationUnknown", PAYMENT_CONFIRMATION_UNKNOWN.equals(code));
         if (reservation != null) {
             model.addAttribute("reservation", PaymentReservationView.from(reservation));
         }

--- a/src/main/java/roomescape/controller/view/dto/PaymentFailRequest.java
+++ b/src/main/java/roomescape/controller/view/dto/PaymentFailRequest.java
@@ -1,0 +1,10 @@
+package roomescape.controller.view.dto;
+
+public record PaymentFailRequest(
+        String code,
+        String message,
+        String orderId,
+        Long paymentId,
+        String name
+) {
+}

--- a/src/main/java/roomescape/controller/view/dto/PaymentSuccessRequest.java
+++ b/src/main/java/roomescape/controller/view/dto/PaymentSuccessRequest.java
@@ -1,0 +1,9 @@
+package roomescape.controller.view.dto;
+
+public record PaymentSuccessRequest(
+        String paymentKey,
+        String orderId,
+        Long amount,
+        String name
+) {
+}

--- a/src/main/java/roomescape/domain/Payment.java
+++ b/src/main/java/roomescape/domain/Payment.java
@@ -13,12 +13,13 @@ public class Payment {
     private final String failureCode;
     private final String failureMessage;
 
-    public Payment(Long id, Long reservationId, String orderId, Long amount, String paymentKey,
-                   PaymentStatus status, String failureCode, String failureMessage) {
+    private Payment(Long id, Long reservationId, String orderId, Long amount, String paymentKey,
+                    PaymentStatus status, String failureCode, String failureMessage) {
         validateReservationId(reservationId);
         validateOrderId(orderId);
         validateAmount(amount);
         validateStatus(status);
+        validateStatusFields(status, paymentKey, failureCode);
 
         this.id = id;
         this.reservationId = reservationId;
@@ -34,7 +35,14 @@ public class Payment {
         return new Payment(null, reservationId, generateOrderId(), amount, null, PaymentStatus.READY, null, null);
     }
 
+    public static Payment restore(Long id, Long reservationId, String orderId, Long amount, String paymentKey,
+                                  PaymentStatus status, String failureCode, String failureMessage) {
+        validateId(id);
+        return new Payment(id, reservationId, orderId, amount, paymentKey, status, failureCode, failureMessage);
+    }
+
     public Payment withId(Long id) {
+        validateId(id);
         return new Payment(id, reservationId, orderId, amount, paymentKey, status, failureCode, failureMessage);
     }
 
@@ -96,6 +104,12 @@ public class Payment {
         return "payment_" + UUID.randomUUID().toString().replace("-", "");
     }
 
+    private static void validateId(Long id) {
+        if (id == null || id <= 0) {
+            throw new IllegalArgumentException("id는 양수여야 합니다.");
+        }
+    }
+
     private void validateReservationId(Long reservationId) {
         if (reservationId == null || reservationId <= 0) {
             throw new IllegalArgumentException("reservationId는 양수여야 합니다.");
@@ -117,6 +131,19 @@ public class Payment {
     private void validateStatus(PaymentStatus status) {
         if (status == null) {
             throw new IllegalArgumentException("status는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private void validateStatusFields(PaymentStatus status, String paymentKey, String failureCode) {
+        if (status == PaymentStatus.READY && (paymentKey != null || failureCode != null)) {
+            throw new IllegalArgumentException("결제 대기 상태는 paymentKey나 실패 코드를 가질 수 없습니다.");
+        }
+        if (status == PaymentStatus.CONFIRMED && (paymentKey == null || paymentKey.isBlank())) {
+            throw new IllegalArgumentException("승인된 결제는 paymentKey가 필요합니다.");
+        }
+        if ((status == PaymentStatus.FAILED || status == PaymentStatus.CANCELED)
+                && (failureCode == null || failureCode.isBlank())) {
+            throw new IllegalArgumentException("실패 또는 취소된 결제는 실패 코드가 필요합니다.");
         }
     }
 }

--- a/src/main/java/roomescape/domain/Payment.java
+++ b/src/main/java/roomescape/domain/Payment.java
@@ -47,19 +47,19 @@ public class Payment {
     }
 
     public Payment confirm(String paymentKey) {
-        if (status != PaymentStatus.READY) {
-            throw new IllegalStateException("결제 대기 상태에서만 승인할 수 있습니다.");
+        if (!canConfirm()) {
+            throw new IllegalStateException("결제 대기 또는 확인 필요 상태에서만 승인할 수 있습니다.");
         }
         if (paymentKey == null || paymentKey.isBlank()) {
             throw new IllegalArgumentException("paymentKey는 비어 있을 수 없습니다.");
         }
         return new Payment(id, reservationId, orderId, amount, paymentKey, PaymentStatus.CONFIRMED,
-                failureCode, failureMessage);
+                null, null);
     }
 
     public Payment fail(String failureCode, String failureMessage) {
-        if (status != PaymentStatus.READY) {
-            throw new IllegalStateException("결제 대기 상태에서만 실패 처리할 수 있습니다.");
+        if (!canConfirm()) {
+            throw new IllegalStateException("결제 대기 또는 확인 필요 상태에서만 실패 처리할 수 있습니다.");
         }
         PaymentStatus failedStatus = "PAY_PROCESS_CANCELED".equals(failureCode)
                 ? PaymentStatus.CANCELED
@@ -69,8 +69,8 @@ public class Payment {
     }
 
     public Payment checkRequired(String failureCode, String failureMessage) {
-        if (status != PaymentStatus.READY) {
-            throw new IllegalStateException("결제 대기 상태에서만 확인 필요 처리할 수 있습니다.");
+        if (!canConfirm()) {
+            throw new IllegalStateException("결제 대기 또는 확인 필요 상태에서만 확인 필요 처리할 수 있습니다.");
         }
         return new Payment(id, reservationId, orderId, amount, paymentKey, PaymentStatus.CHECK_REQUIRED,
                 failureCode, failureMessage);
@@ -154,5 +154,9 @@ public class Payment {
                 && (failureCode == null || failureCode.isBlank())) {
             throw new IllegalArgumentException("실패, 취소 또는 확인 필요 결제는 실패 코드가 필요합니다.");
         }
+    }
+
+    private boolean canConfirm() {
+        return status == PaymentStatus.READY || status == PaymentStatus.CHECK_REQUIRED;
     }
 }

--- a/src/main/java/roomescape/domain/Payment.java
+++ b/src/main/java/roomescape/domain/Payment.java
@@ -68,6 +68,14 @@ public class Payment {
                 failureCode, failureMessage);
     }
 
+    public Payment checkRequired(String failureCode, String failureMessage) {
+        if (status != PaymentStatus.READY) {
+            throw new IllegalStateException("결제 대기 상태에서만 확인 필요 처리할 수 있습니다.");
+        }
+        return new Payment(id, reservationId, orderId, amount, paymentKey, PaymentStatus.CHECK_REQUIRED,
+                failureCode, failureMessage);
+    }
+
     public Long getId() {
         return id;
     }
@@ -141,9 +149,10 @@ public class Payment {
         if (status == PaymentStatus.CONFIRMED && (paymentKey == null || paymentKey.isBlank())) {
             throw new IllegalArgumentException("승인된 결제는 paymentKey가 필요합니다.");
         }
-        if ((status == PaymentStatus.FAILED || status == PaymentStatus.CANCELED)
+        if ((status == PaymentStatus.FAILED || status == PaymentStatus.CANCELED
+                || status == PaymentStatus.CHECK_REQUIRED)
                 && (failureCode == null || failureCode.isBlank())) {
-            throw new IllegalArgumentException("실패 또는 취소된 결제는 실패 코드가 필요합니다.");
+            throw new IllegalArgumentException("실패, 취소 또는 확인 필요 결제는 실패 코드가 필요합니다.");
         }
     }
 }

--- a/src/main/java/roomescape/domain/PaymentStatus.java
+++ b/src/main/java/roomescape/domain/PaymentStatus.java
@@ -4,6 +4,7 @@ public enum PaymentStatus {
     READY,
     FAILED,
     CANCELED,
+    CHECK_REQUIRED,
     CONFIRMED;
 
     public static PaymentStatus fromTossStatus(String tossStatus) {

--- a/src/main/java/roomescape/payment/client/TossClientConfig.java
+++ b/src/main/java/roomescape/payment/client/TossClientConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -14,13 +15,20 @@ public class TossClientConfig {
     @Bean
     RestClient tossRestClient(
             @Value("${toss.base-url:https://api.tosspayments.com}") String baseUrl,
-            @Value("${toss.secret-key:}") String secretKey
+            @Value("${toss.secret-key:}") String secretKey,
+            @Value("${toss.connect-timeout-ms:1000}") int connectTimeoutMs,
+            @Value("${toss.read-timeout-ms:2000}") int readTimeoutMs
     ) {
         String encodedCredentials = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeoutMs);
+        requestFactory.setReadTimeout(readTimeoutMs);
+
         return RestClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials)
+                .requestFactory(requestFactory)
                 .build();
     }
 }

--- a/src/main/java/roomescape/payment/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentGateway.java
@@ -5,9 +5,12 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import roomescape.domain.PaymentStatus;
 import roomescape.service.payment.PaymentConfirmation;
+import roomescape.service.payment.PaymentFailureCategory;
 import roomescape.service.payment.PaymentGateway;
+import roomescape.service.payment.PaymentGatewayException;
 import roomescape.service.payment.PaymentResult;
 import roomescape.payment.client.dto.ConfirmRequest;
 import roomescape.payment.client.dto.TossErrorResponse;
@@ -28,16 +31,27 @@ public class TossPaymentGateway implements PaymentGateway {
     public PaymentResult confirm(PaymentConfirmation confirmation) {
         ConfirmRequest request = new ConfirmRequest(
                 confirmation.paymentKey(), confirmation.orderId(), confirmation.amount());
-        TossPaymentResponse response = tossRestClient.post()
-                .uri("/v1/payments/confirm")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (requestHeaders, clientResponse) -> {
-                    TossErrorResponse error = objectMapper.readValue(clientResponse.getBody(), TossErrorResponse.class);
-                    throw TossPaymentException.of(clientResponse.getStatusCode(), error);
-                })
-                .body(TossPaymentResponse.class);
+        TossPaymentResponse response;
+        try {
+            response = tossRestClient.post()
+                    .uri("/v1/payments/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (requestHeaders, clientResponse) -> {
+                        TossErrorResponse error = objectMapper.readValue(clientResponse.getBody(), TossErrorResponse.class);
+                        throw TossPaymentException.of(clientResponse.getStatusCode(), error);
+                    })
+                    .body(TossPaymentResponse.class);
+        } catch (TossPaymentException e) {
+            throw e;
+        } catch (RestClientException e) {
+            throw new PaymentGatewayException(
+                    PaymentFailureCategory.CONFIRMATION_UNKNOWN,
+                    "PAYMENT_CONFIRMATION_UNKNOWN",
+                    "결제 승인 결과를 확인할 수 없습니다."
+            );
+        }
         return new PaymentResult(
                 response.paymentKey(),
                 response.orderId(),

--- a/src/main/java/roomescape/payment/client/TossPaymentGateway.java
+++ b/src/main/java/roomescape/payment/client/TossPaymentGateway.java
@@ -36,6 +36,7 @@ public class TossPaymentGateway implements PaymentGateway {
             response = tossRestClient.post()
                     .uri("/v1/payments/confirm")
                     .contentType(MediaType.APPLICATION_JSON)
+                    .header("Idempotency-Key", confirmation.orderId())
                     .body(request)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, (requestHeaders, clientResponse) -> {

--- a/src/main/java/roomescape/repository/PaymentRepository.java
+++ b/src/main/java/roomescape/repository/PaymentRepository.java
@@ -15,7 +15,7 @@ public class PaymentRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    private final RowMapper<Payment> paymentRowMapper = (resultSet, rowNum) -> new Payment(
+    private final RowMapper<Payment> paymentRowMapper = (resultSet, rowNum) -> Payment.restore(
             resultSet.getLong("id"),
             resultSet.getLong("reservation_id"),
             resultSet.getString("order_id"),

--- a/src/main/java/roomescape/service/BookingLookupService.java
+++ b/src/main/java/roomescape/service/BookingLookupService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
+import roomescape.repository.PaymentRepository;
 import roomescape.service.dto.BookingStatus;
 
 @Service
@@ -16,17 +17,23 @@ import roomescape.service.dto.BookingStatus;
 public class BookingLookupService {
     private final ReservationService reservationService;
     private final ReservationWaitingService reservationWaitingService;
+    private final PaymentRepository paymentRepository;
 
     public BookingLookupService(ReservationService reservationService,
-                                ReservationWaitingService reservationWaitingService) {
+                                ReservationWaitingService reservationWaitingService,
+                                PaymentRepository paymentRepository) {
         this.reservationService = reservationService;
         this.reservationWaitingService = reservationWaitingService;
+        this.paymentRepository = paymentRepository;
     }
 
     public List<BookingStatus> findByName(String name) {
         return Stream.concat(
                         reservationService.findByName(name).stream()
-                                .map(BookingStatus::reservation),
+                                .map(reservation -> BookingStatus.reservation(
+                                        reservation,
+                                        paymentRepository.findLatestByReservationId(reservation.getId()).orElse(null)
+                                )),
                         reservationWaitingService.findByName(name).stream()
                                 .map(BookingStatus::waiting))
                 .sorted(Comparator
@@ -41,7 +48,10 @@ public class BookingLookupService {
         }
         return Stream.concat(
                         reservationService.findByDateRange(startDate, endDate).stream()
-                                .map(BookingStatus::reservation),
+                                .map(reservation -> BookingStatus.reservation(
+                                        reservation,
+                                        paymentRepository.findLatestByReservationId(reservation.getId()).orElse(null)
+                                )),
                         reservationWaitingService.findByDateRange(startDate, endDate).stream()
                                 .map(BookingStatus::waiting))
                 .sorted(Comparator

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -78,6 +78,9 @@ public class PaymentService {
             if (e.isDefinitiveFailure()) {
                 paymentRepository.update(payment.fail(e.getCode(), e.getMessage()));
             }
+            if (e.requiresConfirmationCheck()) {
+                paymentRepository.update(payment.checkRequired(e.getCode(), e.getMessage()));
+            }
             throw e;
         }
         if (result.status() != PaymentStatus.CONFIRMED) {

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -66,9 +66,9 @@ public class PaymentService {
         if (!payment.getAmount().equals(amount)) {
             throw new PaymentAmountMismatchException(payment.getAmount(), amount);
         }
-        if (payment.getStatus() != PaymentStatus.READY) {
+        if (!canConfirm(payment)) {
             throw new RoomescapeException(ErrorCode.PAYMENT_CONFIRMATION_NOT_ALLOWED,
-                    "결제 대기 상태의 결제만 승인할 수 있습니다.");
+                    "결제 대기 또는 확인 필요 상태의 결제만 승인할 수 있습니다.");
         }
 
         PaymentResult result;
@@ -110,5 +110,9 @@ public class PaymentService {
         }
         throw new RoomescapeException(ErrorCode.PAYMENT_RETRY_NOT_ALLOWED,
                 "결제를 다시 시도할 수 없는 상태입니다.");
+    }
+
+    private boolean canConfirm(Payment payment) {
+        return payment.getStatus() == PaymentStatus.READY || payment.getStatus() == PaymentStatus.CHECK_REQUIRED;
     }
 }

--- a/src/main/java/roomescape/service/dto/BookingPaymentInfo.java
+++ b/src/main/java/roomescape/service/dto/BookingPaymentInfo.java
@@ -1,0 +1,28 @@
+package roomescape.service.dto;
+
+import roomescape.domain.Payment;
+import roomescape.domain.PaymentStatus;
+
+public record BookingPaymentInfo(
+        String orderId,
+        Long amount,
+        String paymentKey,
+        PaymentStatus status,
+        String failureCode,
+        String failureMessage
+) {
+
+    public static BookingPaymentInfo from(Payment payment) {
+        if (payment == null) {
+            return null;
+        }
+        return new BookingPaymentInfo(
+                payment.getOrderId(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getStatus(),
+                payment.getFailureCode(),
+                payment.getFailureMessage()
+        );
+    }
+}

--- a/src/main/java/roomescape/service/dto/BookingStatus.java
+++ b/src/main/java/roomescape/service/dto/BookingStatus.java
@@ -1,6 +1,7 @@
 package roomescape.service.dto;
 
 import java.time.LocalDate;
+import roomescape.domain.Payment;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationSlot;
 import roomescape.domain.ReservationStatus;
@@ -17,9 +18,19 @@ public record BookingStatus(
         Theme theme,
         BookingType bookingType,
         ReservationStatus reservationStatus,
-        Long turn
+        Long turn,
+        BookingPaymentInfo payment
 ) {
+    public BookingStatus(Long id, String name, LocalDate date, ReservationTime time, Theme theme,
+                         BookingType bookingType, ReservationStatus reservationStatus, Long turn) {
+        this(id, name, date, time, theme, bookingType, reservationStatus, turn, null);
+    }
+
     public static BookingStatus reservation(Reservation reservation) {
+        return reservation(reservation, null);
+    }
+
+    public static BookingStatus reservation(Reservation reservation, Payment payment) {
         ReservationSlot slot = reservation.getSlot();
         return new BookingStatus(
                 reservation.getId(),
@@ -29,7 +40,8 @@ public record BookingStatus(
                 slot.getTheme(),
                 BookingType.RESERVATION,
                 reservation.getStatus(),
-                null
+                null,
+                BookingPaymentInfo.from(payment)
         );
     }
 
@@ -44,7 +56,8 @@ public record BookingStatus(
                 slot.getTheme(),
                 BookingType.WAITING,
                 null,
-                waitingWithTurn.turn()
+                waitingWithTurn.turn(),
+                null
         );
     }
 }

--- a/src/main/java/roomescape/service/payment/PaymentFailureCategory.java
+++ b/src/main/java/roomescape/service/payment/PaymentFailureCategory.java
@@ -3,5 +3,6 @@ package roomescape.service.payment;
 public enum PaymentFailureCategory {
     DEFINITIVE,
     UNKNOWN,
+    CONFIRMATION_UNKNOWN,
     CONFIGURATION
 }

--- a/src/main/java/roomescape/service/payment/PaymentGatewayException.java
+++ b/src/main/java/roomescape/service/payment/PaymentGatewayException.java
@@ -22,4 +22,8 @@ public class PaymentGatewayException extends RuntimeException {
     public boolean isDefinitiveFailure() {
         return failureCategory == PaymentFailureCategory.DEFINITIVE;
     }
+
+    public boolean requiresConfirmationCheck() {
+        return failureCategory == PaymentFailureCategory.CONFIRMATION_UNKNOWN;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,5 @@ spring.h2.console.path=/h2-console
 toss.base-url=https://api.tosspayments.com
 toss.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 toss.secret-key=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+toss.connect-timeout-ms=1000
+toss.read-timeout-ms=2000

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -86,6 +86,10 @@ main {
     padding: 3rem 2rem 6rem;
 }
 
+body.my-page main {
+    max-width: 1120px;
+}
+
 /* 스텝 인디케이터 */
 .steps {
     display: flex;
@@ -791,7 +795,7 @@ button:disabled {
 .table-wrap {
     border: 1px solid var(--border);
     border-radius: 8px;
-    overflow: hidden;
+    overflow-x: auto;
     background: var(--surface);
 }
 
@@ -834,6 +838,26 @@ tbody tr.editing,
 tbody tr.edit-row,
 tbody tr.edit-row:hover {
     background: rgba(200,169,110,0.04);
+}
+
+body.my-page th,
+body.my-page td {
+    white-space: nowrap;
+}
+
+body.my-page td:nth-child(4) {
+    min-width: 140px;
+    white-space: normal;
+}
+
+body.my-page tr.edit-row td,
+body.my-page tr.detail-row td {
+    white-space: normal;
+}
+
+tbody tr.detail-row,
+tbody tr.detail-row:hover {
+    background: rgba(200,169,110,0.035);
 }
 
 .sort-indicator {
@@ -944,6 +968,70 @@ tbody tr.edit-row:hover {
 
 .edit-time-grid {
     min-height: 42px;
+}
+
+.booking-detail-panel {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    padding: 1.1rem 1.2rem;
+}
+
+.booking-detail-title {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    color: var(--text-primary);
+    font-weight: 500;
+    margin-bottom: 1rem;
+}
+
+.booking-detail-title span {
+    color: var(--accent);
+    font-size: 0.82rem;
+    font-weight: 400;
+}
+
+.booking-detail-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.75fr) minmax(320px, 1.25fr);
+    gap: 1.25rem;
+}
+
+.booking-detail-section h3 {
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 0.65rem;
+}
+
+.booking-detail-section dl {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.booking-detail-section dl > div {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: start;
+}
+
+.booking-detail-section dt {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+}
+
+.booking-detail-section dd {
+    color: var(--text-primary);
+    font-size: 0.86rem;
+}
+
+.booking-detail-section .code-value {
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .edit-actions {
@@ -1267,6 +1355,15 @@ body.payment-result-fail {
     }
     .edit-grid {
         grid-template-columns: 1fr;
+    }
+    .booking-detail-grid,
+    .booking-detail-title {
+        grid-template-columns: 1fr;
+        flex-direction: column;
+    }
+    .booking-detail-section dl > div {
+        grid-template-columns: 1fr;
+        gap: 0.2rem;
     }
     .edit-actions {
         justify-content: stretch;

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -897,6 +897,12 @@ tbody tr.edit-row:hover {
     background: var(--accent-dim);
 }
 
+.status-badge.failed {
+    border-color: rgba(213,108,91,0.45);
+    color: var(--danger);
+    background: rgba(213,108,91,0.08);
+}
+
 .action-buttons {
     display: flex;
     justify-content: flex-end;

--- a/src/main/resources/templates/my-reservation.html
+++ b/src/main/resources/templates/my-reservation.html
@@ -184,28 +184,64 @@
     function renderDetailRow(reservation) {
         const payment = reservation.payment;
         return `
-            <tr class="edit-row">
+            <tr class="detail-row">
                 <td colspan="8">
-                    <div class="edit-panel">
-                        <div class="edit-current">
-                            상세 정보: ${reservation.date} ${formatTime(reservation.time?.startAt)} · ${escapeHtml(reservation.theme?.name || '')}
+                    <div class="booking-detail-panel">
+                        <div class="booking-detail-title">
+                            ${escapeHtml(reservation.theme?.name || '')}
+                            <span>${reservation.date} ${formatTime(reservation.time?.startAt)}</span>
                         </div>
-                        <div class="edit-grid">
-                            <div class="edit-field">
-                                <span>예약 정보</span>
-                                <div>${escapeHtml(reservation.name || '')}</div>
-                                <div>${escapeHtml(reservation.theme?.name || '')}</div>
-                                <div>${reservation.date} ${formatTime(reservation.time?.startAt)}</div>
+                        <div class="booking-detail-grid">
+                            <div class="booking-detail-section">
+                                <h3>예약 정보</h3>
+                                <dl>
+                                    <div>
+                                        <dt>예약자</dt>
+                                        <dd>${escapeHtml(reservation.name || '')}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>테마</dt>
+                                        <dd>${escapeHtml(reservation.theme?.name || '')}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>예약 일시</dt>
+                                        <dd>${reservation.date} ${formatTime(reservation.time?.startAt)}</dd>
+                                    </div>
+                                </dl>
                             </div>
-                            <div class="edit-field">
-                                <span>결제 정보</span>
+                            <div class="booking-detail-section">
+                                <h3>결제 정보</h3>
                                 ${payment ? `
-                                    <div>상태: ${getPaymentStatusLabel(payment.status)}</div>
-                                    <div>주문번호: ${escapeHtml(payment.orderId || '-')}</div>
-                                    <div>승인키: ${escapeHtml(payment.paymentKey || '-')}</div>
-                                    <div>금액: ${formatAmount(payment.amount)}</div>
-                                    ${payment.failureCode ? `<div>실패 코드: ${escapeHtml(payment.failureCode)}</div>` : ''}
-                                    ${payment.failureMessage ? `<div>사유: ${escapeHtml(payment.failureMessage)}</div>` : ''}
+                                    <dl>
+                                        <div>
+                                            <dt>상태</dt>
+                                            <dd>${getPaymentStatusLabel(payment.status)}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>주문번호</dt>
+                                            <dd class="code-value">${escapeHtml(payment.orderId || '-')}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>승인키</dt>
+                                            <dd class="code-value">${escapeHtml(payment.paymentKey || '-')}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>금액</dt>
+                                            <dd>${formatAmount(payment.amount)}</dd>
+                                        </div>
+                                        ${payment.failureCode ? `
+                                            <div>
+                                                <dt>실패 코드</dt>
+                                                <dd class="code-value">${escapeHtml(payment.failureCode)}</dd>
+                                            </div>
+                                        ` : ''}
+                                        ${payment.failureMessage ? `
+                                            <div>
+                                                <dt>사유</dt>
+                                                <dd>${escapeHtml(payment.failureMessage)}</dd>
+                                            </div>
+                                        ` : ''}
+                                    </dl>
                                 ` : '<div class="muted">결제 정보가 없습니다.</div>'}
                             </div>
                         </div>
@@ -480,7 +516,6 @@
         return `
             ${detailButton}
             <button type="button" class="btn-text" onclick="openEditForm(${reservation.id}, 'RESERVATION')">변경</button>
-            <span class="muted">결제 취소 기능 준비 중</span>
         `;
     }
 

--- a/src/main/resources/templates/my-reservation.html
+++ b/src/main/resources/templates/my-reservation.html
@@ -40,13 +40,14 @@
                 <th data-sort="time">시간<span class="sort-indicator"></span></th>
                 <th data-sort="theme">테마<span class="sort-indicator"></span></th>
                 <th data-sort="status">상태<span class="sort-indicator"></span></th>
+                <th data-sort="payment">결제 상태<span class="sort-indicator"></span></th>
                 <th data-sort="turn">대기 순번<span class="sort-indicator"></span></th>
                 <th class="right">관리</th>
             </tr>
             </thead>
             <tbody id="reservation-body">
             <tr>
-                <td colspan="7" class="empty">조회된 예약이 없습니다</td>
+                <td colspan="8" class="empty">조회된 예약이 없습니다</td>
             </tr>
             </tbody>
         </table>
@@ -64,6 +65,7 @@
     let editingReservationId = null;
     let editingTimeId = null;
     let editingTimes = null;
+    let detailBookingKey = null;
 
     window.onload = () => {
         nameInput.addEventListener('keydown', event => {
@@ -94,7 +96,7 @@
         }
 
         resultMeta.textContent = '예약·대기 목록을 불러오는 중입니다.';
-        reservationBody.innerHTML = `<tr><td colspan="7" class="empty">조회 중입니다</td></tr>`;
+        reservationBody.innerHTML = `<tr><td colspan="8" class="empty">조회 중입니다</td></tr>`;
 
         fetch(`/bookings?name=${encodeURIComponent(name)}`)
             .then(handleResponse)
@@ -103,6 +105,7 @@
                 editingReservationId = null;
                 editingTimeId = null;
                 editingTimes = null;
+                detailBookingKey = null;
                 renderReservations(name, reservations);
             })
             .catch(showError);
@@ -113,7 +116,7 @@
         const sortedRows = [...rows].sort(compareReservation);
         resultMeta.textContent = `${name}님의 예약·대기 ${rows.length}건`;
         if (sortedRows.length === 0) {
-            reservationBody.innerHTML = `<tr><td colspan="7" class="empty">조회된 예약이 없습니다</td></tr>`;
+            reservationBody.innerHTML = `<tr><td colspan="8" class="empty">조회된 예약이 없습니다</td></tr>`;
             return;
         }
 
@@ -130,6 +133,7 @@
                 <td class="accent">${formatTime(reservation.time?.startAt)}</td>
                 <td class="theme-name">${escapeHtml(reservation.theme?.name || '')}</td>
                 <td>${renderStatusBadge(reservation)}</td>
+                <td>${renderPaymentStatusBadge(reservation)}</td>
                 <td>${waiting ? `${reservation.turn}번째` : '-'}</td>
                 <td class="right">
                     <div class="action-buttons">
@@ -140,6 +144,9 @@
             if (editing) {
                 row += renderEditRow(reservation);
             }
+            if (isDetailOpen(reservation)) {
+                row += renderDetailRow(reservation);
+            }
             return row;
         }).join('');
     }
@@ -147,7 +154,7 @@
     function renderEditRow(reservation) {
         return `
             <tr class="edit-row">
-                <td colspan="7">
+                <td colspan="8">
                     <div class="edit-panel">
                         <div class="edit-current">
                             현재 예약: ${reservation.date} ${formatTime(reservation.time?.startAt)} · ${escapeHtml(reservation.theme?.name || '')}
@@ -167,6 +174,40 @@
                         <div class="edit-actions">
                             <button type="button" onclick="updateReservation(${reservation.id})">변경하기</button>
                             <button type="button" class="btn-secondary" onclick="closeEditForm()">닫기</button>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        `;
+    }
+
+    function renderDetailRow(reservation) {
+        const payment = reservation.payment;
+        return `
+            <tr class="edit-row">
+                <td colspan="8">
+                    <div class="edit-panel">
+                        <div class="edit-current">
+                            상세 정보: ${reservation.date} ${formatTime(reservation.time?.startAt)} · ${escapeHtml(reservation.theme?.name || '')}
+                        </div>
+                        <div class="edit-grid">
+                            <div class="edit-field">
+                                <span>예약 정보</span>
+                                <div>${escapeHtml(reservation.name || '')}</div>
+                                <div>${escapeHtml(reservation.theme?.name || '')}</div>
+                                <div>${reservation.date} ${formatTime(reservation.time?.startAt)}</div>
+                            </div>
+                            <div class="edit-field">
+                                <span>결제 정보</span>
+                                ${payment ? `
+                                    <div>상태: ${getPaymentStatusLabel(payment.status)}</div>
+                                    <div>주문번호: ${escapeHtml(payment.orderId || '-')}</div>
+                                    <div>승인키: ${escapeHtml(payment.paymentKey || '-')}</div>
+                                    <div>금액: ${formatAmount(payment.amount)}</div>
+                                    ${payment.failureCode ? `<div>실패 코드: ${escapeHtml(payment.failureCode)}</div>` : ''}
+                                    ${payment.failureMessage ? `<div>사유: ${escapeHtml(payment.failureMessage)}</div>` : ''}
+                                ` : '<div class="muted">결제 정보가 없습니다.</div>'}
+                            </div>
                         </div>
                     </div>
                 </td>
@@ -360,6 +401,7 @@
             time: reservation.time?.startAt,
             theme: reservation.theme?.name,
             status: getStatusLabel(reservation),
+            payment: getPaymentStatusLabel(reservation.payment?.status),
             turn: reservation.turn ?? 0
         }[key] || '';
     }
@@ -394,17 +436,49 @@
         return value ? value.slice(0, 5) : '';
     }
 
+    function formatAmount(value) {
+        if (value === null || value === undefined) {
+            return '-';
+        }
+        return `${Number(value).toLocaleString('ko-KR')}원`;
+    }
+
+    function getBookingKey(reservation) {
+        return `${reservation.bookingType}-${reservation.id}`;
+    }
+
+    function isDetailOpen(reservation) {
+        return detailBookingKey === getBookingKey(reservation);
+    }
+
+    function toggleDetail(id, status) {
+        const reservation = findReservation(id, status);
+        if (!reservation) {
+            showToast('예약 정보를 찾을 수 없습니다', 'error');
+            return;
+        }
+        const key = getBookingKey(reservation);
+        detailBookingKey = detailBookingKey === key ? null : key;
+        renderReservations(nameInput.value.trim(), reservations);
+    }
+
     function renderActions(reservation, waiting, pendingPayment) {
         if (waiting) {
             return `<button type="button" class="btn-text danger" onclick="cancelReservation(${reservation.id}, 'WAITING')">취소</button>`;
         }
+        const detailButton = `<button type="button" class="btn-text" onclick="toggleDetail(${reservation.id}, 'RESERVATION')">${isDetailOpen(reservation) ? '닫기' : '상세'}</button>`;
         if (pendingPayment) {
+            const retryButton = reservation.payment?.status === 'CHECK_REQUIRED'
+                ? ''
+                : `<button type="button" class="btn-text" onclick="retryPayment(${reservation.id})">결제하기</button>`;
             return `
-                <button type="button" class="btn-text" onclick="retryPayment(${reservation.id})">결제하기</button>
+                ${detailButton}
+                ${retryButton}
                 <button type="button" class="btn-text danger" onclick="cancelReservation(${reservation.id}, 'RESERVATION')">취소</button>
             `;
         }
         return `
+            ${detailButton}
             <button type="button" class="btn-text" onclick="openEditForm(${reservation.id}, 'RESERVATION')">변경</button>
             <span class="muted">결제 취소 기능 준비 중</span>
         `;
@@ -432,11 +506,36 @@
         return '<span class="status-badge reserved">예약 확정</span>';
     }
 
+    function renderPaymentStatusBadge(reservation) {
+        if (reservation.bookingType === 'WAITING') {
+            return '<span class="muted">-</span>';
+        }
+        const status = reservation.payment?.status;
+        const label = getPaymentStatusLabel(status);
+        if (status === 'CONFIRMED') {
+            return `<span class="status-badge reserved">${label}</span>`;
+        }
+        if (status === 'FAILED' || status === 'CANCELED') {
+            return `<span class="status-badge failed">${label}</span>`;
+        }
+        return `<span class="status-badge waiting">${label}</span>`;
+    }
+
     function getStatusLabel(reservation) {
         if (reservation.bookingType === 'WAITING') {
             return '대기';
         }
         return reservation.reservationStatus === 'PENDING' ? '결제 대기' : '예약 확정';
+    }
+
+    function getPaymentStatusLabel(status) {
+        return {
+            READY: '결제 대기',
+            CONFIRMED: '결제 완료',
+            FAILED: '결제 실패',
+            CANCELED: '결제 취소',
+            CHECK_REQUIRED: '확인 필요'
+        }[status] || '-';
     }
 
     function escapeHtml(value) {
@@ -476,7 +575,7 @@
 
     function showError(error) {
         resultMeta.textContent = '예약·대기 목록을 불러오지 못했습니다.';
-        reservationBody.innerHTML = `<tr><td colspan="7" class="empty">조회된 예약이 없습니다</td></tr>`;
+        reservationBody.innerHTML = `<tr><td colspan="8" class="empty">조회된 예약이 없습니다</td></tr>`;
         showToast(error.message, 'error');
     }
 

--- a/src/main/resources/templates/payment-fail.html
+++ b/src/main/resources/templates/payment-fail.html
@@ -15,10 +15,13 @@
 
 <main class="payment-result-main">
     <section class="payment-result-card" aria-labelledby="payment-result-title">
-        <p class="payment-result-eyebrow">PAYMENT NOT COMPLETED</p>
+        <p class="payment-result-eyebrow"
+           th:text="${confirmationUnknown} ? 'PAYMENT CHECK REQUIRED' : 'PAYMENT NOT COMPLETED'">PAYMENT NOT COMPLETED</p>
         <div class="payment-result-symbol" aria-hidden="true">!</div>
-        <h1 id="payment-result-title">결제를 완료하지 못했어요</h1>
-        <p class="payment-result-description">예약은 결제 대기 상태로 유지됩니다. 내 예약에서 다시 결제하거나 취소할 수 있어요.</p>
+        <h1 id="payment-result-title"
+            th:text="${confirmationUnknown} ? '결제 승인 결과 확인이 필요해요' : '결제를 완료하지 못했어요'">결제를 완료하지 못했어요</h1>
+        <p class="payment-result-description"
+           th:text="${confirmationUnknown} ? '결제 요청 결과를 바로 확인하지 못했습니다. 내 예약에서 상태를 확인하거나 다시 시도해주세요.' : '예약은 결제 대기 상태로 유지됩니다. 내 예약에서 다시 결제하거나 취소할 수 있어요.'">예약은 결제 대기 상태로 유지됩니다. 내 예약에서 다시 결제하거나 취소할 수 있어요.</p>
 
         <div th:if="${reservation != null}">
             <h2 class="payment-result-detail-title">예약 정보</h2>
@@ -38,7 +41,8 @@
             </dl>
         </div>
 
-        <h2 class="payment-result-detail-title payment-result-failure-title">결제 실패 정보</h2>
+        <h2 class="payment-result-detail-title payment-result-failure-title"
+            th:text="${confirmationUnknown} ? '결제 확인 필요 정보' : '결제 실패 정보'">결제 실패 정보</h2>
         <dl class="payment-result-details">
             <div>
                 <dt>에러 코드</dt>

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -355,7 +355,11 @@ public class MissionStepTest {
                 .body("reservationId", is(1))
                 .body("paymentId", is(1));
 
-        jdbcTemplate.update("UPDATE payment SET status = 'FAILED' WHERE id = 1;");
+        jdbcTemplate.update("""
+                UPDATE payment
+                SET status = 'FAILED', failure_code = 'REJECT_CARD_PAYMENT', failure_message = '카드가 거절되었습니다.'
+                WHERE id = 1;
+                """);
 
         RestAssured.given().log().all()
                 .queryParam("name", "브라운")

--- a/src/test/java/roomescape/controller/admin/AdminBookingControllerTest.java
+++ b/src/test/java/roomescape/controller/admin/AdminBookingControllerTest.java
@@ -55,9 +55,11 @@ class AdminBookingControllerTest {
                 .andExpect(jsonPath("$[0].bookingType").value("RESERVATION"))
                 .andExpect(jsonPath("$[0].reservationStatus").value("CONFIRMED"))
                 .andExpect(jsonPath("$[0].turn").value(nullValue()))
+                .andExpect(jsonPath("$[0].payment").value(nullValue()))
                 .andExpect(jsonPath("$[1].id").value(2))
                 .andExpect(jsonPath("$[1].bookingType").value("WAITING"))
                 .andExpect(jsonPath("$[1].reservationStatus").value(nullValue()))
+                .andExpect(jsonPath("$[1].payment").value(nullValue()))
                 .andExpect(jsonPath("$[1].turn").value(1));
 
         verify(bookingLookupService, times(1)).findByDateRange(startDate, endDate);

--- a/src/test/java/roomescape/controller/user/BookingControllerTest.java
+++ b/src/test/java/roomescape/controller/user/BookingControllerTest.java
@@ -20,8 +20,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import roomescape.domain.ReservationTime;
 import roomescape.domain.ReservationStatus;
+import roomescape.domain.PaymentStatus;
 import roomescape.domain.Theme;
 import roomescape.service.BookingLookupService;
+import roomescape.service.dto.BookingPaymentInfo;
 import roomescape.service.dto.BookingStatus;
 import roomescape.service.dto.BookingType;
 
@@ -51,9 +53,14 @@ class BookingControllerTest {
                 .andExpect(jsonPath("$[0].bookingType").value("RESERVATION"))
                 .andExpect(jsonPath("$[0].reservationStatus").value("CONFIRMED"))
                 .andExpect(jsonPath("$[0].turn").value(nullValue()))
+                .andExpect(jsonPath("$[0].payment.orderId").value("payment_confirmed_123456789012345"))
+                .andExpect(jsonPath("$[0].payment.amount").value(20000))
+                .andExpect(jsonPath("$[0].payment.paymentKey").value("test_payment_key"))
+                .andExpect(jsonPath("$[0].payment.status").value("CONFIRMED"))
                 .andExpect(jsonPath("$[1].id").value(2))
                 .andExpect(jsonPath("$[1].bookingType").value("WAITING"))
                 .andExpect(jsonPath("$[1].reservationStatus").value(nullValue()))
+                .andExpect(jsonPath("$[1].payment").value(nullValue()))
                 .andExpect(jsonPath("$[1].turn").value(1));
 
         verify(bookingLookupService, times(1)).findByName("브라운");
@@ -74,7 +81,9 @@ class BookingControllerTest {
         ReservationTime time = new ReservationTime(1L, LocalTime.of(10, 0));
         Theme theme = new Theme(1L, "테마", "설명", "썸네일");
         return new BookingStatus(1L, "브라운", LocalDate.of(2099, 1, 1), time, theme,
-                BookingType.RESERVATION, ReservationStatus.CONFIRMED, null);
+                BookingType.RESERVATION, ReservationStatus.CONFIRMED, null,
+                new BookingPaymentInfo("payment_confirmed_123456789012345", 20_000L,
+                        "test_payment_key", PaymentStatus.CONFIRMED, null, null));
     }
 
     private BookingStatus waitingBooking() {

--- a/src/test/java/roomescape/controller/user/ReservationControllerTest.java
+++ b/src/test/java/roomescape/controller/user/ReservationControllerTest.java
@@ -315,7 +315,7 @@ class ReservationControllerTest {
     }
 
     private Payment payment() {
-        return new Payment(1L, 1L, "payment_12345678901234567890123456789012", 20_000L, null,
+        return Payment.restore(1L, 1L, "payment_12345678901234567890123456789012", 20_000L, null,
                 PaymentStatus.READY, null, null);
     }
 }

--- a/src/test/java/roomescape/controller/view/PaymentSuccessControllerTest.java
+++ b/src/test/java/roomescape/controller/view/PaymentSuccessControllerTest.java
@@ -114,7 +114,29 @@ class PaymentSuccessControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("payment-fail"))
                 .andExpect(model().attribute("code", "PAY_PROCESS_CANCELED"))
+                .andExpect(model().attribute("confirmationUnknown", false))
                 .andExpect(model().attribute("orderId", (Object) null));
+    }
+
+    @Test
+    void 결제_승인_결과를_알_수_없으면_확인_필요_상태로_렌더링한다() throws Exception {
+        String orderId = "payment_123456789012345678901";
+        given(paymentService.confirm("test_payment_key", orderId, 20_000L))
+                .willThrow(new PaymentGatewayException(
+                        PaymentFailureCategory.CONFIRMATION_UNKNOWN,
+                        "PAYMENT_CONFIRMATION_UNKNOWN",
+                        "결제 승인 결과를 확인할 수 없습니다."));
+        given(paymentService.findReservationByOrderId(orderId)).willReturn(reservation());
+
+        mockMvc.perform(get("/payments/success")
+                        .param("paymentKey", "test_payment_key")
+                        .param("orderId", orderId)
+                        .param("amount", "20000"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("payment-fail"))
+                .andExpect(model().attribute("code", "PAYMENT_CONFIRMATION_UNKNOWN"))
+                .andExpect(model().attribute("confirmationUnknown", true))
+                .andExpect(model().attribute("reservation", PaymentReservationView.from(reservation())));
     }
 
     private Reservation reservation() {

--- a/src/test/java/roomescape/domain/PaymentTest.java
+++ b/src/test/java/roomescape/domain/PaymentTest.java
@@ -50,4 +50,18 @@ class PaymentTest {
         assertThat(checkRequiredPayment.getStatus()).isEqualTo(PaymentStatus.CHECK_REQUIRED);
         assertThat(checkRequiredPayment.getFailureCode()).isEqualTo("PAYMENT_CONFIRMATION_UNKNOWN");
     }
+
+    @Test
+    void 결제_승인_결과_확인이_필요한_결제를_승인하면_실패_정보를_초기화한다() {
+        Payment payment = Payment.restore(1L, 1L, "payment_check_required_123456789", 20_000L,
+                null, PaymentStatus.CHECK_REQUIRED,
+                "PAYMENT_CONFIRMATION_UNKNOWN", "결제 승인 결과를 확인할 수 없습니다.");
+
+        Payment confirmedPayment = payment.confirm("test_payment_key");
+
+        assertThat(confirmedPayment.getStatus()).isEqualTo(PaymentStatus.CONFIRMED);
+        assertThat(confirmedPayment.getPaymentKey()).isEqualTo("test_payment_key");
+        assertThat(confirmedPayment.getFailureCode()).isNull();
+        assertThat(confirmedPayment.getFailureMessage()).isNull();
+    }
 }

--- a/src/test/java/roomescape/domain/PaymentTest.java
+++ b/src/test/java/roomescape/domain/PaymentTest.java
@@ -23,4 +23,20 @@ class PaymentTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("reservationId는 양수여야 합니다.");
     }
+
+    @Test
+    void 승인된_결제는_paymentKey가_필요하다() {
+        assertThatThrownBy(() -> Payment.restore(1L, 1L, "payment_confirmed_123456789012345", 20_000L,
+                null, PaymentStatus.CONFIRMED, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("승인된 결제는 paymentKey가 필요합니다.");
+    }
+
+    @Test
+    void 실패한_결제는_실패_코드가_필요하다() {
+        assertThatThrownBy(() -> Payment.restore(1L, 1L, "payment_failed_123456789012345678", 20_000L,
+                null, PaymentStatus.FAILED, null, "카드 거절"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("실패 또는 취소된 결제는 실패 코드가 필요합니다.");
+    }
 }

--- a/src/test/java/roomescape/domain/PaymentTest.java
+++ b/src/test/java/roomescape/domain/PaymentTest.java
@@ -37,6 +37,17 @@ class PaymentTest {
         assertThatThrownBy(() -> Payment.restore(1L, 1L, "payment_failed_123456789012345678", 20_000L,
                 null, PaymentStatus.FAILED, null, "카드 거절"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("실패 또는 취소된 결제는 실패 코드가 필요합니다.");
+                .hasMessage("실패, 취소 또는 확인 필요 결제는 실패 코드가 필요합니다.");
+    }
+
+    @Test
+    void 결제_승인_결과_확인이_필요한_상태로_변경한다() {
+        Payment payment = Payment.ready(1L, 20_000L);
+
+        Payment checkRequiredPayment = payment.checkRequired(
+                "PAYMENT_CONFIRMATION_UNKNOWN", "결제 승인 결과를 확인할 수 없습니다.");
+
+        assertThat(checkRequiredPayment.getStatus()).isEqualTo(PaymentStatus.CHECK_REQUIRED);
+        assertThat(checkRequiredPayment.getFailureCode()).isEqualTo("PAYMENT_CONFIRMATION_UNKNOWN");
     }
 }

--- a/src/test/java/roomescape/payment/client/TossClientConfigTest.java
+++ b/src/test/java/roomescape/payment/client/TossClientConfigTest.java
@@ -1,0 +1,45 @@
+package roomescape.payment.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClient;
+
+class TossClientConfigTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void 응답이_느리면_read_timeout으로_끊는다() {
+        server.enqueue(new MockResponse()
+                .setBody("slow response")
+                .setBodyDelay(1, TimeUnit.SECONDS));
+        RestClient restClient = new TossClientConfig()
+                .tossRestClient(server.url("/").toString(), "test_secret_key", 500, 100);
+
+        assertThatThrownBy(() -> restClient.get()
+                .uri("/")
+                .retrieve()
+                .body(String.class))
+                .isInstanceOf(RestClientException.class)
+                .hasRootCauseInstanceOf(SocketTimeoutException.class);
+    }
+}

--- a/src/test/java/roomescape/payment/client/TossPaymentGatewayTest.java
+++ b/src/test/java/roomescape/payment/client/TossPaymentGatewayTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.springframework.web.client.RestClient;
 import roomescape.domain.PaymentStatus;
 import roomescape.service.payment.PaymentConfirmation;
 import roomescape.service.payment.PaymentFailureCategory;
+import roomescape.service.payment.PaymentGatewayException;
 import roomescape.service.payment.PaymentResult;
 
 import java.util.stream.Stream;
@@ -64,6 +66,20 @@ class TossPaymentGatewayTest {
                 .contains("\"paymentKey\":\"test_payment_key\"")
                 .contains("\"orderId\":\"payment_123456789012345678901\"")
                 .contains("\"amount\":20000");
+    }
+
+    @Test
+    void 토스_통신_예외를_승인_결과_확인_필요_예외로_변환한다() {
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+        TossPaymentGateway gateway = new TossPaymentGateway(RestClient.builder()
+                .baseUrl(server.url("/").toString())
+                .build(), new ObjectMapper());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> gateway.confirm(new PaymentConfirmation(
+                        "test_payment_key", "payment_123456789012345678901", 20_000L)))
+                .isInstanceOf(PaymentGatewayException.class)
+                .hasFieldOrPropertyWithValue("code", "PAYMENT_CONFIRMATION_UNKNOWN")
+                .hasFieldOrPropertyWithValue("failureCategory", PaymentFailureCategory.CONFIRMATION_UNKNOWN);
     }
 
     @ParameterizedTest

--- a/src/test/java/roomescape/payment/client/TossPaymentGatewayTest.java
+++ b/src/test/java/roomescape/payment/client/TossPaymentGatewayTest.java
@@ -62,6 +62,7 @@ class TossPaymentGatewayTest {
         RecordedRequest request = server.takeRequest();
         assertThat(request.getMethod()).isEqualTo("POST");
         assertThat(request.getPath()).isEqualTo("/v1/payments/confirm");
+        assertThat(request.getHeader("Idempotency-Key")).isEqualTo("payment_123456789012345678901");
         assertThat(request.getBody().readUtf8())
                 .contains("\"paymentKey\":\"test_payment_key\"")
                 .contains("\"orderId\":\"payment_123456789012345678901\"")

--- a/src/test/java/roomescape/repository/PaymentRepositoryTest.java
+++ b/src/test/java/roomescape/repository/PaymentRepositoryTest.java
@@ -47,8 +47,7 @@ class PaymentRepositoryTest {
     @Test
     void 예약의_가장_최근_결제를_조회한다() {
         Long reservationId = createPendingReservation();
-        paymentRepository.insert(new Payment(null, reservationId, "payment_failed_12345678901234567890", 20_000L,
-                null, PaymentStatus.FAILED, "REJECT_CARD_PAYMENT", "카드 거절"));
+        paymentRepository.insert(Payment.ready(reservationId, 20_000L).fail("REJECT_CARD_PAYMENT", "카드 거절"));
         Payment latestPayment = paymentRepository.insert(Payment.ready(reservationId, 20_000L));
 
         assertThat(paymentRepository.findLatestByReservationId(reservationId).orElseThrow().getId())

--- a/src/test/java/roomescape/service/BookingLookupServiceTest.java
+++ b/src/test/java/roomescape/service/BookingLookupServiceTest.java
@@ -10,6 +10,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import roomescape.domain.Payment;
+import roomescape.domain.PaymentStatus;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationSlot;
 import roomescape.domain.ReservationStatus;
@@ -20,6 +22,7 @@ import roomescape.domain.Theme;
 import roomescape.domain.WaitingWithTurn;
 import roomescape.exception.ErrorCode;
 import roomescape.exception.RoomescapeException;
+import roomescape.repository.PaymentRepository;
 import roomescape.service.dto.BookingStatus;
 import roomescape.service.dto.BookingType;
 
@@ -27,9 +30,11 @@ class BookingLookupServiceTest {
 
     private final ReservationService reservationService = mock();
     private final ReservationWaitingService reservationWaitingService = mock();
+    private final PaymentRepository paymentRepository = mock();
     private final BookingLookupService service = new BookingLookupService(
             reservationService,
-            reservationWaitingService);
+            reservationWaitingService,
+            paymentRepository);
 
     private final LocalDate date = LocalDate.now().plusDays(1);
     private final ReservationTime time = new ReservationTime(1L, LocalTime.parse("10:00"));
@@ -45,6 +50,10 @@ class BookingLookupServiceTest {
 
         when(reservationService.findByName(name)).thenReturn(List.of(reservation));
         when(reservationWaitingService.findByName(name)).thenReturn(List.of(waiting));
+        when(paymentRepository.findLatestByReservationId(1L)).thenReturn(java.util.Optional.of(
+                Payment.restore(1L, 1L, "payment_ready_123456789012345678901", 20_000L, null,
+                        PaymentStatus.READY, null, null)
+        ));
 
         List<BookingStatus> result = service.findByName(name);
 
@@ -55,7 +64,10 @@ class BookingLookupServiceTest {
                         .containsExactly(BookingType.WAITING, BookingType.RESERVATION),
                 () -> assertThat(result).extracting(BookingStatus::reservationStatus)
                         .containsExactly(null, ReservationStatus.CONFIRMED),
-                () -> assertThat(result).extracting(BookingStatus::turn).containsExactly(1L, null));
+                () -> assertThat(result).extracting(BookingStatus::turn).containsExactly(1L, null),
+                () -> assertThat(result.get(1).payment().orderId()).isEqualTo("payment_ready_123456789012345678901"),
+                () -> assertThat(result.get(1).payment().status()).isEqualTo(PaymentStatus.READY),
+                () -> assertThat(result.get(0).payment()).isNull());
     }
 
     @Test

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -181,6 +181,27 @@ class PaymentServiceTest {
     }
 
     @Test
+    void 승인_결과를_알_수_없으면_확인_필요_상태로_저장한다() {
+        Payment payment = readyPayment();
+        PaymentConfirmation confirmation = new PaymentConfirmation("test_payment_key", payment.getOrderId(), 20_000L);
+        PaymentGatewayException exception = new PaymentGatewayException(
+                PaymentFailureCategory.CONFIRMATION_UNKNOWN,
+                "PAYMENT_CONFIRMATION_UNKNOWN",
+                "결제 승인 결과를 확인할 수 없습니다.");
+        when(paymentRepository.findByOrderId(payment.getOrderId())).thenReturn(Optional.of(payment));
+        when(paymentGateway.confirm(confirmation)).thenThrow(exception);
+
+        assertThatThrownBy(() -> paymentService.confirm("test_payment_key", payment.getOrderId(), 20_000L))
+                .isSameAs(exception);
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).update(paymentCaptor.capture());
+        assertThat(paymentCaptor.getValue().getStatus()).isEqualTo(PaymentStatus.CHECK_REQUIRED);
+        assertThat(paymentCaptor.getValue().getFailureCode()).isEqualTo("PAYMENT_CONFIRMATION_UNKNOWN");
+        verify(reservationService, never()).confirmPayment(any());
+    }
+
+    @Test
     void 결제_실패를_저장하고_결제_대기_예약은_유지한다() {
         Payment payment = readyPayment();
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -58,7 +58,7 @@ class PaymentServiceTest {
     void 실패한_결제_뒤에는_새_결제를_생성한다() {
         LocalDateTime now = LocalDateTime.of(2026, 6, 24, 12, 0);
         Reservation reservation = pendingReservation(1L, LocalDate.of(2099, 1, 1));
-        Payment failedPayment = new Payment(1L, 1L, "payment_failed_12345678901234567890", 20_000L, null,
+        Payment failedPayment = Payment.restore(1L, 1L, "payment_failed_12345678901234567890", 20_000L, null,
                 PaymentStatus.FAILED, "REJECT_CARD_PAYMENT", "카드가 거절되었습니다.");
         when(reservationService.findPendingByUser(1L, "브라운", now)).thenReturn(reservation);
         when(paymentRepository.findLatestByReservationId(1L)).thenReturn(Optional.of(failedPayment));
@@ -79,7 +79,7 @@ class PaymentServiceTest {
     void 준비된_결제가_있으면_기존_결제를_반환한다() {
         LocalDateTime now = LocalDateTime.of(2026, 6, 24, 12, 0);
         Reservation reservation = pendingReservation(1L, LocalDate.of(2099, 1, 1));
-        Payment readyPayment = new Payment(1L, 1L, "payment_ready_123456789012345678901", 20_000L, null,
+        Payment readyPayment = Payment.restore(1L, 1L, "payment_ready_123456789012345678901", 20_000L, null,
                 PaymentStatus.READY, null, null);
         when(reservationService.findPendingByUser(1L, "브라운", now)).thenReturn(reservation);
         when(paymentRepository.findLatestByReservationId(1L)).thenReturn(Optional.of(readyPayment));
@@ -214,7 +214,7 @@ class PaymentServiceTest {
     }
 
     private Payment readyPayment() {
-        return new Payment(1L, 1L, "payment_ready_123456789012345678901", 20_000L, null,
+        return Payment.restore(1L, 1L, "payment_ready_123456789012345678901", 20_000L, null,
                 PaymentStatus.READY, null, null);
     }
 }

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -146,6 +146,28 @@ class PaymentServiceTest {
     }
 
     @Test
+    void 확인_필요_상태의_결제도_같은_주문으로_승인을_재시도할_수_있다() {
+        Payment payment = Payment.restore(1L, 1L, "payment_check_required_123456789", 20_000L,
+                null, PaymentStatus.CHECK_REQUIRED,
+                "PAYMENT_CONFIRMATION_UNKNOWN", "결제 승인 결과를 확인할 수 없습니다.");
+        PaymentConfirmation confirmation = new PaymentConfirmation("test_payment_key", payment.getOrderId(), 20_000L);
+        PaymentResult result = new PaymentResult("test_payment_key", payment.getOrderId(), PaymentStatus.CONFIRMED, 20_000L);
+        when(paymentRepository.findByOrderId(payment.getOrderId())).thenReturn(Optional.of(payment));
+        when(paymentGateway.confirm(confirmation)).thenReturn(result);
+
+        PaymentResult actual = paymentService.confirm("test_payment_key", payment.getOrderId(), 20_000L);
+
+        assertThat(actual).isEqualTo(result);
+        verify(paymentGateway).confirm(confirmation);
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).update(paymentCaptor.capture());
+        assertThat(paymentCaptor.getValue().getStatus()).isEqualTo(PaymentStatus.CONFIRMED);
+        assertThat(paymentCaptor.getValue().getPaymentKey()).isEqualTo("test_payment_key");
+        assertThat(paymentCaptor.getValue().getFailureCode()).isNull();
+        verify(reservationService).confirmPayment(1L);
+    }
+
+    @Test
     void 확정적인_승인_실패는_결제를_실패_상태로_저장한다() {
         Payment payment = readyPayment();
         PaymentConfirmation confirmation = new PaymentConfirmation("test_payment_key", payment.getOrderId(), 20_000L);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,4 @@
 spring.datasource.url=jdbc:h2:mem:database;NON_KEYWORDS=DATE
 spring.sql.init.data-locations=classpath:test-data.sql
+toss.connect-timeout-ms=1000
+toss.read-timeout-ms=2000


### PR DESCRIPTION
## 외부 API 연동 2단계
- Toss RestClient에 connect/read timeout 설정
- timeout 및 통신 예외는 Toss 에러 응답과 구분해 결제를 CHECK_REQUIRED 상태로 처리
- confirm 재요청 시 orderId를 Idempotency-Key로 보내 중복 승인을 방지
- 내 예약 화면에서 결제 상태(결제 대기/완료/실패/취소/확인 필요), orderId, paymentKey, 금액을 확인할 수 있도록 변경