### PR TITLE
[🚀 방탈출 예약 외부 API 연동 2단계] 대길 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/controller/PaymentViewController.java
+++ b/src/main/java/roomescape/controller/PaymentViewController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import roomescape.domain.payment.PaymentResult;
 import roomescape.exception.NotFoundException;
 import roomescape.exception.PaymentAmountMismatchException;
+import roomescape.exception.PaymentConfirmationUnknownException;
+import roomescape.exception.PaymentConnectionException;
+import roomescape.exception.PaymentGatewayException;
 import roomescape.infra.toss.TossPaymentException;
 import roomescape.service.PaymentService;
 
@@ -53,6 +56,8 @@ public class PaymentViewController {
             model.addAttribute("result", result);
             return "success";
         } catch (PaymentAmountMismatchException | NotFoundException exception) {
+            return failView(model, exception.getErrorCode(), exception.getMessage(), orderId);
+        } catch (PaymentConnectionException | PaymentConfirmationUnknownException | PaymentGatewayException exception) {
             return failView(model, exception.getErrorCode(), exception.getMessage(), orderId);
         } catch (TossPaymentException exception) {
             return failView(model, exception.getCode(), exception.getMessage(), orderId);

--- a/src/main/java/roomescape/controller/dto/ReservationAndWaitingResponse.java
+++ b/src/main/java/roomescape/controller/dto/ReservationAndWaitingResponse.java
@@ -1,7 +1,9 @@
 package roomescape.controller.dto;
 
 import java.time.LocalDate;
+import roomescape.domain.payment.OrderStatus;
 import roomescape.domain.reservation.ReservationAndWaiting;
+import roomescape.domain.reservation.ReservationPaymentInfo;
 
 public record ReservationAndWaitingResponse(
         long id,
@@ -10,10 +12,15 @@ public record ReservationAndWaitingResponse(
         TimeResponse time,
         ThemeResponse theme,
         boolean isReserved,
-        Integer waitingNumber
+        Integer waitingNumber,
+        OrderStatus paymentStatus,
+        String orderId,
+        String paymentKey,
+        Long amount
 ) {
 
     public static ReservationAndWaitingResponse from(ReservationAndWaiting reservationAndWaiting) {
+        ReservationPaymentInfo paymentInfo = reservationAndWaiting.paymentInfo();
         return new ReservationAndWaitingResponse(
                 reservationAndWaiting.id(),
                 reservationAndWaiting.name(),
@@ -21,7 +28,11 @@ public record ReservationAndWaitingResponse(
                 TimeResponse.from(reservationAndWaiting.timeSlot()),
                 ThemeResponse.from(reservationAndWaiting.theme()),
                 reservationAndWaiting.isReserved(),
-                toWaitingNumber(reservationAndWaiting.waitingIndex())
+                toWaitingNumber(reservationAndWaiting.waitingIndex()),
+                paymentStatus(paymentInfo),
+                orderId(paymentInfo),
+                paymentKey(paymentInfo),
+                amount(paymentInfo)
         );
     }
 
@@ -30,5 +41,33 @@ public record ReservationAndWaitingResponse(
             return null;
         }
         return waitingIndex + 1;
+    }
+
+    private static OrderStatus paymentStatus(ReservationPaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        return paymentInfo.status();
+    }
+
+    private static String orderId(ReservationPaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        return paymentInfo.orderId();
+    }
+
+    private static String paymentKey(ReservationPaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        return paymentInfo.paymentKey();
+    }
+
+    private static Long amount(ReservationPaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        return paymentInfo.amount();
     }
 }

--- a/src/main/java/roomescape/domain/payment/OrderRepository.java
+++ b/src/main/java/roomescape/domain/payment/OrderRepository.java
@@ -8,5 +8,7 @@ public interface OrderRepository {
 
     Optional<Order> findByOrderId(String orderId);
 
+    Optional<Order> findByReservationId(long reservationId);
+
     Order updateStatus(String orderId, OrderStatus status);
 }

--- a/src/main/java/roomescape/domain/payment/OrderStatus.java
+++ b/src/main/java/roomescape/domain/payment/OrderStatus.java
@@ -4,5 +4,6 @@ public enum OrderStatus {
     PENDING,
     CONFIRMED,
     FAILED,
-    EXPIRED
+    EXPIRED,
+    REQUIRES_CONFIRMATION
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationAndWaiting.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationAndWaiting.java
@@ -11,17 +11,22 @@ public record ReservationAndWaiting(
         TimeSlot timeSlot,
         Theme theme,
         boolean isReserved,
-        Integer waitingIndex
+        Integer waitingIndex,
+        ReservationPaymentInfo paymentInfo
 ) {
 
     public static ReservationAndWaiting fromReservation(Reservation reservation) {
         return new ReservationAndWaiting(reservation.getId(), reservation.getName(), reservation.getDate(), reservation.getTimeSlot(),
-                reservation.getTheme(), true, null);
+                reservation.getTheme(), true, null, null);
     }
 
     public static ReservationAndWaiting fromWaiting(WaitingWithNumber waitingWithNumber) {
         Reservation waiting = waitingWithNumber.waiting();
         return new ReservationAndWaiting(waiting.getId(), waiting.getName(), waiting.getDate(), waiting.getTimeSlot(),
-                waiting.getTheme(), false, waitingWithNumber.waitingIndex());
+                waiting.getTheme(), false, waitingWithNumber.waitingIndex(), null);
+    }
+
+    public ReservationAndWaiting withPaymentInfo(ReservationPaymentInfo paymentInfo) {
+        return new ReservationAndWaiting(id, name, date, timeSlot, theme, isReserved, waitingIndex, paymentInfo);
     }
 }

--- a/src/main/java/roomescape/domain/reservation/ReservationPaymentInfo.java
+++ b/src/main/java/roomescape/domain/reservation/ReservationPaymentInfo.java
@@ -1,0 +1,11 @@
+package roomescape.domain.reservation;
+
+import roomescape.domain.payment.OrderStatus;
+
+public record ReservationPaymentInfo(
+        OrderStatus status,
+        String orderId,
+        String paymentKey,
+        Long amount
+) {
+}

--- a/src/main/java/roomescape/exception/PaymentConfirmationUnknownException.java
+++ b/src/main/java/roomescape/exception/PaymentConfirmationUnknownException.java
@@ -1,0 +1,15 @@
+package roomescape.exception;
+
+public class PaymentConfirmationUnknownException extends RoomescapeException {
+
+    private static final String ERROR_CODE = "PAYMENT_CONFIRMATION_UNKNOWN";
+    private static final String MESSAGE = "결제 승인 여부를 확인할 수 없습니다. 잠시 후 다시 확인해 주세요.";
+
+    public PaymentConfirmationUnknownException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+
+    public PaymentConfirmationUnknownException(Throwable cause) {
+        super(ERROR_CODE, MESSAGE, cause);
+    }
+}

--- a/src/main/java/roomescape/exception/PaymentConnectionException.java
+++ b/src/main/java/roomescape/exception/PaymentConnectionException.java
@@ -1,0 +1,11 @@
+package roomescape.exception;
+
+public class PaymentConnectionException extends RoomescapeException {
+
+    private static final String ERROR_CODE = "PAYMENT_CONNECTION_FAILED";
+    private static final String MESSAGE = "결제 승인 요청을 완료하지 못했습니다. 다시 시도해 주세요.";
+
+    public PaymentConnectionException(Throwable cause) {
+        super(ERROR_CODE, MESSAGE, cause);
+    }
+}

--- a/src/main/java/roomescape/exception/PaymentGatewayException.java
+++ b/src/main/java/roomescape/exception/PaymentGatewayException.java
@@ -1,0 +1,11 @@
+package roomescape.exception;
+
+public class PaymentGatewayException extends RoomescapeException {
+
+    private static final String ERROR_CODE = "PAYMENT_GATEWAY_ERROR";
+    private static final String MESSAGE = "결제 승인 요청 중 오류가 발생했습니다.";
+
+    public PaymentGatewayException(Throwable cause) {
+        super(ERROR_CODE, MESSAGE, cause);
+    }
+}

--- a/src/main/java/roomescape/exception/RoomescapeException.java
+++ b/src/main/java/roomescape/exception/RoomescapeException.java
@@ -9,6 +9,11 @@ public abstract class RoomescapeException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public RoomescapeException(String errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
     public String getErrorCode() {
         return errorCode;
     }

--- a/src/main/java/roomescape/infra/persistence/JdbcOrderRepository.java
+++ b/src/main/java/roomescape/infra/persistence/JdbcOrderRepository.java
@@ -49,6 +49,17 @@ public class JdbcOrderRepository implements OrderRepository {
     }
 
     @Override
+    public Optional<Order> findByReservationId(long reservationId) {
+        String sql = """
+                SELECT id, order_id, amount, reservation_id, status
+                FROM orders
+                WHERE reservation_id = ?
+                """;
+        List<Order> orders = jdbcTemplate.query(sql, rowMapper(), reservationId);
+        return Optional.ofNullable(DataAccessUtils.singleResult(orders));
+    }
+
+    @Override
     public Order updateStatus(String orderId, OrderStatus status) {
         String sql = "UPDATE orders SET status = ? WHERE order_id = ?";
         jdbcTemplate.update(sql, status.name(), orderId);

--- a/src/main/java/roomescape/infra/toss/TossClientConfig.java
+++ b/src/main/java/roomescape/infra/toss/TossClientConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -14,14 +15,21 @@ public class TossClientConfig {
     @Bean
     public RestClient tossRestClient(
             @Value("${toss.base-url}") String baseUrl,
-            @Value("${toss.secret-key}") String secretKey
+            @Value("${toss.secret-key}") String secretKey,
+            @Value("${toss.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${toss.read-timeout-ms}") int readTimeoutMs
     ) {
         String basic = Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
 
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeoutMs);
+        factory.setReadTimeout(readTimeoutMs);
+
         return RestClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basic)
+                .requestFactory(factory)
                 .build();
     }
 }

--- a/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
+++ b/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
@@ -1,14 +1,20 @@
 package roomescape.infra.toss;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import roomescape.domain.payment.PaymentConfirmation;
 import roomescape.domain.payment.PaymentGateway;
 import roomescape.domain.payment.PaymentResult;
 import roomescape.domain.payment.PaymentStatus;
+import roomescape.exception.PaymentConfirmationUnknownException;
+import roomescape.exception.PaymentConnectionException;
+import roomescape.exception.PaymentGatewayException;
 import roomescape.infra.toss.dto.ConfirmRequest;
 import roomescape.infra.toss.dto.TossErrorResponse;
 import roomescape.infra.toss.dto.TossPaymentResponse;
@@ -32,18 +38,29 @@ public class TossPaymentGateway implements PaymentGateway {
                 confirmation.amount()
         );
 
-        TossPaymentResponse response = tossRestClient.post()
-                .uri("/v1/payments/confirm")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    TossErrorResponse error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
-                    throw TossPaymentException.of(res.getStatusCode(), error);
-                })
-                .body(TossPaymentResponse.class);
+        try {
+            TossPaymentResponse response = tossRestClient.post()
+                    .uri("/v1/payments/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        TossErrorResponse error = objectMapper.readValue(res.getBody(), TossErrorResponse.class);
+                        throw TossPaymentException.of(res.getStatusCode(), error);
+                    })
+                    .body(TossPaymentResponse.class);
 
-        return toResult(response);
+            return toResult(response);
+        } catch (RestClientException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof ConnectException) {
+                throw new PaymentConnectionException(e);
+            }
+            if (cause instanceof SocketTimeoutException) {
+                throw new PaymentConfirmationUnknownException(e);
+            }
+            throw new PaymentGatewayException(e);
+        }
     }
 
     private PaymentResult toResult(TossPaymentResponse response) {

--- a/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
+++ b/src/main/java/roomescape/infra/toss/TossPaymentGateway.java
@@ -42,6 +42,7 @@ public class TossPaymentGateway implements PaymentGateway {
             TossPaymentResponse response = tossRestClient.post()
                     .uri("/v1/payments/confirm")
                     .contentType(MediaType.APPLICATION_JSON)
+                    .header("Idempotency-Key", confirmation.orderId())
                     .body(request)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, (req, res) -> {

--- a/src/main/java/roomescape/service/PaymentService.java
+++ b/src/main/java/roomescape/service/PaymentService.java
@@ -12,6 +12,8 @@ import roomescape.domain.payment.PaymentRepository;
 import roomescape.domain.payment.PaymentResult;
 import roomescape.exception.NotFoundException;
 import roomescape.exception.PaymentAmountMismatchException;
+import roomescape.exception.PaymentConfirmationUnknownException;
+import roomescape.infra.toss.TossPaymentException;
 
 @Service
 public class PaymentService {
@@ -27,7 +29,7 @@ public class PaymentService {
         this.paymentRepository = paymentRepository;
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = {TossPaymentException.class, PaymentConfirmationUnknownException.class})
     public PaymentResult confirm(String paymentKey, String orderId, long amount) {
         Order order = getOrder(orderId);
         if (!order.getAmount().equals(amount)) {
@@ -35,12 +37,24 @@ public class PaymentService {
         }
 
         PaymentConfirmation confirmation = new PaymentConfirmation(paymentKey, orderId, amount);
-        PaymentResult result = paymentGateway.confirm(confirmation);
+        PaymentResult result = confirmPayment(confirmation, orderId);
 
         paymentRepository.save(new Payment(result.paymentKey(), result.orderId()));
         orderRepository.updateStatus(orderId, OrderStatus.CONFIRMED);
 
         return result;
+    }
+
+    private PaymentResult confirmPayment(PaymentConfirmation confirmation, String orderId) {
+        try {
+            return paymentGateway.confirm(confirmation);
+        } catch (PaymentConfirmationUnknownException exception) {
+            orderRepository.updateStatus(orderId, OrderStatus.REQUIRES_CONFIRMATION);
+            throw exception;
+        } catch (TossPaymentException exception) {
+            orderRepository.updateStatus(orderId, OrderStatus.FAILED);
+            throw exception;
+        }
     }
 
     private Order getOrder(String orderId) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -11,8 +11,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.domain.payment.Order;
 import roomescape.domain.payment.OrderRepository;
+import roomescape.domain.payment.Payment;
+import roomescape.domain.payment.PaymentRepository;
 import roomescape.domain.reservation.Reservation;
 import roomescape.domain.reservation.ReservationAndWaiting;
+import roomescape.domain.reservation.ReservationPaymentInfo;
 import roomescape.domain.reservation.ReservationSlot;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.timeslot.TimeSlot;
@@ -37,13 +40,15 @@ public class ReservationService {
     private final ThemeRepository themeRepository;
     private final ReservationSlotRepository reservationSlotRepository;
     private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
 
     public ReservationService(
             ReservationRepository reservationRepository,
             TimeSlotRepository timeSlotRepository,
             ThemeRepository themeRepository,
             ReservationSlotRepository reservationSlotRepository,
-            OrderRepository orderRepository
+            OrderRepository orderRepository,
+            PaymentRepository paymentRepository
     ) {
 
         this.reservationRepository = reservationRepository;
@@ -51,6 +56,7 @@ public class ReservationService {
         this.themeRepository = themeRepository;
         this.reservationSlotRepository = reservationSlotRepository;
         this.orderRepository = orderRepository;
+        this.paymentRepository = paymentRepository;
     }
 
     public List<Reservation> findAllReservations() {
@@ -68,7 +74,9 @@ public class ReservationService {
         List<WaitingWithNumber> waitings = createWaitingsWithNumber(reservationsByName);
 
         UserReservations userReservations = new UserReservations(name, reservations, waitings);
-        return userReservations.getReservationAndWaitings();
+        return userReservations.getReservationAndWaitings().stream()
+                .map(this::attachPaymentInfo)
+                .toList();
     }
 
     @Transactional
@@ -126,6 +134,29 @@ public class ReservationService {
 
     private String createOrderId() {
         return UUID.randomUUID().toString();
+    }
+
+    private ReservationAndWaiting attachPaymentInfo(ReservationAndWaiting reservationAndWaiting) {
+        if (!reservationAndWaiting.isReserved()) {
+            return reservationAndWaiting;
+        }
+
+        return orderRepository.findByReservationId(reservationAndWaiting.id())
+                .map(order -> reservationAndWaiting.withPaymentInfo(createPaymentInfo(order)))
+                .orElse(reservationAndWaiting);
+    }
+
+    private ReservationPaymentInfo createPaymentInfo(Order order) {
+        String paymentKey = paymentRepository.findByOrderId(order.getOrderId())
+                .map(Payment::getPaymentKey)
+                .orElse(null);
+
+        return new ReservationPaymentInfo(
+                order.getStatus(),
+                order.getOrderId(),
+                paymentKey,
+                order.getAmount()
+        );
     }
 
     private void deleteReservationAndPromoteWaiting(Reservation reservation, String requestName,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,5 @@ toss:
   base-url: https://api.tosspayments.com
   client-key: ${TOSS_CLIENT_KEY}
   secret-key: ${TOSS_SECRET_KEY}
+  connect-timeout-ms: ${TOSS_CONNECT_TIMEOUT_MS:1000}
+  read-timeout-ms: ${TOSS_READ_TIMEOUT_MS:2000}

--- a/src/main/resources/templates/my-reservation.html
+++ b/src/main/resources/templates/my-reservation.html
@@ -267,6 +267,44 @@
             color: var(--success);
         }
 
+        .payment-meta {
+            margin-top: 0.75rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid var(--border);
+            flex-wrap: wrap;
+            row-gap: 0.6rem;
+        }
+
+        .payment-status {
+            display: inline-block;
+            width: fit-content;
+            font-size: 0.58rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            padding: 3px 7px;
+            border-radius: 2px;
+        }
+
+        .payment-pending {
+            background: rgba(255,255,255,0.05);
+            color: var(--text-muted);
+        }
+
+        .payment-confirmed {
+            background: rgba(76,175,125,0.12);
+            color: var(--success);
+        }
+
+        .payment-failed {
+            background: rgba(220,88,88,0.12);
+            color: var(--danger);
+        }
+
+        .payment-check {
+            background: rgba(200,169,110,0.12);
+            color: var(--accent);
+        }
+
         .reservation-actions {
             display: flex;
             gap: 0.6rem;
@@ -810,6 +848,7 @@
                     <span class="reservation-status ${statusClass}">
                         ${statusText}
                     </span>
+                    ${renderPaymentInfo(r)}
                 </div>
                 <div class="reservation-actions">
                     ${isReserved
@@ -827,6 +866,52 @@
 
         container.innerHTML = '';
         container.appendChild(list);
+    }
+
+    function renderPaymentInfo(reservation) {
+        if (!reservation.orderId) {
+            return '';
+        }
+
+        const status = paymentStatus(reservation.paymentStatus);
+        const orderId = escapeHtml(reservation.orderId);
+        const paymentKey = reservation.paymentKey ? escapeHtml(reservation.paymentKey) : '-';
+        const amount = reservation.amount == null ? '-' : `${Number(reservation.amount).toLocaleString('ko-KR')}원`;
+
+        return `
+            <div class="reservation-meta payment-meta">
+                <div class="reservation-meta-item">
+                    <span class="meta-label">결제 상태</span>
+                    <span class="payment-status ${status.className}">${status.text}</span>
+                </div>
+                <div class="reservation-meta-item">
+                    <span class="meta-label">주문 번호</span>
+                    <span class="meta-value">${orderId}</span>
+                </div>
+                <div class="reservation-meta-item">
+                    <span class="meta-label">결제 키</span>
+                    <span class="meta-value">${paymentKey}</span>
+                </div>
+                <div class="reservation-meta-item">
+                    <span class="meta-label">금액</span>
+                    <span class="meta-value">${amount}</span>
+                </div>
+            </div>
+        `;
+    }
+
+    function paymentStatus(status) {
+        switch (status) {
+            case 'CONFIRMED':
+                return { text: '결제 확정', className: 'payment-confirmed' };
+            case 'FAILED':
+                return { text: '결제 실패', className: 'payment-failed' };
+            case 'REQUIRES_CONFIRMATION':
+                return { text: '확인 필요', className: 'payment-check' };
+            case 'PENDING':
+            default:
+                return { text: '결제 대기', className: 'payment-pending' };
+        }
     }
 
     // ── 예약 취소 ─────────────────────────────────────

--- a/src/test/java/roomescape/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/controller/ReservationControllerTest.java
@@ -27,7 +27,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import roomescape.controller.dto.ReservationRequest;
 import roomescape.controller.dto.UpdateReservationRequest;
+import roomescape.domain.payment.OrderStatus;
 import roomescape.domain.reservation.Reservation;
+import roomescape.domain.reservation.ReservationAndWaiting;
+import roomescape.domain.reservation.ReservationPaymentInfo;
 import roomescape.domain.reservation.ReservationSlot;
 import roomescape.domain.reservation.ReservationStatus;
 import roomescape.domain.theme.Theme;
@@ -68,6 +71,21 @@ class ReservationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("브라운"))
                 .andExpect(jsonPath("$.status").value("RESERVED"));
+    }
+
+    @Test
+    @DisplayName("사용자 이름으로 예약과 결제 정보를 함께 조회한다.")
+    void 사용자_예약_결제_정보_조회() throws Exception {
+        given(reservationService.findReservationAndWaitingByName("브라운"))
+                .willReturn(List.of(createMockReservationAndWaiting()));
+
+        mockMvc.perform(get("/reservations").param("userName", "브라운"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reservationAndWaitingResponses[0].name").value("브라운"))
+                .andExpect(jsonPath("$.reservationAndWaitingResponses[0].paymentStatus").value("CONFIRMED"))
+                .andExpect(jsonPath("$.reservationAndWaitingResponses[0].orderId").value("order-1"))
+                .andExpect(jsonPath("$.reservationAndWaitingResponses[0].paymentKey").value("payment-key"))
+                .andExpect(jsonPath("$.reservationAndWaitingResponses[0].amount").value(50000));
     }
 
     @Test
@@ -178,5 +196,16 @@ class ReservationControllerTest {
         Theme theme = new Theme(1L, "테마", "설명", "url", 50000L);
         ReservationSlot slot = new ReservationSlot(1L, LocalDate.now(), timeSlot, theme);
         return new Reservation(1L, "브라운", slot, LocalDate.now().atStartOfDay(), ReservationStatus.RESERVED);
+    }
+
+    private ReservationAndWaiting createMockReservationAndWaiting() {
+        Reservation reservation = createMockReservation();
+        return ReservationAndWaiting.fromReservation(reservation)
+                .withPaymentInfo(new ReservationPaymentInfo(
+                        OrderStatus.CONFIRMED,
+                        "order-1",
+                        "payment-key",
+                        50000L
+                ));
     }
 }

--- a/src/test/java/roomescape/infra/toss/RestClientTimeoutTest.java
+++ b/src/test/java/roomescape/infra/toss/RestClientTimeoutTest.java
@@ -1,0 +1,48 @@
+package roomescape.infra.toss;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Disabled("외부 네트워크와 OS 라우팅에 의존하는 timeout 관찰용 테스트")
+class RestClientTimeoutTest {
+
+    private static final String BLACK_HOLE_URL = "http://10.255.255.1:81";
+
+    @Test
+    void connectTimeout이_없으면_오래_걸린다() {
+        RestClient client = RestClient.builder()
+                .baseUrl(BLACK_HOLE_URL)
+                .build();
+
+        long start = System.currentTimeMillis();
+        try {
+            client.get().retrieve().body(String.class);
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            System.out.println("걸린 시간: " + elapsed + "ms");
+            System.out.println("예외: " + e.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    void connectTimeout을_걸면_빠르게_포기한다() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(1000);
+
+        RestClient client = RestClient.builder()
+                .baseUrl(BLACK_HOLE_URL)
+                .requestFactory(factory)
+                .build();
+
+        long start = System.currentTimeMillis();
+        try {
+            client.get().retrieve().body(String.class);
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            System.out.println("걸린 시간: " + elapsed + "ms");
+            System.out.println("예외: " + e.getClass().getSimpleName());
+        }
+    }
+}

--- a/src/test/java/roomescape/infra/toss/TossPaymentGatewayTest.java
+++ b/src/test/java/roomescape/infra/toss/TossPaymentGatewayTest.java
@@ -1,0 +1,56 @@
+package roomescape.infra.toss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import roomescape.domain.payment.PaymentConfirmation;
+import roomescape.domain.payment.PaymentResult;
+import roomescape.domain.payment.PaymentStatus;
+
+class TossPaymentGatewayTest {
+
+    @Test
+    @DisplayName("결제 승인 요청에 주문 번호를 Idempotency-Key 헤더로 전송한다.")
+    void 멱등키_헤더_전송() {
+        RestClient.Builder builder = RestClient.builder()
+                .baseUrl("https://api.tosspayments.com");
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        TossPaymentGateway gateway = new TossPaymentGateway(builder.build(), new ObjectMapper());
+
+        server.expect(requestTo("https://api.tosspayments.com/v1/payments/confirm"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Idempotency-Key", "order-1"))
+                .andExpect(content().json("""
+                        {
+                          "paymentKey": "payment-key",
+                          "orderId": "order-1",
+                          "amount": 50000
+                        }
+                        """))
+                .andRespond(withSuccess("""
+                        {
+                          "paymentKey": "payment-key",
+                          "orderId": "order-1",
+                          "status": "DONE",
+                          "totalAmount": 50000
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        PaymentResult result = gateway.confirm(new PaymentConfirmation("payment-key", "order-1", 50000L));
+
+        assertThat(result.orderId()).isEqualTo("order-1");
+        assertThat(result.status()).isEqualTo(PaymentStatus.DONE);
+        server.verify();
+    }
+}

--- a/src/test/java/roomescape/repository/FakeOrderRepository.java
+++ b/src/test/java/roomescape/repository/FakeOrderRepository.java
@@ -34,6 +34,13 @@ public class FakeOrderRepository implements OrderRepository {
     }
 
     @Override
+    public Optional<Order> findByReservationId(long reservationId) {
+        return storage.values().stream()
+                .filter(order -> order.getReservationId().equals(reservationId))
+                .findAny();
+    }
+
+    @Override
     public Order updateStatus(String orderId, OrderStatus status) {
         Order order = findByOrderId(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 주문 정보를 찾을 수 없습니다."));

--- a/src/test/java/roomescape/repository/JdbcOrderRepositoryTest.java
+++ b/src/test/java/roomescape/repository/JdbcOrderRepositoryTest.java
@@ -66,6 +66,19 @@ class JdbcOrderRepositoryTest {
     }
 
     @Test
+    @DisplayName("예약 식별자로 주문 정보를 조회한다.")
+    void 예약_식별자로_주문_조회() {
+        Long reservationId = insertReservation();
+        jdbcOrderRepository.save(new Order("order-1", 50000L, reservationId));
+
+        Optional<Order> foundOrder = jdbcOrderRepository.findByReservationId(reservationId);
+
+        assertThat(foundOrder).isPresent();
+        assertThat(foundOrder.get().getOrderId()).isEqualTo("order-1");
+        assertThat(foundOrder.get().getAmount()).isEqualTo(50000L);
+    }
+
+    @Test
     @DisplayName("주문 번호로 주문 상태를 업데이트한다.")
     void 주문_상태_업데이트() {
         Long reservationId = insertReservation();

--- a/src/test/java/roomescape/service/PaymentServiceTest.java
+++ b/src/test/java/roomescape/service/PaymentServiceTest.java
@@ -14,6 +14,9 @@ import roomescape.domain.payment.PaymentResult;
 import roomescape.domain.payment.PaymentStatus;
 import roomescape.exception.NotFoundException;
 import roomescape.exception.PaymentAmountMismatchException;
+import roomescape.exception.PaymentConfirmationUnknownException;
+import roomescape.exception.PaymentConnectionException;
+import roomescape.infra.toss.TossPaymentException;
 import roomescape.repository.FakeOrderRepository;
 import roomescape.repository.FakePaymentRepository;
 
@@ -78,13 +81,59 @@ class PaymentServiceTest {
                 .isEqualTo(OrderStatus.PENDING);
     }
 
+    @Test
+    @DisplayName("토스가 명확히 거절하면 주문 상태를 실패로 변경한다.")
+    void 토스_거절_주문_실패() {
+        orderRepository.save(new Order("order-1", 50000L, 1L));
+        paymentGateway.reject();
+
+        assertThatThrownBy(() -> paymentService.confirm("payment-key", "order-1", 50000L))
+                .isInstanceOf(TossPaymentException.class);
+
+        assertThat(orderRepository.findByOrderId("order-1").orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.FAILED);
+        assertThat(paymentRepository.findByOrderId("order-1")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("결제 승인 여부를 알 수 없으면 주문 상태를 확인 필요로 변경한다.")
+    void 결제_결과_불명확_주문_확인_필요() {
+        orderRepository.save(new Order("order-1", 50000L, 1L));
+        paymentGateway.unknown();
+
+        assertThatThrownBy(() -> paymentService.confirm("payment-key", "order-1", 50000L))
+                .isInstanceOf(PaymentConfirmationUnknownException.class);
+
+        assertThat(orderRepository.findByOrderId("order-1").orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.REQUIRES_CONFIRMATION);
+        assertThat(paymentRepository.findByOrderId("order-1")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("토스 연결 실패로 승인 요청을 완료하지 못하면 주문 상태를 대기로 유지한다.")
+    void 토스_연결_실패_주문_대기_유지() {
+        orderRepository.save(new Order("order-1", 50000L, 1L));
+        paymentGateway.connectionFailed();
+
+        assertThatThrownBy(() -> paymentService.confirm("payment-key", "order-1", 50000L))
+                .isInstanceOf(PaymentConnectionException.class);
+
+        assertThat(orderRepository.findByOrderId("order-1").orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.PENDING);
+        assertThat(paymentRepository.findByOrderId("order-1")).isEmpty();
+    }
+
     private static class FakePaymentGateway implements PaymentGateway {
 
         private boolean confirmed;
+        private RuntimeException exception;
 
         @Override
         public PaymentResult confirm(PaymentConfirmation confirmation) {
             confirmed = true;
+            if (exception != null) {
+                throw exception;
+            }
             return new PaymentResult(
                     confirmation.paymentKey(),
                     confirmation.orderId(),
@@ -95,6 +144,18 @@ class PaymentServiceTest {
 
         public boolean isConfirmed() {
             return confirmed;
+        }
+
+        public void reject() {
+            exception = new TossPaymentException.CardRejected("카드 결제가 거절되었습니다.");
+        }
+
+        public void unknown() {
+            exception = new PaymentConfirmationUnknownException();
+        }
+
+        public void connectionFailed() {
+            exception = new PaymentConnectionException(new RuntimeException());
         }
     }
 }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -17,10 +17,14 @@ import roomescape.domain.reservation.ReservationSlot;
 import roomescape.domain.reservation.ReservationStatus;
 import roomescape.domain.theme.Theme;
 import roomescape.domain.timeslot.TimeSlot;
+import roomescape.domain.payment.Order;
+import roomescape.domain.payment.OrderStatus;
+import roomescape.domain.payment.Payment;
 import roomescape.exception.DuplicateException;
 import roomescape.exception.NotOwnerException;
 import roomescape.exception.PastTimeException;
 import roomescape.repository.FakeOrderRepository;
+import roomescape.repository.FakePaymentRepository;
 import roomescape.repository.FakeReservationRepository;
 import roomescape.repository.FakeReservationSlotRepository;
 import roomescape.repository.FakeThemeRepository;
@@ -37,6 +41,7 @@ class ReservationServiceTest {
     private FakeTimeSlotRepository timeSlotRepository;
     private FakeThemeRepository themeRepository;
     private FakeOrderRepository orderRepository;
+    private FakePaymentRepository paymentRepository;
 
     private TimeSlot savedTimeSlot;
     private Theme savedTheme;
@@ -48,9 +53,10 @@ class ReservationServiceTest {
         reservationSlotRepository = new FakeReservationSlotRepository();
         themeRepository = new FakeThemeRepository();
         orderRepository = new FakeOrderRepository();
+        paymentRepository = new FakePaymentRepository();
 
         reservationService = new ReservationService(reservationRepository, timeSlotRepository, themeRepository,
-                reservationSlotRepository, orderRepository);
+                reservationSlotRepository, orderRepository, paymentRepository);
 
         savedTimeSlot = timeSlotRepository.save(new TimeSlot(LocalTime.of(10, 0)));
         savedTheme = themeRepository.save(new Theme("이름", "설명", "test.com", 50000L));
@@ -78,6 +84,25 @@ class ReservationServiceTest {
         assertThat(result.orderId()).isNotBlank();
         assertThat(result.amount()).isEqualTo(50000L);
         assertThat(orderRepository.findByOrderId(result.orderId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("사용자의 예약 목록을 조회하면 결제 정보를 함께 반환한다.")
+    void 사용자_예약_결제_정보_조회() {
+        LocalDate futureDate = LocalDate.now().plusDays(1);
+        ReservationCreateResult result = reservationService.saveReservationWithOrder(
+                "브라운", futureDate, savedTimeSlot.getId(), savedTheme.getId(), REQUEST_TIME
+        );
+        orderRepository.updateStatus(result.orderId(), OrderStatus.CONFIRMED);
+        paymentRepository.save(new Payment("payment-key", result.orderId()));
+
+        List<ReservationAndWaiting> reservations = reservationService.findReservationAndWaitingByName("브라운");
+
+        assertThat(reservations).hasSize(1);
+        assertThat(reservations.getFirst().paymentInfo().status()).isEqualTo(OrderStatus.CONFIRMED);
+        assertThat(reservations.getFirst().paymentInfo().orderId()).isEqualTo(result.orderId());
+        assertThat(reservations.getFirst().paymentInfo().paymentKey()).isEqualTo("payment-key");
+        assertThat(reservations.getFirst().paymentInfo().amount()).isEqualTo(50000L);
     }
 
     @Test

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -6,3 +6,5 @@ toss:
   base-url: http://localhost:8089
   client-key: test_client_key
   secret-key: test_secret_key
+  connect-timeout-ms: 1000
+  read-timeout-ms: 2000


### PR DESCRIPTION
안녕하세요 로지!
이번 2단계 리뷰도 잘 부탁드립니다!
2단계 미션의 "더 생각해보기" 질문도 함께 공유하고자 아래에 남겨두었습니다.
시간 괜찮으실 때 확인 부탁드리겠습니다!
감사합니다🙇‍♂️

## 체크 리스트
- [X] 미션의 필수 요구사항을 모두 구현했나요?
- [X] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [X] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [X] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
### read timeout 값과 토스 응답 시간이 거의 같은 경계값에서는 성공과 실패가 어떻게 갈릴까? 이때 얻은 감각을 connect/read timeout 값을 정하는 데 어떻게 활용할 수 있을까?
read timeout과 토스 실제 응답 시간이 거의 같은 경계값에서는, 토스는 정상적으로 결제를 처리하고 응답을 보냈지만 우리 서버는 그 직전에 연결을 끊어 버려 타임아웃으로 처리하게 됩니다.
이 경우 결제는 성공했는데 DB의 상태는 "확인 필요" 상태가 됩니다.
그래서 타임아웃 값은 평균 응답 시간이 아니라 테스트를 통해 대부분 통과하는 시간 값으로 여유 있게 정해서, 멀쩡한 결제를 실패로 처리하지 않도록 합니다.

### 결제 승인 호출에서 connect와 read 중 어느 쪽을 더 짧게 두는 게 합리적일까?
connect를 더 짧게 두는 게 합리적이라고 생각합니다.
connect는 TCP 연결만 맺으면 되는 작업이라 정상이라면 짧고 일정한 시간 안에 처리됩니다. 
반면에 read는 토스가 결제를 처리하는 시간까지 포함하기 때문에 connect보다 시간이 오래 걸립니다.
또한 connect 단계에서 실패하게 되면 요청이 토스에 도달조차 하지 않은 것이기 때문에 결제가 발생하지 않고, 재시도가 가능합니다.
반면에 read 타임아웃은 요청은 보냈는데 응답만 받지 못한 상태이기 때문에 결제 성공 여부가 불확실합니다.
그래서 connect는 짧게 끊고 재시도하도록 하고, read는 성공한 결제 응답을 실패로 처리하지 않도록 더 여유 있게 두는 게 맞다고 생각합니다.

### read timeout으로 불확실해진 결제를 "확인 필요"로 두는 것과 "실패"로 단정하는 것 중 무엇이 나을까? "확인 필요"가 영구 상태로 방치되지 않고 성공/실패로 수렴하려면 무엇이 필요할까(결제 조회 API, 멱등 재시도)?
read timeout으로 불확실해진 결제는 "실패"로 단정하기보다는 "확인 필요" 상태로 두는 게 맞다고 생각합니다.
실패로 단정하면, 토스에서는 실제로 결제가 성공했는데 DB의 상태는 실패로 기록되어 돈은 빠져나갔는데 예약은 안 잡히는 정합성 문제가 생길 수 있습니다.
"확인 필요" 상태가 영구 상태로 방치되지 않기 위해서는 결제 조회 API로 토스에 실제 결제 상태를 확인하고 성공/실패를 결정해야 합니다.

### read timeout(됐는지 모름)과 connect 실패(연결조차 못 함)는 재시도 안전성이 다를까?
재시도 안전성이 다릅니다.
connect 실패는 연결조차 못 한 상태이기 때문에 요청이 토스에 도달하지 않았고, 결제가 발생할 수 없습니다. 그렇기 때문에 재시도에 안전합니다.
반면에 read timeout은 요청은 토스에 이미 도달했지만 응답을 받지 못한 상태이기 때문에 결제가 이미 처리됐을 수 있습니다.
이때 그냥 재시도하면 중복 결제가 될 위험이 있습니다
다만 멱등 키가 있으면 같은 키로 다시 요청해도 토스가 이미 처리된 결제로 인식해 중복 결제를 막아 주기 때문에 read timeout 상황에서도 안전하게 재시도할 수 있습니다.

### 진짜 connect 타임아웃은 닫힌 포트(즉시 거부)가 아니라 SYN에 무응답인 블랙홀 IP(예: 10.255.255.1:81)로만 재현된다. connect timeout이 없으면 이 연결이 OS 기본값(수십 초)까지 스레드를 잡는다. 학습 테스트에서 가볍게 실험해보자.
connect timeout을 설정하지 않고 블랙홀 IP(10.255.255.1:81)로 연결을 시도했을 때 150,030ms(약 2분 30초) 동안 스레드가 묶인 후에 예외가 발생했습니다.

